### PR TITLE
Support DC over RDMA for inter node transport

### DIFF
--- a/crates/phenomenal_io/Cargo.toml
+++ b/crates/phenomenal_io/Cargo.toml
@@ -46,5 +46,16 @@ aligned-vec     = { workspace = true }
 crossbeam-queue = { workspace = true }
 once_cell       = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+rdma-mummy-sys = { version = "0.2", optional = true }
+
+[target.'cfg(target_os = "linux")'.build-dependencies]
+bindgen = { version = "0.71", optional = true }
+
+[features]
+rdma = ["dep:rdma-mummy-sys", "dep:bindgen"]
+
 [dev-dependencies]
-tempfile      = { workspace = true }
+tempfile           = { workspace = true }
+tracing-subscriber = { workspace = true }
+anyhow             = { workspace = true }

--- a/crates/phenomenal_io/build.rs
+++ b/crates/phenomenal_io/build.rs
@@ -1,0 +1,38 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    #[cfg(all(feature = "rdma", target_os = "linux"))]
+    rdma::bindgen_mlx5dv();
+}
+
+#[cfg(all(feature = "rdma", target_os = "linux"))]
+mod rdma {
+    use std::{env, path::PathBuf};
+
+    pub fn bindgen_mlx5dv() {
+        println!("cargo:rustc-link-lib=mlx5");
+        let out = PathBuf::from(env::var("OUT_DIR").unwrap()).join("mlx5dv_sys.rs");
+        bindgen::Builder::default()
+            .header_contents("wrapper.h", "#include <infiniband/mlx5dv.h>\n")
+            .clang_arg("-D_GNU_SOURCE")
+            .raw_line("use rdma_mummy_sys::*;")
+            .allowlist_function("mlx5dv_.*")
+            .allowlist_type    ("mlx5dv_.*")
+            .allowlist_var     ("MLX5DV_.*")
+            .blocklist_function("ibv_.*")
+            .blocklist_type    ("ibv_.*")
+            .blocklist_type    ("verbs_.*")
+            .blocklist_type    ("__be.*")
+            // mlx5dv_flow_* references ibv_flow_attr_type / ibv_flow_action_*
+            // as types, but rdma-mummy-sys emits those as modules. We do not
+            // use flow steering on DC, so blocklist the whole flow subsystem.
+            .blocklist_type    ("mlx5dv_flow.*")
+            .blocklist_function("mlx5dv_create_flow.*")
+            .blocklist_function("mlx5dv_destroy_flow.*")
+            .blocklist_function("mlx5dv_dr_.*")
+            .blocklist_function("mlx5dv_flow.*")
+            .layout_tests(false)
+            .derive_default(true)
+            .generate().expect("bindgen mlx5dv.h")
+            .write_to_file(&out).expect("write mlx5dv_sys.rs");
+    }
+}

--- a/crates/phenomenal_io/examples/rdma_loopback.rs
+++ b/crates/phenomenal_io/examples/rdma_loopback.rs
@@ -1,0 +1,165 @@
+//! Single-process RDMA loopback probe.
+//!
+//! Brings up an RdmaNode, registers ITSELF as the only peer (DCI loops
+//! back through the local HCA into the local DCT), serves StatVol on a
+//! `LocalFsBackend`, and then drives a `StatVol` request through
+//! `RdmaBackend` to prove the wire works end-to-end on real hardware.
+//!
+//! Run on a host with `/dev/infiniband/uverbs0`:
+//!   cargo run --release --features rdma -p phenomenal_io --example rdma_loopback
+
+#![cfg(all(feature = "rdma", target_os = "linux"))]
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+use phenomenal_io::rdma::{
+    PeerEndpoint, RdmaConfig, RdmaNode, RdmaQos, BUF_SIZE,
+};
+use phenomenal_io::rdma_backend::{Envelope, RdmaBackend, ENVELOPE_MAGIC};
+use phenomenal_io::rpc::{decode, encode, Request, Response};
+use phenomenal_io::{LocalFsBackend, StorageBackend};
+
+use anyhow::Context;
+use futures::stream::StreamExt;
+
+fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let rt = compio::runtime::RuntimeBuilder::new().build()?;
+    rt.block_on(async move {
+        if let Err(e) = run().await {
+            eprintln!("FAIL: {e:#}");
+            std::process::exit(1);
+        }
+    });
+    Ok(())
+}
+
+async fn run() -> anyhow::Result<()> {
+    let dir = std::env::temp_dir().join("phenomenal-rdma-loop");
+    let _   = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir)?;
+    let disk: Rc<dyn StorageBackend> = Rc::new(LocalFsBackend::new(&dir)?);
+    disk.make_vol("probe").await?;
+    eprintln!("local disk ready at {}", dir.display());
+
+    let cfg = RdmaConfig {
+        self_node_id: 0,
+        dev_name:     std::env::var("PHENOMENAL_RDMA_DEV").unwrap_or_else(|_| "mlx5_0".into()),
+        dc_key:       0xdeadbeef_cafef00d,
+        qos:          RdmaQos { traffic_class: 0, service_level: 0 },
+        // self-loopback: RdmaNode::start patches gid+dct_num with the
+        // real local values, so the placeholders here don't matter.
+        peers: vec![PeerEndpoint {
+            node_id: 0,
+            gid:     [0u8; 16],
+            dct_num: 0,
+            dc_key:  0,
+        }],
+    };
+
+    let node = Arc::new(RdmaNode::start(cfg).context("RdmaNode::start")?);
+    eprintln!(
+        "RdmaNode up: self_dct_num={} gid={:02x?}",
+        node.sock.self_dct_identifier(), node.dev.gid_bytes(),
+    );
+
+    let disks = Rc::new(vec![disk.clone()]);
+    let dispatcher = compio::runtime::spawn({
+        let node  = node.clone();
+        let disks = disks.clone();
+        async move {
+            if let Err(e) = dispatch_loop(node, disks).await {
+                eprintln!("dispatcher exited: {e:#}");
+            }
+        }
+    });
+
+    let backend = RdmaBackend::new(node.clone(), /*peer_id*/ 0, /*disk_idx*/ 0);
+    eprintln!("issuing StatVol via RdmaBackend...");
+    let vol = backend.stat_vol("probe").await?;
+    eprintln!("OK: stat_vol -> {vol:?}");
+
+    drop(dispatcher);
+    Ok(())
+}
+
+async fn dispatch_loop(
+    node:  Arc<RdmaNode>,
+    disks: Rc<Vec<Rc<dyn StorageBackend>>>,
+) -> anyhow::Result<()> {
+    let mut rx = node.pump.take_recv_rx()
+        .ok_or_else(|| anyhow::anyhow!("pump recv_rx already taken"))?;
+    let mut buf = Vec::with_capacity(BUF_SIZE);
+    loop {
+        loop {
+            buf.clear();
+            if node.sock.attempt_singular_rcv(&mut buf).is_none() { break; }
+            handle_envelope(&node, &disks, &buf).await;
+        }
+        if rx.next().await.is_none() { return Ok(()); }
+    }
+}
+
+async fn handle_envelope(
+    node:  &Arc<RdmaNode>,
+    disks: &Rc<Vec<Rc<dyn StorageBackend>>>,
+    bytes: &[u8],
+) {
+    let env: Envelope = match decode(bytes) {
+        Ok(e)  => e,
+        Err(e) => { eprintln!("decode err: {e}"); return; }
+    };
+    match env {
+        Envelope::Req { magic, from_node_id, request_id, payload } => {
+            if magic != ENVELOPE_MAGIC { eprintln!("bad req magic"); return; }
+            let peer = match node.peer(from_node_id) {
+                Some(p) => p.clone(),
+                None    => { eprintln!("unknown sender {from_node_id}"); return; }
+            };
+            let ah = match node.ah_cache.get_or_create(&peer) {
+                Ok(a)  => a,
+                Err(e) => { eprintln!("ah err: {e}"); return; }
+            };
+            let resp = match payload {
+                Request::StatVol { disk_idx, volume } => {
+                    match disks.get(disk_idx as usize) {
+                        Some(d) => match d.stat_vol(&volume).await {
+                            Ok(v)  => Response::Vol(v),
+                            Err(e) => Response::Err(e.into()),
+                        },
+                        None => Response::Err(phenomenal_io::rpc::WireError::from(
+                            phenomenal_io::IoError::Io(std::io::Error::other(
+                                format!("disk_idx {disk_idx} out of range"),
+                            )),
+                        )),
+                    }
+                }
+                other => {
+                    eprintln!("loopback dispatcher: unsupported request {other:?}");
+                    return;
+                }
+            };
+            let body = match encode(&Envelope::Rsp {
+                magic: ENVELOPE_MAGIC, request_id, payload: resp,
+            }) {
+                Ok(b)  => b,
+                Err(e) => { eprintln!("encode rsp: {e}"); return; }
+            };
+            if let Err(e) = node.sock.send(&body, ah, peer.dct_num, peer.dc_key) {
+                eprintln!("send rsp: {e}");
+            }
+        }
+        Envelope::Rsp { magic, request_id, payload } => {
+            if magic != ENVELOPE_MAGIC { eprintln!("bad rsp magic"); return; }
+            if let Some(tx) = node.pending_responses.lock().unwrap().remove(&request_id) {
+                let _ = tx.send(payload);
+            } else {
+                eprintln!("unmatched rsp request_id {request_id}");
+            }
+        }
+    }
+}

--- a/crates/phenomenal_io/src/lib.rs
+++ b/crates/phenomenal_io/src/lib.rs
@@ -16,6 +16,10 @@ pub mod backend;
 pub mod error;
 pub mod local_fs;
 pub mod purge;
+#[cfg(all(feature = "rdma", target_os = "linux"))]
+pub mod rdma;
+#[cfg(all(feature = "rdma", target_os = "linux"))]
+pub mod rdma_backend;
 pub mod remote_fs;
 pub mod rpc;
 pub mod stream;

