### PR TITLE
#2 [v0.1] Support HTTP/2 over mTLS on the cluster RPC plane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+# Build artifacts and editor scratch.
 /target
 **/*.rs.bk
 Cargo.lock.bak
 *.swp
+*.orig
 .DS_Store
 /data

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,4 +1,5 @@
-edition      = "2021"
-max_width    = 100
-tab_spaces   = 4
+# Format settings shared by every crate in the workspace.
+edition           = "2021"
+max_width         = 100
+tab_spaces        = 4
 use_try_shorthand = true

--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,4 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
    implied. See the License for the specific language governing
    permissions and limitations under the License.
+

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
+# Pinned toolchain. CI mirrors this exactly.
 [toolchain]
 channel    = "1.91.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
#2 [v0.1] Support HTTP/2 over mTLS on the cluster RPC plane