### PR TITLE
[core] Ensure plaintext can be configured for inter node RPC

### DIFF
--- a/crates/phenomenal_io/src/remote_fs.rs
+++ b/crates/phenomenal_io/src/remote_fs.rs
@@ -129,11 +129,13 @@ impl PeerClient {
     /// rustls `ClientConfig` (ALPN list = `[b"h2"]`, root CA pinned).
     /// The client is lazy: no socket is opened until the first
     /// request.
-    pub fn new(addr: SocketAddr, tls: Arc<ClientConfig>) -> Self {
-        let client = cyper::Client::builder()
-            .use_rustls(tls)
-            .build();
-        Self { base: format!("https://{addr}"), client }
+    pub fn new(addr: SocketAddr, tls: Option<Arc<ClientConfig>>) -> Self {
+        let builder = cyper::Client::builder();
+        let (client, scheme) = match tls {
+            Some(cfg) => (builder.use_rustls(cfg).build(), "https"),
+            None      => (builder.http2_prior_knowledge().build(), "http"),
+        };
+        Self { base: format!("{scheme}://{addr}"), client }
     }
 
     fn url(&self, suffix: &str) -> String {


### PR DESCRIPTION
 - Ensure the engine can configure the plaintext for H2 
 - No longer mandate tls since this is not always preferred in trusted envs/carries perf overhead