--- a/crates/phenomenal_io/src/rdma/ah_cache.rs
+++ b/crates/phenomenal_io/src/rdma/ah_cache.rs
@@ -1,0 +1,62 @@
+use std::collections::HashMap;
+use std::io;
+use std::mem;
+use std::ptr::NonNull;
+use std::sync::Mutex;
+
+use rdma_mummy_sys::{ibv_ah, ibv_ah_attr, ibv_create_ah, ibv_destroy_ah, ibv_pd};
+
+use super::device::PORT_NUM;
+use super::node::{PeerEndpoint, RdmaQos};
+
+pub struct AhCache {
+    pd:        *mut ibv_pd,
+    qos:       RdmaQos,
+    gid_index: u8,
+    local_lid: u16,
+    table:     Mutex<HashMap<u16, NonNull<ibv_ah>>>,
+}
+
+unsafe impl Send for AhCache {}
+unsafe impl Sync for AhCache {}
+
+impl AhCache {
+    pub fn new(pd: *mut ibv_pd, qos: RdmaQos, gid_index: u8, local_lid: u16) -> Self {
+        Self { pd, qos, gid_index, local_lid, table: Mutex::new(HashMap::new()) }
+    }
+
+    pub fn get_or_create(&self, peer: &PeerEndpoint) -> io::Result<*mut ibv_ah> {
+        if let Some(ah) = self.table.lock().unwrap().get(&peer.node_id) {
+            return Ok(ah.as_ptr());
+        }
+        let ah = unsafe {
+            let mut a: ibv_ah_attr = mem::zeroed();
+            a.is_global           = 1;
+            a.dlid                = self.local_lid;
+            a.port_num            = PORT_NUM;
+            a.sl                  = self.qos.service_level;
+            a.grh.dgid.raw        = peer.gid;
+            a.grh.sgid_index      = self.gid_index;
+            a.grh.hop_limit       = 64;
+            // todo @arnav revisit sl and traffic class for pfc etc on roce
+            a.grh.traffic_class   = self.qos.traffic_class;
+            ibv_create_ah(self.pd, &mut a)
+        };
+        let ah = NonNull::new(ah).ok_or_else(io::Error::last_os_error)?;
+        let mut t = self.table.lock().unwrap();
+        if let Some(e) = t.get(&peer.node_id) {
+            unsafe { ibv_destroy_ah(ah.as_ptr()); }
+            return Ok(e.as_ptr());
+        }
+        t.insert(peer.node_id, ah);
+        Ok(ah.as_ptr())
+    }
+}
+
+impl Drop for AhCache {
+    fn drop(&mut self) {
+        for (_, ah) in self.table.lock().unwrap().drain() {
+            unsafe { ibv_destroy_ah(ah.as_ptr()); }
+        }
+    }
+}

--- a/crates/phenomenal_io/src/rdma/buffers.rs
+++ b/crates/phenomenal_io/src/rdma/buffers.rs
@@ -1,0 +1,115 @@
+use std::alloc::{alloc_zeroed, dealloc, Layout};
+use std::collections::VecDeque;
+use std::io;
+use std::ptr::NonNull;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+
+use rdma_mummy_sys::{
+    ibv_access_flags, ibv_dereg_mr, ibv_mr, ibv_pd, ibv_reg_mr,
+};
+
+pub const BUF_SIZE:         usize = 16 * 1024;   // 16 KiB per slot
+pub const SEND_BUF_CNT:     usize = 32;          // slots per direction per QP
+pub const BUF_ACK_BATCH:    u32   = 8;           // credit ACK every 8 consumed RECVs
+pub const BUF_SIGNAL_BATCH: u32   = 8;           // signal every 8th SEND
+const PAGE_ALIGN:           usize = 4096;        // ibv_reg_mr page alignment
+
+pub struct BufferMem {
+    base:   NonNull<u8>,
+    layout: Layout,
+    mr:     NonNull<ibv_mr>,
+}
+
+unsafe impl Send for BufferMem {}
+unsafe impl Sync for BufferMem {}
+
+impl BufferMem {
+    pub fn new(pd: *mut ibv_pd, total: usize) -> io::Result<Self> {
+        let layout = Layout::from_size_align(total, PAGE_ALIGN)
+            .map_err(|e| io::Error::other(format!("layout: {e}")))?;
+        unsafe {
+            let raw = alloc_zeroed(layout);
+            let base = NonNull::new(raw).ok_or_else(|| io::Error::other("alloc"))?;
+            let flags = ibv_access_flags::IBV_ACCESS_LOCAL_WRITE.0
+                      | ibv_access_flags::IBV_ACCESS_REMOTE_WRITE.0
+                      | ibv_access_flags::IBV_ACCESS_REMOTE_READ.0
+                      | ibv_access_flags::IBV_ACCESS_RELAXED_ORDERING.0;
+            let mr = ibv_reg_mr(pd, base.as_ptr() as *mut _, total, flags as i32);
+            let mr = match NonNull::new(mr) {
+                Some(m) => m,
+                None => { let e = io::Error::last_os_error(); dealloc(base.as_ptr(), layout); return Err(e); }
+            };
+            Ok(BufferMem { base, layout, mr })
+        }
+    }
+    pub fn lkey(&self) -> u32 { unsafe { (*self.mr.as_ptr()).lkey } }
+    pub fn ptr(&self)  -> *mut u8 { self.base.as_ptr() }
+}
+
+impl Drop for BufferMem {
+    fn drop(&mut self) {
+        unsafe { ibv_dereg_mr(self.mr.as_ptr()); dealloc(self.base.as_ptr(), self.layout); }
+    }
+}
+
+pub struct Buffers {
+    mem:      BufferMem,
+    buf_size: usize,
+    buf_cnt:  usize,
+}
+
+impl Buffers {
+    pub fn new(pd: *mut ibv_pd, buf_cnt: usize, buf_size: usize) -> io::Result<Self> {
+        Ok(Buffers { mem: BufferMem::new(pd, buf_cnt * buf_size)?, buf_size, buf_cnt })
+    }
+    pub fn slot_ptr(&self, idx: usize) -> *mut u8 { unsafe { self.mem.ptr().add(idx * self.buf_size) } }
+    pub fn slot_addr(&self, idx: usize) -> u64 { self.slot_ptr(idx) as u64 }
+    pub fn lkey(&self)     -> u32   { self.mem.lkey() }
+    pub fn buf_size(&self) -> usize { self.buf_size }
+    pub fn buf_cnt(&self)  -> usize { self.buf_cnt }
+}
+
+pub struct SendBuffers {
+    base:  Buffers,
+    front: AtomicU64,
+    tail:  AtomicU64,
+}
+
+impl SendBuffers {
+    pub fn new(pd: *mut ibv_pd, buf_cnt: usize, buf_size: usize) -> io::Result<Self> {
+        Ok(SendBuffers {
+            base:  Buffers::new(pd, buf_cnt, buf_size)?,
+            front: AtomicU64::new(0),
+            tail:  AtomicU64::new(buf_cnt as u64),
+        })
+    }
+    pub fn empty(&self) -> bool {
+        self.front.load(Ordering::Acquire) >= self.tail.load(Ordering::Acquire)
+    }
+    pub fn try_pop(&self) -> Option<usize> {
+        let f = self.front.load(Ordering::Acquire);
+        if f >= self.tail.load(Ordering::Acquire) { return None; }
+        self.front.fetch_add(1, Ordering::AcqRel);
+        Some((f as usize) % self.base.buf_cnt())
+    }
+    pub fn push(&self, n: u64) { self.tail.fetch_add(n, Ordering::AcqRel); }
+    pub fn base(&self) -> &Buffers { &self.base }
+}
+
+pub struct RecvBuffers {
+    base:  Buffers,
+    queue: Mutex<VecDeque<(u32, u32)>>,
+}
+
+impl RecvBuffers {
+    pub fn new(pd: *mut ibv_pd, buf_cnt: usize, buf_size: usize) -> io::Result<Self> {
+        Ok(RecvBuffers {
+            base:  Buffers::new(pd, buf_cnt, buf_size)?,
+            queue: Mutex::new(VecDeque::with_capacity(buf_cnt)),
+        })
+    }
+    pub fn push(&self, idx: u32, len: u32) { self.queue.lock().unwrap().push_back((idx, len)); }
+    pub fn pop(&self) -> Option<(u32, u32)> { self.queue.lock().unwrap().pop_front() }
+    pub fn base(&self) -> &Buffers { &self.base }
+}

--- a/crates/phenomenal_io/src/rdma/device.rs
+++ b/crates/phenomenal_io/src/rdma/device.rs
@@ -1,0 +1,87 @@
+use std::ffi::CStr;
+use std::io;
+use std::mem;
+use std::ptr::NonNull;
+
+use rdma_mummy_sys::{
+    ibv_alloc_pd, ibv_close_device, ibv_context, ibv_dealloc_pd, ibv_free_device_list,
+    ibv_get_device_list, ibv_get_device_name, ibv_gid, ibv_open_device, ibv_pd,
+    ibv_port_attr, ibv_query_gid, ibv_query_port,
+};
+
+pub const PORT_NUM:  u8 = 1;
+// IB (link_layer=1) populates only the link-local default GID at slot 0.
+// RoCE v2 on Mellanox places the IPv4-mapped GID at slot 3.
+pub const GID_INDEX_IB:   u8 = 0;
+pub const GID_INDEX_ROCE: u8 = 3;
+
+pub struct IbDevice {
+    pub(super) ctx:       NonNull<ibv_context>,
+    pub(super) pd:        NonNull<ibv_pd>,
+    pub(super) port_attr: ibv_port_attr,
+    pub(super) gid:       [u8; 16],
+    pub(super) gid_index: u8,
+}
+
+unsafe impl Send for IbDevice {}
+unsafe impl Sync for IbDevice {}
+
+impl IbDevice {
+    pub fn gid_bytes(&self) -> [u8; 16] { self.gid }
+
+    pub fn open(dev_name: &str) -> io::Result<Self> {
+        unsafe {
+            let mut n: i32 = 0;
+            let list = ibv_get_device_list(&mut n);
+            if list.is_null() || n == 0 {
+                if !list.is_null() { ibv_free_device_list(list); }
+                return Err(io::Error::other("no rdma devices"));
+            }
+            let mut chosen = std::ptr::null_mut();
+            for i in 0..n {
+                let d = *list.offset(i as isize);
+                if CStr::from_ptr(ibv_get_device_name(d)).to_string_lossy() == dev_name {
+                    chosen = d;
+                    break;
+                }
+            }
+            if chosen.is_null() { chosen = *list; }
+            let ctx = ibv_open_device(chosen);
+            ibv_free_device_list(list);
+            let ctx = NonNull::new(ctx).ok_or_else(io::Error::last_os_error)?;
+
+            let pd = NonNull::new(ibv_alloc_pd(ctx.as_ptr()))
+                .ok_or_else(|| { ibv_close_device(ctx.as_ptr()); io::Error::last_os_error() })?;
+
+            let mut port_attr: ibv_port_attr = mem::zeroed();
+            let rc = ibv_query_port(ctx.as_ptr(), PORT_NUM, &mut port_attr);
+            if rc != 0 {
+                return Err(io::Error::other(format!(
+                    "ibv_query_port port={PORT_NUM} rc={rc} errno={}",
+                    io::Error::last_os_error()
+                )));
+            }
+
+            let gid_index = if port_attr.link_layer == 1 { GID_INDEX_IB } else { GID_INDEX_ROCE };
+            let mut gid: ibv_gid = mem::zeroed();
+            let rc = ibv_query_gid(ctx.as_ptr(), PORT_NUM, gid_index as i32, &mut gid);
+            if rc != 0 {
+                return Err(io::Error::other(format!(
+                    "ibv_query_gid port={PORT_NUM} gid_index={gid_index} link_layer={} rc={rc} errno={}",
+                    port_attr.link_layer, io::Error::last_os_error()
+                )));
+            }
+
+            Ok(IbDevice { ctx, pd, port_attr, gid: gid.raw, gid_index })
+        }
+    }
+}
+
+impl Drop for IbDevice {
+    fn drop(&mut self) {
+        unsafe {
+            ibv_dealloc_pd(self.pd.as_ptr());
+            ibv_close_device(self.ctx.as_ptr());
+        }
+    }
+}

--- a/crates/phenomenal_io/src/rdma/mlx5dv_sys.rs
+++ b/crates/phenomenal_io/src/rdma/mlx5dv_sys.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/mlx5dv_sys.rs"));

--- a/crates/phenomenal_io/src/rdma/mod.rs
+++ b/crates/phenomenal_io/src/rdma/mod.rs
@@ -1,0 +1,16 @@
+mod ah_cache;
+mod buffers;
+mod device;
+#[allow(non_camel_case_types, non_snake_case, non_upper_case_globals, dead_code, improper_ctypes)]
+mod mlx5dv_sys;
+mod node;
+mod rdma_buf;
+mod socket;
+mod wr;
+
+pub use ah_cache::AhCache;
+pub use buffers::BUF_SIZE;
+pub use device::IbDevice;
+pub use node::{PeerEndpoint, RdmaConfig, RdmaNode, RdmaQos};
+pub use rdma_buf::{RdmaBuf, RdmaBufPool, RdmaRemoteBuf};
+pub use socket::{CqPump, IbSocket};

--- a/crates/phenomenal_io/src/rdma/node.rs
+++ b/crates/phenomenal_io/src/rdma/node.rs
@@ -1,0 +1,87 @@
+use std::collections::HashMap;
+use std::io;
+use std::sync::atomic::AtomicU64;
+use std::sync::{Arc, Mutex};
+
+use futures::channel::oneshot;
+use serde::{Deserialize, Serialize};
+
+use super::ah_cache::AhCache;
+use super::device::IbDevice;
+use super::socket::{CqPump, IbSocket};
+use crate::rpc::Response;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PeerEndpoint {
+    pub node_id: u16,
+    pub gid:     [u8; 16],
+    pub dct_num: u32,
+    pub dc_key:  u64,
+}
+
+/// QoS for outbound RDMA traffic. Stamped onto every `ibv_ah_attr` we
+/// build (peer AH cache + DCT/DCI RTR transitions). Operator-set,
+/// no default: lossless RoCE deployments REQUIRE these to match the
+/// switch fabric's PFC/ECN configuration. Values of 0 give best-effort.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct RdmaQos {
+    /// 8-bit IP TOS byte. Upper 6 bits = DSCP. Switch fabric maps this
+    /// DSCP to the PFC priority queue (priority 3 lossless RoCE is
+    /// typically traffic_class = 96, i.e. DSCP 24 << 2).
+    pub traffic_class: u8,
+    /// Service Level. Mellanox HCAs use this to select the egress TC
+    /// queue in SL-based PFC mode. For PFC priority 3 set sl=3.
+    pub service_level: u8,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RdmaConfig {
+    pub self_node_id: u16,
+    pub dev_name:     String,
+    pub dc_key:       u64,
+    pub qos:          RdmaQos,
+    pub peers:        Vec<PeerEndpoint>,
+}
+
+pub struct RdmaNode {
+    pub self_id:           u16,
+    pub dev:               Arc<IbDevice>,
+    pub sock:              Arc<IbSocket>,
+    pub ah_cache:          Arc<AhCache>,
+    pub peers:             HashMap<u16, PeerEndpoint>,
+    pub pump:              CqPump,
+    pub next_request_id:   AtomicU64,
+    pub pending_responses: Mutex<HashMap<u64, oneshot::Sender<Response>>>,
+}
+
+impl RdmaNode {
+    pub fn start(cfg: RdmaConfig) -> io::Result<Self> {
+        let dev      = Arc::new(IbDevice::open(&cfg.dev_name)?);
+        let sock     = Arc::new(IbSocket::new(dev.clone(), cfg.dc_key, cfg.qos)?);
+        let ah_cache = Arc::new(AhCache::new(dev.pd.as_ptr(), cfg.qos, dev.gid_index, dev.port_attr.lid));
+        let pump     = CqPump::start(sock.clone())?;
+        let self_dct_identifier = sock.self_dct_identifier;
+        let my_gid     = dev.gid;
+        let mut peers = HashMap::with_capacity(cfg.peers.len());
+        for mut p in cfg.peers {
+            // Loopback: a peer entry referencing ourselves gets its
+            // gid + dct_num patched with the real values discovered at
+            // boot (TOML can't predict the DCT number we get from the HCA).
+            if p.node_id == cfg.self_node_id {
+                p.gid     = my_gid;
+                p.dct_num = self_dct_identifier;
+                p.dc_key  = cfg.dc_key;
+            }
+            peers.insert(p.node_id, p);
+        }
+        Ok(RdmaNode {
+            self_id: cfg.self_node_id, dev, sock, ah_cache, peers, pump,
+            next_request_id:   AtomicU64::new(1),
+            pending_responses: Mutex::new(HashMap::new()),
+        })
+    }
+
+    pub fn peer(&self, node_id: u16) -> Option<&PeerEndpoint> {
+        self.peers.get(&node_id)
+    }
+}

--- a/crates/phenomenal_io/src/rdma/rdma_buf.rs
+++ b/crates/phenomenal_io/src/rdma/rdma_buf.rs
@@ -1,0 +1,82 @@
+use std::alloc::{alloc_zeroed, dealloc, Layout};
+use std::io;
+use std::ptr::NonNull;
+use std::sync::Mutex;
+
+use rdma_mummy_sys::{
+    ibv_access_flags, ibv_dereg_mr, ibv_mr, ibv_pd, ibv_reg_mr,
+};
+use serde::{Deserialize, Serialize};
+
+const PAGE_ALIGN: usize = 4096;
+
+pub struct RdmaBuf {
+    base:   NonNull<u8>,
+    layout: Layout,
+    mr:     NonNull<ibv_mr>,
+    capacity: usize,
+}
+
+unsafe impl Send for RdmaBuf {}
+unsafe impl Sync for RdmaBuf {}
+
+impl RdmaBuf {
+    pub fn new(pd: *mut ibv_pd, capacity: usize) -> io::Result<Self> {
+        let layout = Layout::from_size_align(capacity, PAGE_ALIGN)
+            .map_err(|e| io::Error::other(format!("layout: {e}")))?;
+        unsafe {
+            let raw = alloc_zeroed(layout);
+            let base = NonNull::new(raw).ok_or_else(|| io::Error::other("alloc"))?;
+            let flags = ibv_access_flags::IBV_ACCESS_LOCAL_WRITE.0
+                      | ibv_access_flags::IBV_ACCESS_REMOTE_WRITE.0
+                      | ibv_access_flags::IBV_ACCESS_REMOTE_READ.0
+                      | ibv_access_flags::IBV_ACCESS_RELAXED_ORDERING.0;
+            let mr = ibv_reg_mr(pd, base.as_ptr() as *mut _, capacity, flags as i32);
+            let mr = match NonNull::new(mr) {
+                Some(m) => m,
+                None => { let e = io::Error::last_os_error(); dealloc(base.as_ptr(), layout); return Err(e); }
+            };
+            Ok(RdmaBuf { base, layout, mr, capacity })
+        }
+    }
+    pub fn addr(&self)     -> u64   { self.base.as_ptr() as u64 }
+    pub fn lkey(&self)     -> u32   { unsafe { (*self.mr.as_ptr()).lkey } }
+    pub fn rkey(&self)     -> u32   { unsafe { (*self.mr.as_ptr()).rkey } }
+    pub fn capacity(&self) -> usize { self.capacity }
+    pub fn as_remote(&self, len: u32) -> RdmaRemoteBuf {
+        RdmaRemoteBuf { addr: self.addr(), len, rkey: self.rkey() }
+    }
+    pub fn as_slice_mut(&mut self) -> &mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.base.as_ptr(), self.capacity) }
+    }
+    pub fn as_slice(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.base.as_ptr(), self.capacity) }
+    }
+}
+
+impl Drop for RdmaBuf {
+    fn drop(&mut self) {
+        unsafe { ibv_dereg_mr(self.mr.as_ptr()); dealloc(self.base.as_ptr(), self.layout); }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct RdmaRemoteBuf {
+    pub addr: u64,
+    pub len:  u32,
+    pub rkey: u32,
+}
+
+pub struct RdmaBufPool {
+    free: Mutex<Vec<RdmaBuf>>,
+}
+
+impl RdmaBufPool {
+    pub fn new(pd: *mut ibv_pd, count: usize, capacity: usize) -> io::Result<Self> {
+        let mut v = Vec::with_capacity(count);
+        for _ in 0..count { v.push(RdmaBuf::new(pd, capacity)?); }
+        Ok(RdmaBufPool { free: Mutex::new(v) })
+    }
+    pub fn acquire(&self) -> Option<RdmaBuf> { self.free.lock().unwrap().pop() }
+    pub fn release(&self, buf: RdmaBuf)      { self.free.lock().unwrap().push(buf); }
+}

--- a/crates/phenomenal_io/src/rdma/socket.rs
+++ b/crates/phenomenal_io/src/rdma/socket.rs
@@ -1,0 +1,569 @@
+use std::collections::HashMap;
+use std::io;
+use std::mem;
+use std::ptr::{self, NonNull};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use futures::channel::{mpsc, oneshot};
+
+use rdma_mummy_sys::{
+    ibv_access_flags, ibv_ack_cq_events, ibv_ah, ibv_comp_channel, ibv_cq,
+    ibv_create_comp_channel, ibv_create_cq, ibv_create_srq, ibv_destroy_comp_channel,
+    ibv_destroy_cq, ibv_destroy_qp, ibv_destroy_srq, ibv_get_cq_event, ibv_modify_qp,
+    ibv_poll_cq, ibv_post_srq_recv, ibv_qp, ibv_qp_attr, ibv_qp_attr_mask,
+    ibv_qp_init_attr_ex, ibv_qp_state, ibv_qp_to_qp_ex, ibv_qp_type, ibv_recv_wr,
+    ibv_req_notify_cq, ibv_send_flags, ibv_sge, ibv_srq, ibv_srq_init_attr, ibv_wc,
+    ibv_wc_flags, ibv_wc_opcode, ibv_wc_status, ibv_wr_complete, ibv_wr_rdma_read,
+    ibv_wr_rdma_write, ibv_wr_send, ibv_wr_send_imm, ibv_wr_set_sge, ibv_wr_start,
+};
+
+use super::buffers::{
+    RecvBuffers, SendBuffers, BUF_ACK_BATCH, BUF_SIGNAL_BATCH, BUF_SIZE, SEND_BUF_CNT,
+};
+use super::device::{IbDevice, PORT_NUM};
+use super::node::RdmaQos;
+use super::mlx5dv_sys::{
+    mlx5dv_create_qp, mlx5dv_qp_ex_from_ibv_qp_ex, mlx5dv_qp_init_attr,
+    mlx5dv_dc_type_MLX5DV_DCTYPE_DCT, mlx5dv_dc_type_MLX5DV_DCTYPE_DCI,
+    mlx5dv_qp_init_attr_mask_MLX5DV_QP_INIT_ATTR_MASK_DC,
+};
+use super::wr::{ImmData, ImmType, WrId, WrType};
+
+const CQ_DEPTH:        i32 = 4096;
+const MAX_SEND_WR:     u32 = 256;
+const SRQ_DEPTH:       u32 = 64;
+const MAX_RD_ATOMIC:   u8  = 16;
+const MIN_RNR_TIMER:   u8  = 1;
+const QP_TIMEOUT:      u8  = 14;
+const QP_RETRY_CNT:    u8  = 7;
+
+pub struct IbSocket {
+    pub(super) dev:          Arc<IbDevice>,
+    pub(super) cq:           NonNull<ibv_cq>,
+    pub(super) comp_channel: NonNull<ibv_comp_channel>,
+    pub(super) srq:          NonNull<ibv_srq>,
+    pub(super) dct:          NonNull<ibv_qp>,
+    pub(super) dci:          NonNull<ibv_qp>,
+    pub(super) send_bufs:    SendBuffers,
+    pub(super) recv_bufs:    RecvBuffers,
+    pub(super) dc_key:       u64,
+    pub(super) self_dct_identifier:   u32,
+
+    // Credit accounting, mutated by the CQ pump.
+    pub(super) send_signaled:     AtomicU64,
+    pub(super) send_acked:        AtomicU64,
+    pub(super) send_not_signaled: AtomicU32,
+    pub(super) recv_not_acked:    AtomicU32,
+
+    // Serialize ibv_wr_start..ibv_wr_complete on the DCI.
+    pub(super) post_mu: Mutex<()>,
+
+    // Per-wr_id completion waiters for one-sided RDMA WRITE/READ.
+    pub(super) completion: Mutex<HashMap<u64, oneshot::Sender<i32>>>,
+    pub(super) next_wr_id: AtomicU64,
+}
+
+unsafe impl Send for IbSocket {}
+unsafe impl Sync for IbSocket {}
+
+impl IbSocket {
+    pub fn self_dct_identifier(&self) -> u32 { self.self_dct_identifier }
+
+    pub fn new(dev: Arc<IbDevice>, dc_key: u64, qos: RdmaQos) -> io::Result<Self> {
+        unsafe {
+            let comp_channel = ibv_create_comp_channel(dev.ctx.as_ptr());
+            let comp_channel = NonNull::new(comp_channel)
+                .ok_or_else(|| io::Error::other("ibv_create_comp_channel returned NULL"))?;
+            let cq = ibv_create_cq(dev.ctx.as_ptr(), CQ_DEPTH, ptr::null_mut(),
+                                   comp_channel.as_ptr(), 0);
+            let cq = match NonNull::new(cq) {
+                Some(c) => c,
+                None    => { ibv_destroy_comp_channel(comp_channel.as_ptr());
+                             return Err(io::Error::other("ibv_create_cq returned NULL")); }
+            };
+            if ibv_req_notify_cq(cq.as_ptr(), 0) != 0 {
+                let e = io::Error::other(format!("ibv_req_notify_cq: {}", io::Error::last_os_error()));
+                ibv_destroy_cq(cq.as_ptr());
+                ibv_destroy_comp_channel(comp_channel.as_ptr());
+                return Err(e);
+            }
+
+            let mut srq_attr: ibv_srq_init_attr = mem::zeroed();
+            srq_attr.attr.max_wr  = SRQ_DEPTH;
+            srq_attr.attr.max_sge = 1;
+            let srq = ibv_create_srq(dev.pd.as_ptr(), &mut srq_attr);
+            let srq = NonNull::new(srq)
+                .ok_or_else(|| io::Error::other(format!("ibv_create_srq: {}", io::Error::last_os_error())))?;
+
+            let dct = create_dct(&dev, cq.as_ptr(), srq.as_ptr(), dc_key)
+                .map_err(|e| io::Error::other(format!("create_dct: {e}")))?;
+            transition_dct(dct.as_ptr(), &dev, qos)
+                .map_err(|e| io::Error::other(format!("transition_dct: {e}")))?;
+            // mlx5dv assigns the DCT number during the RTR transition, not at create.
+            let self_dct_identifier = (*dct.as_ptr()).qp_num;
+
+            let dci = create_dci(&dev, cq.as_ptr())
+                .map_err(|e| io::Error::other(format!("create_dci: {e}")))?;
+            transition_dci(dci.as_ptr(), &dev, qos)
+                .map_err(|e| io::Error::other(format!("transition_dci: {e}")))?;
+
+            let send_bufs = SendBuffers::new(dev.pd.as_ptr(), SEND_BUF_CNT, BUF_SIZE)?;
+            let recv_bufs = RecvBuffers::new(dev.pd.as_ptr(), SEND_BUF_CNT, BUF_SIZE)?;
+
+            let sock = IbSocket {
+                dev, cq, comp_channel, srq, dct, dci,
+                send_bufs, recv_bufs, dc_key, self_dct_identifier,
+                send_signaled:     AtomicU64::new(0),
+                send_acked:        AtomicU64::new(0),
+                send_not_signaled: AtomicU32::new(0),
+                recv_not_acked:    AtomicU32::new(0),
+                post_mu:           Mutex::new(()),
+                completion:        Mutex::new(HashMap::new()),
+                next_wr_id:        AtomicU64::new(1),
+            };
+            for i in 0..SEND_BUF_CNT { sock.post_recv(i as u32)?; }
+            Ok(sock)
+        }
+    }
+
+    pub fn send(
+        &self, mut buf: &[u8], ah: *mut ibv_ah, peer_dct_num: u32, peer_dc_key: u64,
+    ) -> io::Result<usize> {
+        let mut total = 0;
+        let bs = BUF_SIZE;
+        while !buf.is_empty() {
+            let Some(idx) = self.send_bufs.try_pop() else { break; };
+            let n = buf.len().min(bs);
+            unsafe {
+                // todo: @arnav revisit memcp here
+                ptr::copy_nonoverlapping(
+                    buf.as_ptr(),
+                    self.send_bufs.base().slot_ptr(idx),
+                    n,
+                );
+            }
+            self.post_send(idx as u32, n as u32, ah, peer_dct_num, peer_dc_key)?;
+            total += n;
+            buf = &buf[n..];
+        }
+        Ok(total)
+    }
+
+    /// Pop one fully-received envelope from the recv queue. Used by the
+    /// rdma_server dispatcher which awaits notification from the pump
+    /// and then drains envelopes one at a time.
+    pub fn attempt_singular_rcv(&self, out: &mut Vec<u8>) -> Option<()> {
+        let (idx, len) = self.recv_bufs.pop()?;
+        out.resize(len as usize, 0);
+        unsafe {
+            ptr::copy_nonoverlapping(
+                self.recv_bufs.base().slot_ptr(idx as usize),
+                out.as_mut_ptr(),
+                len as usize,
+            );
+        }
+        Some(())
+    }
+
+    pub fn recv(
+        &self, mut out: &mut [u8], ah: *mut ibv_ah, peer_dct_num: u32, peer_dc_key: u64,
+    ) -> io::Result<usize> {
+        let mut total = 0;
+        while !out.is_empty() {
+            let Some((idx, len)) = self.recv_bufs.pop() else { break; };
+            let n = (len as usize).min(out.len());
+            unsafe {
+                // todo: @arnav revisit memcp here
+                ptr::copy_nonoverlapping(
+                    self.recv_bufs.base().slot_ptr(idx as usize),
+                    out.as_mut_ptr(),
+                    n,
+                );
+            }
+            out = &mut out[n..];
+            total += n;
+            let prev = self.recv_not_acked.fetch_add(1, Ordering::Relaxed) + 1;
+            if prev >= BUF_ACK_BATCH {
+                self.recv_not_acked.store(0, Ordering::Relaxed);
+                self.post_ack(ah, peer_dct_num, peer_dc_key)?;
+            }
+        }
+        Ok(total)
+    }
+
+    pub async fn rdma_write(
+        &self,
+        local_addr: u64, local_len: u32, local_lkey: u32,
+        remote_addr: u64, remote_rkey: u32,
+        ah: *mut ibv_ah, peer_dct_num: u32, peer_dc_key: u64,
+    ) -> io::Result<()> {
+        let wr_id = self.next_wr_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = oneshot::channel();
+        self.completion.lock().unwrap().insert(wr_id, tx);
+        {
+            let _g = self.post_mu.lock().unwrap();
+            unsafe {
+                let qpx  = ibv_qp_to_qp_ex(self.dci.as_ptr());
+                let mqpx = mlx5dv_qp_ex_from_ibv_qp_ex(qpx);
+                ibv_wr_start(qpx);
+                (*qpx).wr_id    = wr_id;
+                (*qpx).wr_flags = ibv_send_flags::IBV_SEND_SIGNALED.0 as u32;
+                ibv_wr_rdma_write(qpx, remote_rkey, remote_addr);
+                ibv_wr_set_sge(qpx, local_lkey, local_addr, local_len);
+                ((*mqpx).wr_set_dc_addr.expect("wr_set_dc_addr"))(mqpx, ah, peer_dct_num, peer_dc_key);
+                let rc = ibv_wr_complete(qpx);
+                if rc != 0 {
+                    self.completion.lock().unwrap().remove(&wr_id);
+                    return Err(io::Error::from_raw_os_error(rc));
+                }
+            }
+        }
+        let status = rx.await.map_err(|_| io::Error::other("pump dropped"))?;
+        if status != 0 { return Err(io::Error::other(format!("rdma_write wc.status={status}"))); }
+        Ok(())
+    }
+
+    pub async fn rdma_read(
+        &self,
+        local_addr: u64, local_len: u32, local_lkey: u32,
+        remote_addr: u64, remote_rkey: u32,
+        ah: *mut ibv_ah, peer_dct_num: u32, peer_dc_key: u64,
+    ) -> io::Result<()> {
+        let wr_id = self.next_wr_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = oneshot::channel();
+        self.completion.lock().unwrap().insert(wr_id, tx);
+        {
+            let _g = self.post_mu.lock().unwrap();
+            unsafe {
+                let qpx  = ibv_qp_to_qp_ex(self.dci.as_ptr());
+                let mqpx = mlx5dv_qp_ex_from_ibv_qp_ex(qpx);
+                ibv_wr_start(qpx);
+                (*qpx).wr_id    = wr_id;
+                (*qpx).wr_flags = ibv_send_flags::IBV_SEND_SIGNALED.0 as u32;
+                ibv_wr_rdma_read(qpx, remote_rkey, remote_addr);
+                ibv_wr_set_sge(qpx, local_lkey, local_addr, local_len);
+                ((*mqpx).wr_set_dc_addr.expect("wr_set_dc_addr"))(mqpx, ah, peer_dct_num, peer_dc_key);
+                let rc = ibv_wr_complete(qpx);
+                if rc != 0 {
+                    self.completion.lock().unwrap().remove(&wr_id);
+                    return Err(io::Error::from_raw_os_error(rc));
+                }
+            }
+        }
+        let status = rx.await.map_err(|_| io::Error::other("pump dropped"))?;
+        if status != 0 { return Err(io::Error::other(format!("rdma_read wc.status={status}"))); }
+        Ok(())
+    }
+
+    pub(super) fn post_send(
+        &self, buf_idx: u32, len: u32, ah: *mut ibv_ah, peer_dct_num: u32, peer_dc_key: u64,
+    ) -> io::Result<()> {
+        let prev = self.send_not_signaled.fetch_add(1, Ordering::Relaxed) + 1;
+        let signal = if prev >= BUF_SIGNAL_BATCH {
+            self.send_not_signaled.store(0, Ordering::Relaxed);
+            prev
+        } else { 0 };
+        let _g = self.post_mu.lock().unwrap();
+        unsafe {
+            let qpx  = ibv_qp_to_qp_ex(self.dci.as_ptr());
+            let mqpx = mlx5dv_qp_ex_from_ibv_qp_ex(qpx);
+            ibv_wr_start(qpx);
+            (*qpx).wr_id    = WrId::send(signal).0;
+            (*qpx).wr_flags = if signal > 0 { ibv_send_flags::IBV_SEND_SIGNALED.0 as u32 } else { 0 };
+            ibv_wr_send(qpx);
+            ibv_wr_set_sge(qpx, self.send_bufs.base().lkey(),
+                           self.send_bufs.base().slot_addr(buf_idx as usize), len);
+            ((*mqpx).wr_set_dc_addr.expect("wr_set_dc_addr"))(mqpx, ah, peer_dct_num, peer_dc_key);
+            let rc = ibv_wr_complete(qpx);
+            if rc != 0 { return Err(io::Error::from_raw_os_error(rc)); }
+        }
+        Ok(())
+    }
+
+    pub(super) fn post_ack(
+        &self, ah: *mut ibv_ah, peer_dct_num: u32, peer_dc_key: u64,
+    ) -> io::Result<()> {
+        let _g = self.post_mu.lock().unwrap();
+        unsafe {
+            let qpx  = ibv_qp_to_qp_ex(self.dci.as_ptr());
+            let mqpx = mlx5dv_qp_ex_from_ibv_qp_ex(qpx);
+            ibv_wr_start(qpx);
+            (*qpx).wr_id    = WrId::ack().0;
+            (*qpx).wr_flags = ibv_send_flags::IBV_SEND_SIGNALED.0 as u32;
+            ibv_wr_send_imm(qpx, ImmData::ack(BUF_ACK_BATCH).0.to_be());
+            ((*mqpx).wr_set_dc_addr.expect("wr_set_dc_addr"))(mqpx, ah, peer_dct_num, peer_dc_key);
+            let rc = ibv_wr_complete(qpx);
+            if rc != 0 { return Err(io::Error::from_raw_os_error(rc)); }
+        }
+        Ok(())
+    }
+
+    pub(super) fn post_recv(&self, buf_idx: u32) -> io::Result<()> {
+        unsafe {
+            let mut sge: ibv_sge = mem::zeroed();
+            sge.addr   = self.recv_bufs.base().slot_addr(buf_idx as usize);
+            sge.length = BUF_SIZE as u32;
+            sge.lkey   = self.recv_bufs.base().lkey();
+            let mut wr: ibv_recv_wr = mem::zeroed();
+            wr.wr_id   = super::wr::WrId::recv(buf_idx).0;
+            wr.sg_list = &mut sge;
+            wr.num_sge = 1;
+            let mut bad: *mut ibv_recv_wr = ptr::null_mut();
+            let rc = ibv_post_srq_recv(self.srq.as_ptr(), &mut wr, &mut bad);
+            if rc != 0 { return Err(io::Error::from_raw_os_error(rc)); }
+        }
+        Ok(())
+    }
+}
+
+impl Drop for IbSocket {
+    fn drop(&mut self) {
+        unsafe {
+            ibv_destroy_qp(self.dci.as_ptr());
+            ibv_destroy_qp(self.dct.as_ptr());
+            ibv_destroy_srq(self.srq.as_ptr());
+            ibv_destroy_cq(self.cq.as_ptr());
+            ibv_destroy_comp_channel(self.comp_channel.as_ptr());
+        }
+    }
+}
+
+unsafe fn create_dct(dev: &IbDevice, cq: *mut ibv_cq, srq: *mut ibv_srq, dc_key: u64)
+    -> io::Result<NonNull<ibv_qp>>
+{
+    let mut a: ibv_qp_init_attr_ex = mem::zeroed();
+    a.qp_type   = ibv_qp_type::IBV_QPT_DRIVER as u32;
+    a.send_cq   = cq;
+    a.recv_cq   = cq;
+    a.srq       = srq;
+    a.pd        = dev.pd.as_ptr();
+    a.comp_mask = rdma_mummy_sys::ibv_qp_init_attr_mask::IBV_QP_INIT_ATTR_PD.0;
+    let mut m: mlx5dv_qp_init_attr = mem::zeroed();
+    m.comp_mask                                  = mlx5dv_qp_init_attr_mask_MLX5DV_QP_INIT_ATTR_MASK_DC as u64;
+    m.dc_init_attr.dc_type                       = mlx5dv_dc_type_MLX5DV_DCTYPE_DCT;
+    m.dc_init_attr.__bindgen_anon_1.dct_access_key = dc_key;
+    NonNull::new(mlx5dv_create_qp(dev.ctx.as_ptr(), &mut a, &mut m))
+        .ok_or_else(io::Error::last_os_error)
+}
+
+unsafe fn create_dci(dev: &IbDevice, cq: *mut ibv_cq) -> io::Result<NonNull<ibv_qp>> {
+    let mut a: ibv_qp_init_attr_ex = mem::zeroed();
+    a.qp_type           = ibv_qp_type::IBV_QPT_DRIVER as u32;
+    a.send_cq           = cq;
+    a.recv_cq           = cq;
+    a.pd                = dev.pd.as_ptr();
+    a.cap.max_send_wr   = MAX_SEND_WR;
+    a.cap.max_send_sge  = 1;
+    a.comp_mask         = rdma_mummy_sys::ibv_qp_init_attr_mask::IBV_QP_INIT_ATTR_PD.0
+                        | rdma_mummy_sys::ibv_qp_init_attr_mask::IBV_QP_INIT_ATTR_SEND_OPS_FLAGS.0;
+    a.send_ops_flags    = (rdma_mummy_sys::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_SEND.0
+                         | rdma_mummy_sys::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_SEND_WITH_IMM.0
+                         | rdma_mummy_sys::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_WRITE.0
+                         | rdma_mummy_sys::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM.0
+                         | rdma_mummy_sys::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_READ.0) as u64;
+    let mut m: mlx5dv_qp_init_attr = mem::zeroed();
+    m.comp_mask              = mlx5dv_qp_init_attr_mask_MLX5DV_QP_INIT_ATTR_MASK_DC as u64;
+    m.dc_init_attr.dc_type   = mlx5dv_dc_type_MLX5DV_DCTYPE_DCI;
+    NonNull::new(mlx5dv_create_qp(dev.ctx.as_ptr(), &mut a, &mut m))
+        .ok_or_else(io::Error::last_os_error)
+}
+
+unsafe fn transition_dct(qp: *mut ibv_qp, dev: &IbDevice, qos: RdmaQos) -> io::Result<()> {
+    let mut a: ibv_qp_attr = mem::zeroed();
+    a.qp_state        = ibv_qp_state::IBV_QPS_INIT;
+    a.port_num        = PORT_NUM;
+    a.qp_access_flags = (ibv_access_flags::IBV_ACCESS_LOCAL_WRITE.0
+                       | ibv_access_flags::IBV_ACCESS_REMOTE_WRITE.0
+                       | ibv_access_flags::IBV_ACCESS_REMOTE_READ.0) as u32;
+    let m = ibv_qp_attr_mask::IBV_QP_STATE.0
+          | ibv_qp_attr_mask::IBV_QP_PKEY_INDEX.0
+          | ibv_qp_attr_mask::IBV_QP_PORT.0
+          | ibv_qp_attr_mask::IBV_QP_ACCESS_FLAGS.0;
+    let rc = ibv_modify_qp(qp, &mut a, m as i32);
+    if rc != 0 {
+        return Err(io::Error::other(format!(
+            "ibv_modify_qp rc={rc} errno={}", io::Error::last_os_error()
+        )));
+    }
+
+    let mut a: ibv_qp_attr = mem::zeroed();
+    a.qp_state           = ibv_qp_state::IBV_QPS_RTR;
+    a.path_mtu           = dev.port_attr.active_mtu;
+    a.min_rnr_timer      = MIN_RNR_TIMER;
+    a.max_dest_rd_atomic = MAX_RD_ATOMIC;
+    a.ah_attr.is_global         = 1;
+    a.ah_attr.port_num          = PORT_NUM;
+    a.ah_attr.sl                = qos.service_level;
+    a.ah_attr.grh.sgid_index    = dev.gid_index;
+    a.ah_attr.grh.hop_limit     = 64;
+    a.ah_attr.grh.traffic_class = qos.traffic_class;
+    let m = ibv_qp_attr_mask::IBV_QP_STATE.0
+          | ibv_qp_attr_mask::IBV_QP_PATH_MTU.0
+          | ibv_qp_attr_mask::IBV_QP_AV.0
+          | ibv_qp_attr_mask::IBV_QP_MIN_RNR_TIMER.0;
+    let rc = ibv_modify_qp(qp, &mut a, m as i32);
+    if rc != 0 {
+        return Err(io::Error::other(format!(
+            "ibv_modify_qp rc={rc} errno={}", io::Error::last_os_error()
+        )));
+    }
+    Ok(())
+}
+
+pub struct CqPump {
+    _task:   compio::runtime::Task<Result<(), Box<dyn std::any::Any + Send>>>,
+    sock:    Arc<IbSocket>,
+    recv_rx: Mutex<Option<mpsc::UnboundedReceiver<()>>>,
+}
+
+impl CqPump {
+    pub fn start(sock: Arc<IbSocket>) -> io::Result<Self> {
+        let fd = unsafe { (*sock.comp_channel.as_ptr()).fd };
+        let (tx, rx) = mpsc::unbounded();
+        let s = sock.clone();
+        let task = compio::runtime::spawn(async move { run_pump_compio(s, fd, tx).await });
+        Ok(CqPump { _task: task, sock, recv_rx: Mutex::new(Some(rx)) })
+    }
+    pub fn socket(&self) -> &Arc<IbSocket> { &self.sock }
+    pub fn take_recv_rx(&self) -> Option<mpsc::UnboundedReceiver<()>> {
+        self.recv_rx.lock().unwrap().take()
+    }
+}
+
+const WC_BATCH: i32 = 16;
+
+struct CompChannelFd(std::os::fd::RawFd);
+impl std::os::fd::AsFd for CompChannelFd {
+    fn as_fd(&self) -> std::os::fd::BorrowedFd<'_> {
+        unsafe { std::os::fd::BorrowedFd::borrow_raw(self.0) }
+    }
+}
+
+async fn run_pump_compio(sock: Arc<IbSocket>, fd: std::os::fd::RawFd, recv_tx: mpsc::UnboundedSender<()>) {
+    let mut wcs: [ibv_wc; WC_BATCH as usize] = unsafe { mem::zeroed() };
+    loop {
+        let op = compio::driver::op::PollOnce::new(
+            CompChannelFd(fd),
+            compio::driver::op::Interest::Readable,
+        );
+        if compio::runtime::submit(op).await.0.is_err() { return; }
+        unsafe {
+            let mut ev_cq: *mut ibv_cq = ptr::null_mut();
+            let mut ctx:   *mut std::ffi::c_void = ptr::null_mut();
+            if ibv_get_cq_event(sock.comp_channel.as_ptr(), &mut ev_cq, &mut ctx) != 0 { return; }
+            ibv_ack_cq_events(ev_cq, 1);
+            if ibv_req_notify_cq(sock.cq.as_ptr(), 0) != 0 { return; }
+            loop {
+                let n = ibv_poll_cq(sock.cq.as_ptr(), WC_BATCH, wcs.as_mut_ptr());
+                if n <= 0 { break; }
+                for wc in &wcs[..n as usize] {
+                    handle_wc(&sock, wc, &recv_tx);
+                }
+                reconcile_credit(&sock);
+            }
+        }
+    }
+}
+
+fn handle_wc(sock: &IbSocket, wc: &ibv_wc, recv_tx: &mpsc::UnboundedSender<()>) {
+    let status_ok = wc.status == ibv_wc_status::IBV_WC_SUCCESS;
+    let wr = WrId(wc.wr_id);
+    let imm_set = (wc.wc_flags & ibv_wc_flags::IBV_WC_WITH_IMM.0) != 0;
+    match wc.opcode {
+        ibv_wc_opcode::IBV_WC_SEND => {
+            if status_ok && wr.ty() == WrType::Send {
+                let n = wr.signal_count() as u64;
+                if n > 0 { sock.send_signaled.fetch_add(n, Ordering::Relaxed); }
+            }
+        }
+        ibv_wc_opcode::IBV_WC_RDMA_WRITE | ibv_wc_opcode::IBV_WC_RDMA_READ => {
+            if let Some(tx) = sock.completion.lock().unwrap().remove(&wc.wr_id) {
+                let _ = tx.send(wc.status as i32);
+            }
+        }
+        ibv_wc_opcode::IBV_WC_RECV | ibv_wc_opcode::IBV_WC_RECV_RDMA_WITH_IMM => {
+            if !status_ok { return; }
+            let buf_idx = (wc.wr_id & ((1 << 56) - 1)) as u32;
+            if imm_set {
+                let imm = unsafe {
+                    ImmData(u32::from_be(wc.imm_data_invalidated_rkey_union.imm_data))
+                };
+                if imm.ty() == ImmType::Ack {
+                    sock.send_acked.fetch_add(imm.data() as u64, Ordering::Relaxed);
+                }
+            } else {
+                sock.recv_bufs.push(buf_idx, wc.byte_len);
+                let _ = recv_tx.unbounded_send(());
+            }
+            let _ = sock.post_recv(buf_idx);
+        }
+        _ => {}
+    }
+}
+
+fn reconcile_credit(sock: &IbSocket) {
+    let signaled = sock.send_signaled.load(Ordering::Relaxed);
+    let acked    = sock.send_acked.load(Ordering::Relaxed);
+    let avail    = signaled.min(acked);
+    if avail > 0 {
+        sock.send_signaled.fetch_sub(avail, Ordering::Relaxed);
+        sock.send_acked   .fetch_sub(avail, Ordering::Relaxed);
+        sock.send_bufs.push(avail);
+    }
+}
+
+unsafe fn transition_dci(qp: *mut ibv_qp, dev: &IbDevice, qos: RdmaQos) -> io::Result<()> {
+    let mut a: ibv_qp_attr = mem::zeroed();
+    a.qp_state = ibv_qp_state::IBV_QPS_INIT;
+    a.port_num = PORT_NUM;
+    let m = ibv_qp_attr_mask::IBV_QP_STATE.0
+          | ibv_qp_attr_mask::IBV_QP_PKEY_INDEX.0
+          | ibv_qp_attr_mask::IBV_QP_PORT.0;
+    let rc = ibv_modify_qp(qp, &mut a, m as i32);
+    if rc != 0 {
+        return Err(io::Error::other(format!(
+            "DCI INIT ibv_modify_qp rc={rc} errno={}", io::Error::last_os_error()
+        )));
+    }
+
+    let mut a: ibv_qp_attr = mem::zeroed();
+    a.qp_state                  = ibv_qp_state::IBV_QPS_RTR;
+    a.path_mtu                  = dev.port_attr.active_mtu;
+    a.ah_attr.is_global         = 1;
+    a.ah_attr.port_num          = PORT_NUM;
+    a.ah_attr.sl                = qos.service_level;
+    a.ah_attr.grh.sgid_index    = dev.gid_index;
+    a.ah_attr.grh.hop_limit     = 64;
+    a.ah_attr.grh.traffic_class = qos.traffic_class;
+    let m = ibv_qp_attr_mask::IBV_QP_STATE.0
+          | ibv_qp_attr_mask::IBV_QP_PATH_MTU.0
+          | ibv_qp_attr_mask::IBV_QP_AV.0;
+    let rc = ibv_modify_qp(qp, &mut a, m as i32);
+    if rc != 0 {
+        return Err(io::Error::other(format!(
+            "DCI RTR ibv_modify_qp rc={rc} errno={}", io::Error::last_os_error()
+        )));
+    }
+
+    let mut a: ibv_qp_attr = mem::zeroed();
+    a.qp_state      = ibv_qp_state::IBV_QPS_RTS;
+    a.sq_psn        = 0;
+    a.timeout       = QP_TIMEOUT;
+    a.retry_cnt     = QP_RETRY_CNT;
+    a.rnr_retry     = 0;
+    a.max_rd_atomic = MAX_RD_ATOMIC;
+    let m = ibv_qp_attr_mask::IBV_QP_STATE.0
+          | ibv_qp_attr_mask::IBV_QP_SQ_PSN.0
+          | ibv_qp_attr_mask::IBV_QP_TIMEOUT.0
+          | ibv_qp_attr_mask::IBV_QP_RETRY_CNT.0
+          | ibv_qp_attr_mask::IBV_QP_RNR_RETRY.0
+          | ibv_qp_attr_mask::IBV_QP_MAX_QP_RD_ATOMIC.0;
+    let rc = ibv_modify_qp(qp, &mut a, m as i32);
+    if rc != 0 {
+        return Err(io::Error::other(format!(
+            "DCI RTS ibv_modify_qp rc={rc} errno={}", io::Error::last_os_error()
+        )));
+    }
+    Ok(())
+}

--- a/crates/phenomenal_io/src/rdma/wr.rs
+++ b/crates/phenomenal_io/src/rdma/wr.rs
@@ -1,0 +1,51 @@
+const TAG_SHIFT: u32 = 24;
+const TAG_MASK_32: u32 = (1 << TAG_SHIFT) - 1;
+const TAG_SEND:  u64 = 1 << 56;
+const TAG_RECV:  u64 = 2 << 56;
+const TAG_ACK:   u64 = 3 << 56;
+const TAG_CLOSE: u64 = 4 << 56;
+const TAG_MASK_64: u64 = 0xFF << 56;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WrType { Send, Recv, Ack, Close, Other }
+
+#[derive(Clone, Copy, Debug)]
+pub struct WrId(pub u64);
+
+impl WrId {
+    pub fn send(signal_count: u32) -> Self { Self(TAG_SEND | signal_count as u64) }
+    pub fn recv(buf_idx: u32)      -> Self { Self(TAG_RECV | buf_idx as u64) }
+    pub fn ack()                   -> Self { Self(TAG_ACK) }
+    pub fn close()                 -> Self { Self(TAG_CLOSE) }
+
+    pub fn ty(self) -> WrType {
+        match self.0 & TAG_MASK_64 {
+            TAG_SEND  => WrType::Send,
+            TAG_RECV  => WrType::Recv,
+            TAG_ACK   => WrType::Ack,
+            TAG_CLOSE => WrType::Close,
+            _         => WrType::Other,
+        }
+    }
+    pub fn signal_count(self) -> u32 { (self.0 & !TAG_MASK_64) as u32 }
+    pub fn buf_idx(self)      -> u32 { (self.0 & !TAG_MASK_64) as u32 }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ImmType { Ack, Close, Other }
+
+#[derive(Clone, Copy, Debug)]
+pub struct ImmData(pub u32);
+
+impl ImmData {
+    pub fn ack(count: u32)   -> Self { Self((1 << TAG_SHIFT) | (count & TAG_MASK_32)) }
+    pub fn close()           -> Self { Self(2 << TAG_SHIFT) }
+    pub fn ty(self) -> ImmType {
+        match self.0 >> TAG_SHIFT {
+            1 => ImmType::Ack,
+            2 => ImmType::Close,
+            _ => ImmType::Other,
+        }
+    }
+    pub fn data(self) -> u32 { self.0 & TAG_MASK_32 }
+}

--- a/crates/phenomenal_io/src/rdma_backend.rs
+++ b/crates/phenomenal_io/src/rdma_backend.rs
@@ -1,0 +1,105 @@
+use std::io;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::channel::oneshot;
+use serde::{Deserialize, Serialize};
+
+use crate::backend::StorageBackend;
+use crate::error::{IoError, IoResult};
+use crate::rdma::RdmaNode;
+use crate::rpc::{encode, Request, Response};
+use crate::stream::{ByteSink, ByteStream};
+use crate::types::{
+    DeleteOptions, DiskInfo, FileInfo, FormatJson, RenameDataResp, RenameOptions,
+    UpdateMetadataOpts, VolInfo,
+};
+
+pub const ENVELOPE_MAGIC: u32 = 0x52444D31; // "RDM1"
+
+#[derive(Serialize, Deserialize)]
+pub enum Envelope {
+    Req { magic: u32, from_node_id: u16, request_id: u64, payload: Request  },
+    Rsp { magic: u32, request_id: u64,                   payload: Response },
+}
+
+pub struct RdmaBackend {
+    node:     Arc<RdmaNode>,
+    peer_id:  u16,
+    disk_idx: u16,
+}
+
+impl RdmaBackend {
+    pub fn new(node: Arc<RdmaNode>, peer_id: u16, disk_idx: u16) -> Self {
+        Self { node, peer_id, disk_idx }
+    }
+
+    async fn unary(&self, payload: Request) -> IoResult<Response> {
+        let peer = self.node.peer(self.peer_id)
+            .ok_or_else(|| IoError::Io(io::Error::other(
+                format!("rdma peer {} not in registry", self.peer_id)
+            )))?
+            .clone();
+        let ah = self.node.ah_cache.get_or_create(&peer).map_err(IoError::Io)?;
+
+        let request_id = self.node.next_request_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = oneshot::channel();
+        self.node.pending_responses.lock().unwrap().insert(request_id, tx);
+
+        let env = Envelope::Req {
+            magic: ENVELOPE_MAGIC,
+            from_node_id: self.node.self_id,
+            request_id,
+            payload,
+        };
+        let body = encode(&env)?;
+        if let Err(e) = self.node.sock.send(&body, ah, peer.dct_num, peer.dc_key) {
+            self.node.pending_responses.lock().unwrap().remove(&request_id);
+            return Err(IoError::Io(e));
+        }
+
+        rx.await.map_err(|_| IoError::Io(io::Error::other("dispatcher dropped waiter")))
+    }
+}
+
+fn ns(op: &'static str) -> IoError {
+    IoError::Io(io::Error::other(format!("rdma backend: {op} not yet implemented")))
+}
+
+#[async_trait(?Send)]
+impl StorageBackend for RdmaBackend {
+    fn label(&self) -> String { format!("rdma:n{}d{}", self.peer_id, self.disk_idx) }
+
+    async fn stat_vol(&self, volume: &str) -> IoResult<VolInfo> {
+        match self.unary(Request::StatVol { disk_idx: self.disk_idx, volume: volume.into() }).await? {
+            Response::Vol(v) => Ok(v),
+            Response::Err(e) => Err(IoError::from(e)),
+            other            => Err(IoError::Decode(format!("expected Vol, got {other:?}"))),
+        }
+    }
+
+    async fn disk_info(&self)                          -> IoResult<DiskInfo>     { Err(ns("disk_info")) }
+    async fn make_vol(&self, _v: &str)                 -> IoResult<()>           { Err(ns("make_vol")) }
+    async fn list_vols(&self)                          -> IoResult<Vec<VolInfo>> { Err(ns("list_vols")) }
+    async fn delete_vol(&self, _v: &str, _f: bool)     -> IoResult<()>           { Err(ns("delete_vol")) }
+    async fn list_dir(&self, _v: &str, _d: &str, _c: usize) -> IoResult<Vec<String>> { Err(ns("list_dir")) }
+    async fn read_file_stream(&self, _v: &str, _p: &str, _o: u64, _l: u64) -> IoResult<Box<dyn ByteStream>> { Err(ns("read_file_stream")) }
+    async fn create_file_writer(&self, _v: &str, _p: &str, _s: u64)        -> IoResult<Box<dyn ByteSink>>   { Err(ns("create_file_writer")) }
+    async fn rename_file(&self, _: &str, _: &str, _: &str, _: &str)        -> IoResult<()> { Err(ns("rename_file")) }
+    async fn check_file(&self, _: &str, _: &str)                            -> IoResult<()> { Err(ns("check_file")) }
+    async fn delete(&self, _: &str, _: &str, _: bool)                       -> IoResult<()> { Err(ns("delete")) }
+    async fn delete_batch(&self, _: &str, _: &[&str], _: bool) -> IoResult<Vec<IoResult<()>>> { Err(ns("delete_batch")) }
+    async fn walk_dir(&self, _: &str, _: &str, _: bool, _: &str, _: Option<&str>, _: Option<usize>) -> IoResult<Vec<(String, FileInfo)>> { Err(ns("walk_dir")) }
+    async fn write_metadata(&self, _: &str, _: &str, _: &str, _: &FileInfo) -> IoResult<()> { Err(ns("write_metadata")) }
+    async fn read_version(&self, _: &str, _: &str, _: &str, _: Option<&str>, _: bool) -> IoResult<FileInfo> { Err(ns("read_version")) }
+    async fn update_metadata(&self, _: &str, _: &str, _: &FileInfo, _: &UpdateMetadataOpts) -> IoResult<()> { Err(ns("update_metadata")) }
+    async fn delete_version(&self, _: &str, _: &str, _: &FileInfo, _: bool, _: &DeleteOptions) -> IoResult<()> { Err(ns("delete_version")) }
+    async fn rename_data(&self, _: &str, _: &str, _: &FileInfo, _: &str, _: &str, _: &RenameOptions) -> IoResult<RenameDataResp> { Err(ns("rename_data")) }
+    async fn verify_file(&self, _: &str, _: &str, _: &FileInfo) -> IoResult<()> { Err(ns("verify_file")) }
+    async fn read_format(&self) -> IoResult<Option<FormatJson>> { Err(ns("read_format")) }
+    async fn write_format(&self, _: &FormatJson)             -> IoResult<()> { Err(ns("write_format")) }
+    async fn write_file(&self, _: &str, _: &str, _: Vec<u8>) -> IoResult<()> { Err(ns("write_file")) }
+    async fn read_file(&self, _: &str, _: &str)              -> IoResult<Option<Vec<u8>>> { Err(ns("read_file")) }
+    async fn make_dir_all(&self, _: &str, _: &str)           -> IoResult<()> { Err(ns("make_dir_all")) }
+}

--- a/crates/phenomenal_server/Cargo.toml
+++ b/crates/phenomenal_server/Cargo.toml
@@ -9,6 +9,9 @@ license.workspace      = true
 name = "phenomenald"
 path = "src/main.rs"
 
+[features]
+rdma = ["phenomenal_io/rdma"]
+
 [dependencies]
 phenomenal_io      = { path = "../phenomenal_io" }
 phenomenal_storage = { path = "../phenomenal_storage" }

--- a/crates/phenomenal_server/src/config.rs
+++ b/crates/phenomenal_server/src/config.rs
@@ -128,6 +128,40 @@ pub struct Config {
     /// bucket — sane for production. Operators rarely set this.
     #[serde(default)]
     pub memory_pool:     MemoryPoolToml,
+    #[serde(default)]
+    pub transport:       TransportMode,        // h2 (default) | rdma
+    #[serde(default)]
+    pub rdma:            Option<RdmaToml>,     // required when transport = rdma
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TransportMode {
+    #[default] H2,
+    Rdma,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RdmaToml {
+    pub self_node_id: u16,
+    pub dev_name:     String,
+    pub dc_key:       u64,
+    pub qos:          RdmaQosToml,
+    pub peers:        Vec<RdmaPeerToml>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+pub struct RdmaQosToml {
+    pub traffic_class: u8,
+    pub service_level: u8,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RdmaPeerToml {
+    pub node_id: u16,
+    pub gid:     [u8; 16],
+    pub dct_num: u32,
+    pub dc_key:  u64,
 }
 
 /// TOML-friendly mirror of `phenomenal_io::MemoryPoolConfig`. Defaults
@@ -310,10 +344,10 @@ impl Config {
         // never call `RemoteBackend`, so plaintext is fine there.
         match (cfg.nodes.len(), &cfg.rpc_tls) {
             (1, _) => {}
-            (_, None) => anyhow::bail!(
-                "rpc_tls is required for multi-node clusters: the inter-node \
-                 RPC plane is HTTP/2 over TLS only"
-            ),
+            // Plaintext multi-node is allowed (trusted private network):
+            // PeerClient falls back to h2c (http2_prior_knowledge) when
+            // rpc_tls is absent.
+            (_, None) => {}
             (_, Some(t)) => {
                 validate_tls_files(t, "rpc_tls")?;
                 if t.client_ca.is_none() {
@@ -329,6 +363,16 @@ impl Config {
             // its files so a typo in cert_path is caught at startup.
             if cfg.nodes.len() == 1 {
                 validate_tls_files(t, "rpc_tls")?;
+            }
+        }
+        if cfg.transport == TransportMode::Rdma && cfg.rdma.is_none() {
+            anyhow::bail!("transport = \"rdma\" requires an [rdma] config block");
+        }
+        if cfg.transport == TransportMode::Rdma {
+            if !cfg!(all(feature = "rdma", target_os = "linux")) {
+                anyhow::bail!(
+                    "transport = \"rdma\" requires the `rdma` cargo feature on a Linux build"
+                );
             }
         }
         Ok(cfg)

--- a/crates/phenomenal_server/src/main.rs
+++ b/crates/phenomenal_server/src/main.rs
@@ -34,6 +34,8 @@ mod config;
 mod s3;
 mod lock_server;
 mod rpc_server;
+#[cfg(all(feature = "rdma", target_os = "linux"))]
+mod rdma_server;
 mod tls_material;
 
 use std::path::PathBuf;
@@ -230,8 +232,8 @@ fn create_runtime() -> anyhow::Result<compio::runtime::Runtime> {
     let mut proactor = compio::driver::ProactorBuilder::new();
     proactor
         .capacity(4096) // iouring size
-        .coop_taskrun(true)
-        .taskrun_flag(true);
+        .coop_taskrun(false)
+        .taskrun_flag(false);
 
     #[cfg(not(target_os = "macos"))]
     proactor.thread_pool_limit(0);
@@ -310,6 +312,14 @@ async fn run_runtime(
     let local_lock_peer: Rc<dyn LockPeer> =
         Rc::new(LocalLockPeer::new(lock_server.clone()));
 
+    #[cfg(all(feature = "rdma", target_os = "linux"))]
+    let rdma_node: Option<std::sync::Arc<phenomenal_io::rdma::RdmaNode>> = match cfg.transport {
+        config::TransportMode::Rdma => Some(std::sync::Arc::new(
+            phenomenal_io::rdma::RdmaNode::start(build_rdma_config(cfg.rdma.as_ref().unwrap()))?
+        )),
+        config::TransportMode::H2 => None,
+    };
+
     for n in &cfg.nodes {
         if n.id == cfg.self_id {
             // Local node — register every local disk.
@@ -321,38 +331,42 @@ async fn run_runtime(
             }
             lock_peer_by_node.insert(n.id, local_lock_peer.clone());
         } else {
-            // Peer node — one shared `PeerClient`, then one
-            // `RemoteBackend` per disk on that peer. The `PeerClient`
-            // wraps a `cyper::Client`; its hyper-util pool keeps a
-            // single multiplexed h2 connection per (runtime, peer)
-            // pair, so concurrent disk RPCs ride h2 streams instead
-            // of fresh TCP dials.
-            //
-            // The cluster CA's leaf certs must include the peer's IP
-            // (or DNS name reachable via the cyper URL parser) in
-            // their SubjectAltName for verification to pass — same
-            // requirement the legacy raw-rustls path had.
-            //
-            // Multi-node clusters require `rpc_tls` (validated in
-            // `Config::from_toml`); the `expect` here exists only to
-            // turn a config-validation oversight into an immediate
-            // panic rather than silent plaintext fallback.
-            let connector = rpc_connector.clone()
-                .expect("multi-node cluster requires rpc_tls (config validation)");
-            let peer = Rc::new(PeerClient::new(n.rpc_addr, connector));
-            for disk_idx in 0..n.disk_count {
-                let rb = Rc::new(RemoteBackend::new(peer.clone(), disk_idx));
-                backends.insert(
-                    DiskAddr { node_id: n.id, disk_idx },
-                    rb as Rc<dyn StorageBackend>,
-                );
-            }
-            // Lock plane: any RemoteBackend on this peer talks to
-            // the same LockServer, so we only need one. Pick
-            // disk_idx=0; its disk_idx field is unused by the
-            // lock-plane RPCs (they don't carry disk_idx).
-            let lock_rb = Rc::new(RemoteBackend::new(peer, 0));
+            // `rpc_connector` is `Some` when rpc_tls is configured, `None`
+            // for plaintext h2c clusters. PeerClient handles both.
+            let peer = Rc::new(PeerClient::new(n.rpc_addr, rpc_connector.clone()));
+
+            let lock_rb = Rc::new(RemoteBackend::new(peer.clone(), 0));
             lock_peer_by_node.insert(n.id, lock_rb as Rc<dyn LockPeer>);
+
+            // Data plane backends: pick per transport.
+            match cfg.transport {
+                config::TransportMode::H2 => {
+                    for disk_idx in 0..n.disk_count {
+                        let rb = Rc::new(RemoteBackend::new(peer.clone(), disk_idx));
+                        backends.insert(
+                            DiskAddr { node_id: n.id, disk_idx },
+                            rb as Rc<dyn StorageBackend>,
+                        );
+                    }
+                }
+                #[cfg(all(feature = "rdma", target_os = "linux"))]
+                config::TransportMode::Rdma => {
+                    let node = rdma_node.as_ref().expect("rdma node built in rdma mode").clone();
+                    for disk_idx in 0..n.disk_count {
+                        let rb = Rc::new(phenomenal_io::rdma_backend::RdmaBackend::new(
+                            node.clone(), n.id, disk_idx,
+                        ));
+                        backends.insert(
+                            DiskAddr { node_id: n.id, disk_idx },
+                            rb as Rc<dyn StorageBackend>,
+                        );
+                    }
+                }
+                #[cfg(not(all(feature = "rdma", target_os = "linux")))]
+                config::TransportMode::Rdma => {
+                    anyhow::bail!("rdma transport selected but build lacks rdma feature");
+                }
+            }
         }
     }
 
@@ -387,6 +401,21 @@ async fn run_runtime(
             tracing::error!(runtime_id, "rpc serve error: {e:#}");
         }
     });
+
+    #[cfg(all(feature = "rdma", target_os = "linux"))]
+    let _rdma_task = match cfg.transport {
+        config::TransportMode::Rdma => {
+            let node   = rdma_node.as_ref().expect("rdma node built in rdma mode").clone();
+            let disks  = Rc::new(local_disks.clone());
+            let locks  = lock_server.clone();
+            Some(compio::runtime::spawn(async move {
+                if let Err(e) = rdma_server::serve(node, disks, locks).await {
+                    tracing::error!(runtime_id, "rdma serve error: {e:#}");
+                }
+            }))
+        }
+        config::TransportMode::H2 => None,
+    };
 
     let deployment_id: Uuid = if runtime_id == 0 {
         let mut local_b   : Vec<Rc<dyn StorageBackend>> = Vec::new();
@@ -464,4 +493,23 @@ async fn run_runtime(
     let _ = s3_task.await;
     let _ = rpc_task.await;
     Ok(())
+}
+
+#[cfg(all(feature = "rdma", target_os = "linux"))]
+fn build_rdma_config(t: &config::RdmaToml) -> phenomenal_io::rdma::RdmaConfig {
+    phenomenal_io::rdma::RdmaConfig {
+        self_node_id: t.self_node_id,
+        dev_name:     t.dev_name.clone(),
+        dc_key:       t.dc_key,
+        qos: phenomenal_io::rdma::RdmaQos {
+            traffic_class: t.qos.traffic_class,
+            service_level: t.qos.service_level,
+        },
+        peers: t.peers.iter().map(|p| phenomenal_io::rdma::PeerEndpoint {
+            node_id: p.node_id,
+            gid:     p.gid,
+            dct_num: p.dct_num,
+            dc_key:  p.dc_key,
+        }).collect(),
+    }
 }

--- a/crates/phenomenal_server/src/rdma_server.rs
+++ b/crates/phenomenal_server/src/rdma_server.rs
@@ -1,0 +1,81 @@
+#![cfg(all(feature = "rdma", target_os = "linux"))]
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+use futures::stream::StreamExt;
+use phenomenal_io::rdma::{BUF_SIZE, RdmaNode};
+use phenomenal_io::rdma_backend::{Envelope, ENVELOPE_MAGIC};
+use phenomenal_io::rpc::{decode, encode};
+use phenomenal_io::StorageBackend;
+
+use crate::lock_server::LockServer;
+use crate::rpc_server::dispatch;
+
+pub async fn serve(
+    node:  Arc<RdmaNode>,
+    disks: Rc<Vec<Rc<dyn StorageBackend>>>,
+    locks: Arc<LockServer>,
+) -> anyhow::Result<()> {
+    let mut rx = node.pump.take_recv_rx()
+        .ok_or_else(|| anyhow::anyhow!("rdma_server: pump recv_rx already taken"))?;
+    let mut buf = Vec::with_capacity(BUF_SIZE);
+    loop {
+        // Drain every envelope queued before parking again.
+        loop {
+            buf.clear();
+            if node.sock.attempt_singular_rcv(&mut buf).is_none() { break; }
+            handle(&node, &disks, &locks, &buf).await;
+        }
+        if rx.next().await.is_none() { return Ok(()); }
+    }
+}
+
+async fn handle(
+    node:  &Arc<RdmaNode>,
+    disks: &Rc<Vec<Rc<dyn StorageBackend>>>,
+    locks: &Arc<LockServer>,
+    bytes: &[u8],
+) {
+    let env: Envelope = match decode(bytes) {
+        Ok(e)  => e,
+        Err(e) => { tracing::warn!("rdma_server: decode envelope: {e}"); return; }
+    };
+    match env {
+        Envelope::Req { magic, from_node_id, request_id, payload } => {
+            if magic != ENVELOPE_MAGIC {
+                tracing::warn!("rdma_server: bad request magic {:#x}", magic);
+                return;
+            }
+            let sender = match node.peer(from_node_id) {
+                Some(p) => p.clone(),
+                None    => { tracing::warn!("rdma_server: unknown sender {from_node_id}"); return; }
+            };
+            let sender_ah = match node.ah_cache.get_or_create(&sender) {
+                Ok(ah) => ah,
+                Err(e) => { tracing::warn!("rdma_server: ah for {}: {e}", from_node_id); return; }
+            };
+            let resp = dispatch(disks, locks, payload).await;
+            let body = match encode(&Envelope::Rsp {
+                magic: ENVELOPE_MAGIC, request_id, payload: resp,
+            }) {
+                Ok(b)  => b,
+                Err(e) => { tracing::warn!("rdma_server: encode response: {e}"); return; }
+            };
+            if let Err(e) = node.sock.send(&body, sender_ah, sender.dct_num, sender.dc_key) {
+                tracing::warn!("rdma_server: send response: {e}");
+            }
+        }
+        Envelope::Rsp { magic, request_id, payload } => {
+            if magic != ENVELOPE_MAGIC {
+                tracing::warn!("rdma_server: bad response magic {:#x}", magic);
+                return;
+            }
+            if let Some(tx) = node.pending_responses.lock().unwrap().remove(&request_id) {
+                let _ = tx.send(payload);
+            } else {
+                tracing::warn!("rdma_server: unmatched response request_id {request_id}");
+            }
+        }
+    }
+}

--- a/crates/phenomenal_server/src/rpc_server.rs
+++ b/crates/phenomenal_server/src/rpc_server.rs
@@ -448,7 +448,7 @@ fn disk_at<'a>(
 /// One match arm per envelope-shaped `Request` variant. Streaming
 /// variants are handled by their dedicated routes (and rejected
 /// here as a wire-protocol bug).
-async fn dispatch(
+pub(crate) async fn dispatch(
     disks: &[Rc<dyn StorageBackend>],
     locks: &Arc<LockServer>,
     req:   Request,


### PR DESCRIPTION
 - Adds DC rdma for inter node RPC selectable per cluster via config.transport = "rdma".
 - Currently supports stat command, other commands will be supported in the future.
 - Supports credit based ring buffers used to manage congestion/concurrency of engine

    Stack:
       - IbDevice (open + GID/port resolution)
       - IbSocket (CQ, comp_channel, SRQ, DCT, DCI, send/recv slab rings)
       - AhCache  (per-peer ibv_ah)
       - CqPump   (compio task parking on comp_channel fd via PollOnce,
                drains ibv_poll_cq, dispatches via per-wr_id WrId tags,
                credit reconciliation via signaled-SEND + ACK imm)
       - RdmaNode (assembly + loopback peer patch)
       - RdmaBackend (StorageBackend impl that envelope-encodes Request,
                   sends via DCI, awaits oneshot keyed by request_id)
       - rdma_server::serve (dispatcher: drains recv queue, decodes envelopes,
                          routes Req -> rpc_server::dispatch, Rsp -> tx.send)

    Fabric support:
       - Both InfiniBand (link_layer=1) and RoCE v2