### PR TITLE
#24 [v0.1] Add RPC fallback for RDMA backend

### DIFF
--- a/crates/phenomenal_io/Cargo.toml
+++ b/crates/phenomenal_io/Cargo.toml
@@ -59,3 +59,7 @@ rdma = ["dep:rdma-mummy-sys", "dep:bindgen"]
 tempfile           = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow             = { workspace = true }
+
+[[example]]
+name              = "rdma_loopback"
+required-features = ["rdma"]

--- a/crates/phenomenal_io/examples/rdma_loopback.rs
+++ b/crates/phenomenal_io/examples/rdma_loopback.rs
@@ -1,393 +1,405 @@
-#![cfg(all(feature = "rdma", target_os = "linux"))]
-
-use std::rc::Rc;
-
-use anyhow::Context;
-use futures::stream::StreamExt;
-
-use phenomenal_io::rdma::{
-    PeerEndpoint, RdmaConfig, RdmaNode, RdmaQos, RawAddressHandle, BUF_SIZE,
-};
-use phenomenal_io::rdma_backend::{Envelope, RdmaBackend, ENVELOPE_MAGIC};
-use phenomenal_io::rpc::{decode, encode, RdmaRemoteBuf, Request, Response, WireError};
-use phenomenal_io::stream::ByteStream;
-use phenomenal_io::{IoError, LocalFsBackend, StorageBackend};
-
-const DEFAULT_RDMA_DEVICE:           &str = "mlx5_0";
-const DEFAULT_OBJECT_SIZE_BYTES:     usize = 1024 * 1024;
-const DEFAULT_ITERATION_COUNT:       usize = 1;
-const BULK_BUFFER_SIZE_BYTES:        usize = 4 * 1024 * 1024;
-const BULK_POOL_CAPACITY:            usize = 8;
-const LOOPBACK_VOLUME_NAME:          &str = "loopback-volume";
-const LOOPBACK_OBJECT_PATH:          &str = "loopback-object/data";
-const LOOPBACK_DISK_SUBDIRECTORY:    &str = "openlake-rdma-loopback";
-const DC_ACCESS_KEY:                 u64  = 0xdeadbeef_cafef00d;
-const SELF_NODE_ID:                  u16  = 0;
-const LOCAL_DISK_INDEX:              u16  = 0;
-const ENV_RDMA_DEVICE:               &str = "OPENLAKE_RDMA_DEVICE";
-const ENV_OBJECT_SIZE_BYTES:         &str = "OPENLAKE_OBJECT_SIZE_BYTES";
-const ENV_ITERATION_COUNT:           &str = "OPENLAKE_ITERATION_COUNT";
-
 fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
-
-    let runtime = compio::runtime::RuntimeBuilder::new().build()?;
-    runtime.block_on(async move {
-        if let Err(error) = run_loopback_probe().await {
-            eprintln!("rdma_loopback: FAILED: {error:#}");
-            std::process::exit(1);
-        }
-    });
-    Ok(())
-}
-
-async fn run_loopback_probe() -> anyhow::Result<()> {
-    let object_size_bytes: usize = std::env::var(ENV_OBJECT_SIZE_BYTES)
-        .ok()
-        .and_then(|value| value.parse().ok())
-        .unwrap_or(DEFAULT_OBJECT_SIZE_BYTES);
-    let iteration_count: usize = std::env::var(ENV_ITERATION_COUNT)
-        .ok()
-        .and_then(|value| value.parse().ok())
-        .unwrap_or(DEFAULT_ITERATION_COUNT);
-
-    let local_disk_root = std::env::temp_dir().join(LOOPBACK_DISK_SUBDIRECTORY);
-    let _ = std::fs::remove_dir_all(&local_disk_root);
-    std::fs::create_dir_all(&local_disk_root)?;
-
-    let local_storage_backend: Rc<dyn StorageBackend> =
-        Rc::new(LocalFsBackend::new(&local_disk_root)?);
-    local_storage_backend.make_vol(LOOPBACK_VOLUME_NAME).await?;
-    eprintln!(
-        "rdma_loopback: prepared local disk root at {}",
-        local_disk_root.display(),
-    );
-
-    let mut payload = vec![0u8; object_size_bytes];
-    for (index, byte) in payload.iter_mut().enumerate() {
-        *byte = (index.wrapping_mul(2654435761) & 0xFF) as u8;
-    }
-    local_storage_backend
-        .write_file(LOOPBACK_VOLUME_NAME, LOOPBACK_OBJECT_PATH, payload.clone())
-        .await
-        .context("write_file")?;
-    eprintln!(
-        "rdma_loopback: wrote object {}/{} ({} bytes)",
-        LOOPBACK_VOLUME_NAME, LOOPBACK_OBJECT_PATH, object_size_bytes,
-    );
-
-    let rdma_device = std::env::var(ENV_RDMA_DEVICE)
-        .unwrap_or_else(|_| DEFAULT_RDMA_DEVICE.to_string());
-
-    let rdma_node = Rc::new(
-        RdmaNode::start(RdmaConfig {
-            self_node_id:  SELF_NODE_ID,
-            dev_name:      rdma_device.clone(),
-            dc_key:        DC_ACCESS_KEY,
-            qos:           RdmaQos { traffic_class: 0, service_level: 0 },
-            peers: vec![PeerEndpoint {
-                node_id: SELF_NODE_ID,
-                gid:     [0u8; 16],
-                dct_num: 0,
-                dc_key:  0,
-            }],
-            bulk_buf_size: BULK_BUFFER_SIZE_BYTES,
-            bulk_pool_cap: BULK_POOL_CAPACITY,
-        })
-        .context("RdmaNode::start")?,
-    );
-    eprintln!(
-        "rdma_loopback: RdmaNode started on device {} (self_dct_num={}, gid={:02x?})",
-        rdma_device,
-        rdma_node.sock.self_dct_identifier(),
-        rdma_node.dev.gid_bytes(),
-    );
-
-    let local_disks: Rc<Vec<Rc<dyn StorageBackend>>> =
-        Rc::new(vec![local_storage_backend.clone()]);
-
-    let dispatcher_task = compio::runtime::spawn({
-        let rdma_node   = rdma_node.clone();
-        let local_disks = local_disks.clone();
-        async move {
-            if let Err(error) = run_dispatcher_loop(rdma_node, local_disks).await {
-                eprintln!("rdma_loopback: dispatcher exited with error: {error:#}");
-            }
-        }
-    });
-
-    let rdma_backend = RdmaBackend::new(
-        rdma_node.clone(),
-        SELF_NODE_ID,
-        LOCAL_DISK_INDEX,
-    );
-
-    eprintln!("rdma_loopback: [1/2] StatVol over RDMA loopback ...");
-    let volume_info = rdma_backend.stat_vol(LOOPBACK_VOLUME_NAME).await?;
-    eprintln!("rdma_loopback:        StatVol succeeded: {volume_info:?}");
-
-    eprintln!(
-        "rdma_loopback: [2/2] ReadFileChunk over RDMA loopback ({} iterations, {} bytes each) ...",
-        iteration_count, object_size_bytes,
-    );
-
+    #[cfg(all(feature = "rdma", target_os = "linux"))]
+    { linux::entry() }
+    #[cfg(not(all(feature = "rdma", target_os = "linux")))]
     {
-        let mut stream = rdma_backend
-            .read_file_stream(LOOPBACK_VOLUME_NAME, LOOPBACK_OBJECT_PATH, 0, object_size_bytes as u64)
-            .await?;
-        let mut received: Vec<u8> = Vec::with_capacity(object_size_bytes);
-        loop {
-            let chunk = stream.read().await?;
-            if chunk.is_empty() { break; }
-            received.extend_from_slice(&chunk[..]);
-        }
-        if received != payload {
-            let bad_offset = received
-                .iter()
-                .zip(payload.iter())
-                .position(|(actual, expected)| actual != expected)
-                .unwrap_or(0);
-            anyhow::bail!("content mismatch at offset {bad_offset}");
-        }
-    }
-
-    let started_at = std::time::Instant::now();
-    let mut bytes_transferred_total: u64 = 0;
-    for _ in 0..iteration_count {
-        let mut stream = rdma_backend
-            .read_file_stream(LOOPBACK_VOLUME_NAME, LOOPBACK_OBJECT_PATH, 0, object_size_bytes as u64)
-            .await?;
-        loop {
-            let chunk = stream.read().await?;
-            if chunk.is_empty() { break; }
-            bytes_transferred_total += chunk.len() as u64;
-        }
-    }
-    let elapsed_seconds   = started_at.elapsed().as_secs_f64();
-    let bytes_per_second  = (bytes_transferred_total as f64) / elapsed_seconds;
-    let gibibytes_per_sec = bytes_per_second / (1024.0 * 1024.0 * 1024.0);
-    let gigabits_per_sec  = (bytes_per_second * 8.0) / 1.0e9;
-    eprintln!(
-        "rdma_loopback:        ReadFileChunk succeeded: {} iterations, {} bytes in {:.3}s",
-        iteration_count, bytes_transferred_total, elapsed_seconds,
-    );
-    eprintln!(
-        "rdma_loopback:        throughput: {:.3} GiB/s ({:.2} Gbps wire)",
-        gibibytes_per_sec, gigabits_per_sec,
-    );
-
-    drop(dispatcher_task);
-    Ok(())
-}
-
-async fn run_dispatcher_loop(
-    rdma_node:   Rc<RdmaNode>,
-    local_disks: Rc<Vec<Rc<dyn StorageBackend>>>,
-) -> anyhow::Result<()> {
-    let mut completion_signal = rdma_node
-        .pump
-        .take_recv_rx()
-        .ok_or_else(|| anyhow::anyhow!("recv_rx already taken from CqPump"))?;
-    let mut envelope_buffer = Vec::with_capacity(BUF_SIZE);
-
-    loop {
-        loop {
-            envelope_buffer.clear();
-            if rdma_node.sock.attempt_singular_rcv(&mut envelope_buffer).is_none() {
-                break;
-            }
-            handle_received_envelope(&rdma_node, &local_disks, &envelope_buffer).await;
-        }
-        if completion_signal.next().await.is_none() {
-            return Ok(());
-        }
+        eprintln!("rdma_loopback requires Linux with --features rdma; not building target body on this platform");
+        Ok(())
     }
 }
 
-async fn handle_received_envelope(
-    rdma_node:     &Rc<RdmaNode>,
-    local_disks:   &Rc<Vec<Rc<dyn StorageBackend>>>,
-    encoded_bytes: &[u8],
-) {
-    let envelope: Envelope = match decode(encoded_bytes) {
-        Ok(envelope) => envelope,
-        Err(error)   => {
-            eprintln!("rdma_loopback: failed to decode envelope: {error}");
-            return;
-        }
+#[cfg(all(feature = "rdma", target_os = "linux"))]
+mod linux {
+    use std::rc::Rc;
+
+    use anyhow::Context;
+    use futures::stream::StreamExt;
+
+    use phenomenal_io::rdma::{
+        PeerEndpoint, RdmaConfig, RdmaNode, RdmaQos, RawAddressHandle, BUF_SIZE,
     };
+    use phenomenal_io::rdma_backend::{Envelope, RdmaBackend, ENVELOPE_MAGIC};
+    use phenomenal_io::rpc::{decode, encode, RdmaRemoteBuf, Request, Response, WireError};
+    use phenomenal_io::stream::ByteStream;
+    use phenomenal_io::{IoError, LocalFsBackend, StorageBackend};
 
-    match envelope {
-        Envelope::Req { magic, from_node_id, request_id, payload } => {
-            if magic != ENVELOPE_MAGIC {
-                eprintln!("rdma_loopback: rejected request envelope with bad magic {magic:#x}");
+    const DEFAULT_RDMA_DEVICE:           &str = "mlx5_0";
+    const DEFAULT_OBJECT_SIZE_BYTES:     usize = 1024 * 1024;
+    const DEFAULT_ITERATION_COUNT:       usize = 1;
+    const BULK_BUFFER_SIZE_BYTES:        usize = 4 * 1024 * 1024;
+    const BULK_POOL_CAPACITY:            usize = 8;
+    const LOOPBACK_VOLUME_NAME:          &str = "loopback-volume";
+    const LOOPBACK_OBJECT_PATH:          &str = "loopback-object/data";
+    const LOOPBACK_DISK_SUBDIRECTORY:    &str = "openlake-rdma-loopback";
+    const DC_ACCESS_KEY:                 u64  = 0xdeadbeef_cafef00d;
+    const SELF_NODE_ID:                  u16  = 0;
+    const LOCAL_DISK_INDEX:              u16  = 0;
+    const ENV_RDMA_DEVICE:               &str = "OPENLAKE_RDMA_DEVICE";
+    const ENV_OBJECT_SIZE_BYTES:         &str = "OPENLAKE_OBJECT_SIZE_BYTES";
+    const ENV_ITERATION_COUNT:           &str = "OPENLAKE_ITERATION_COUNT";
+
+    pub fn entry() -> anyhow::Result<()> {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .init();
+
+        let runtime = compio::runtime::RuntimeBuilder::new().build()?;
+        runtime.block_on(async move {
+            if let Err(error) = run_loopback_probe().await {
+                eprintln!("rdma_loopback: FAILED: {error:#}");
+                std::process::exit(1);
+            }
+        });
+        Ok(())
+    }
+
+    async fn run_loopback_probe() -> anyhow::Result<()> {
+        let object_size_bytes: usize = std::env::var(ENV_OBJECT_SIZE_BYTES)
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(DEFAULT_OBJECT_SIZE_BYTES);
+        let iteration_count: usize = std::env::var(ENV_ITERATION_COUNT)
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(DEFAULT_ITERATION_COUNT);
+
+        let local_disk_root = std::env::temp_dir().join(LOOPBACK_DISK_SUBDIRECTORY);
+        let _ = std::fs::remove_dir_all(&local_disk_root);
+        std::fs::create_dir_all(&local_disk_root)?;
+
+        let local_storage_backend: Rc<dyn StorageBackend> =
+            Rc::new(LocalFsBackend::new(&local_disk_root)?);
+        local_storage_backend.make_vol(LOOPBACK_VOLUME_NAME).await?;
+        eprintln!(
+            "rdma_loopback: prepared local disk root at {}",
+            local_disk_root.display(),
+        );
+
+        let mut payload = vec![0u8; object_size_bytes];
+        for (index, byte) in payload.iter_mut().enumerate() {
+            *byte = (index.wrapping_mul(2654435761) & 0xFF) as u8;
+        }
+        local_storage_backend
+            .write_file(LOOPBACK_VOLUME_NAME, LOOPBACK_OBJECT_PATH, payload.clone())
+            .await
+            .context("write_file")?;
+        eprintln!(
+            "rdma_loopback: wrote object {}/{} ({} bytes)",
+            LOOPBACK_VOLUME_NAME, LOOPBACK_OBJECT_PATH, object_size_bytes,
+        );
+
+        let rdma_device = std::env::var(ENV_RDMA_DEVICE)
+            .unwrap_or_else(|_| DEFAULT_RDMA_DEVICE.to_string());
+
+        let rdma_node = Rc::new(
+            RdmaNode::start(RdmaConfig {
+                self_node_id:  SELF_NODE_ID,
+                dev_name:      rdma_device.clone(),
+                dc_key:        DC_ACCESS_KEY,
+                qos:           RdmaQos { traffic_class: 0, service_level: 0 },
+                peers: vec![PeerEndpoint {
+                    node_id: SELF_NODE_ID,
+                    gid:     [0u8; 16],
+                    dct_num: 0,
+                    dc_key:  0,
+                }],
+                bulk_buf_size: BULK_BUFFER_SIZE_BYTES,
+                bulk_pool_cap: BULK_POOL_CAPACITY,
+            })
+            .context("RdmaNode::start")?,
+        );
+        eprintln!(
+            "rdma_loopback: RdmaNode started on device {} (self_dct_num={}, gid={:02x?})",
+            rdma_device,
+            rdma_node.sock.self_dct_identifier(),
+            rdma_node.dev.gid_bytes(),
+        );
+
+        let local_disks: Rc<Vec<Rc<dyn StorageBackend>>> =
+            Rc::new(vec![local_storage_backend.clone()]);
+
+        let dispatcher_task = compio::runtime::spawn({
+            let rdma_node   = rdma_node.clone();
+            let local_disks = local_disks.clone();
+            async move {
+                if let Err(error) = run_dispatcher_loop(rdma_node, local_disks).await {
+                    eprintln!("rdma_loopback: dispatcher exited with error: {error:#}");
+                }
+            }
+        });
+
+        let rdma_backend = RdmaBackend::new(
+            rdma_node.clone(),
+            SELF_NODE_ID,
+            LOCAL_DISK_INDEX,
+            local_storage_backend.clone(),
+        );
+
+        eprintln!("rdma_loopback: [1/2] StatVol over RDMA loopback ...");
+        let volume_info = rdma_backend.stat_vol(LOOPBACK_VOLUME_NAME).await?;
+        eprintln!("rdma_loopback:        StatVol succeeded: {volume_info:?}");
+
+        eprintln!(
+            "rdma_loopback: [2/2] ReadFileChunk over RDMA loopback ({} iterations, {} bytes each) ...",
+            iteration_count, object_size_bytes,
+        );
+
+        {
+            let mut stream = rdma_backend
+                .read_file_stream(LOOPBACK_VOLUME_NAME, LOOPBACK_OBJECT_PATH, 0, object_size_bytes as u64)
+                .await?;
+            let mut received: Vec<u8> = Vec::with_capacity(object_size_bytes);
+            loop {
+                let chunk = stream.read().await?;
+                if chunk.is_empty() { break; }
+                received.extend_from_slice(&chunk[..]);
+            }
+            if received != payload {
+                let bad_offset = received
+                    .iter()
+                    .zip(payload.iter())
+                    .position(|(actual, expected)| actual != expected)
+                    .unwrap_or(0);
+                anyhow::bail!("content mismatch at offset {bad_offset}");
+            }
+        }
+
+        let started_at = std::time::Instant::now();
+        let mut bytes_transferred_total: u64 = 0;
+        for _ in 0..iteration_count {
+            let mut stream = rdma_backend
+                .read_file_stream(LOOPBACK_VOLUME_NAME, LOOPBACK_OBJECT_PATH, 0, object_size_bytes as u64)
+                .await?;
+            loop {
+                let chunk = stream.read().await?;
+                if chunk.is_empty() { break; }
+                bytes_transferred_total += chunk.len() as u64;
+            }
+        }
+        let elapsed_seconds   = started_at.elapsed().as_secs_f64();
+        let bytes_per_second  = (bytes_transferred_total as f64) / elapsed_seconds;
+        let gibibytes_per_sec = bytes_per_second / (1024.0 * 1024.0 * 1024.0);
+        let gigabits_per_sec  = (bytes_per_second * 8.0) / 1.0e9;
+        eprintln!(
+            "rdma_loopback:        ReadFileChunk succeeded: {} iterations, {} bytes in {:.3}s",
+            iteration_count, bytes_transferred_total, elapsed_seconds,
+        );
+        eprintln!(
+            "rdma_loopback:        throughput: {:.3} GiB/s ({:.2} Gbps wire)",
+            gibibytes_per_sec, gigabits_per_sec,
+        );
+
+        drop(dispatcher_task);
+        Ok(())
+    }
+
+    async fn run_dispatcher_loop(
+        rdma_node:   Rc<RdmaNode>,
+        local_disks: Rc<Vec<Rc<dyn StorageBackend>>>,
+    ) -> anyhow::Result<()> {
+        let mut completion_signal = rdma_node
+            .pump
+            .take_recv_rx()
+            .ok_or_else(|| anyhow::anyhow!("recv_rx already taken from CqPump"))?;
+        let mut envelope_buffer = Vec::with_capacity(BUF_SIZE);
+
+        loop {
+            loop {
+                envelope_buffer.clear();
+                if rdma_node.sock.attempt_singular_rcv(&mut envelope_buffer).is_none() {
+                    break;
+                }
+                handle_received_envelope(&rdma_node, &local_disks, &envelope_buffer).await;
+            }
+            if completion_signal.next().await.is_none() {
+                return Ok(());
+            }
+        }
+    }
+
+    async fn handle_received_envelope(
+        rdma_node:     &Rc<RdmaNode>,
+        local_disks:   &Rc<Vec<Rc<dyn StorageBackend>>>,
+        encoded_bytes: &[u8],
+    ) {
+        let envelope: Envelope = match decode(encoded_bytes) {
+            Ok(envelope) => envelope,
+            Err(error)   => {
+                eprintln!("rdma_loopback: failed to decode envelope: {error}");
                 return;
             }
-            let peer_endpoint = match rdma_node.peer(from_node_id) {
-                Some(peer) => peer.clone(),
-                None => {
-                    eprintln!("rdma_loopback: unknown sender node_id {from_node_id}");
-                    return;
-                }
-            };
-            let address_handle = match rdma_node.ah_cache.get_or_create(&peer_endpoint) {
-                Ok(handle) => handle,
-                Err(error) => {
-                    eprintln!(
-                        "rdma_loopback: failed to resolve address handle for peer {from_node_id}: {error}",
-                    );
-                    return;
-                }
-            };
-
-            let response = match payload {
-                Request::StatVol { disk_idx, volume } => {
-                    match local_disks.get(disk_idx as usize) {
-                        Some(disk) => match disk.stat_vol(&volume).await {
-                            Ok(info)   => Response::Vol(info),
-                            Err(error) => Response::Err(error.into()),
-                        },
-                        None => Response::Err(WireError::from(IoError::Io(
-                            std::io::Error::other(format!("disk_idx {disk_idx} out of range")),
-                        ))),
-                    }
-                }
-                Request::ReadFileChunk { disk_idx, volume, path, offset, length, target } => {
-                    handle_read_file_chunk(
-                        rdma_node,
-                        local_disks,
-                        address_handle,
-                        peer_endpoint.dct_num,
-                        peer_endpoint.dc_key,
-                        disk_idx,
-                        volume,
-                        path,
-                        offset,
-                        length,
-                        target,
-                    )
-                    .await
-                }
-                other => {
-                    eprintln!(
-                        "rdma_loopback: dispatcher does not support request variant {other:?}",
-                    );
-                    return;
-                }
-            };
-
-            let encoded_response = match encode(&Envelope::Rsp {
-                magic: ENVELOPE_MAGIC,
-                request_id,
-                payload: response,
-            }) {
-                Ok(encoded) => encoded,
-                Err(error)  => {
-                    eprintln!("rdma_loopback: failed to encode response: {error}");
-                    return;
-                }
-            };
-
-            if let Err(error) = rdma_node.sock.send(
-                &encoded_response,
-                address_handle,
-                peer_endpoint.dct_num,
-                peer_endpoint.dc_key,
-            ) {
-                eprintln!("rdma_loopback: failed to send response: {error}");
-            }
-        }
-        Envelope::Rsp { magic, request_id, payload } => {
-            if magic != ENVELOPE_MAGIC {
-                eprintln!("rdma_loopback: rejected response envelope with bad magic {magic:#x}");
-                return;
-            }
-            if let Some(sender) = rdma_node
-                .pending_responses
-                .borrow_mut()
-                .remove(&request_id)
-            {
-                let _ = sender.send(payload);
-            } else {
-                eprintln!(
-                    "rdma_loopback: received response for unknown request_id {request_id}",
-                );
-            }
-        }
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn handle_read_file_chunk(
-    rdma_node:     &Rc<RdmaNode>,
-    local_disks:   &Rc<Vec<Rc<dyn StorageBackend>>>,
-    sender_ah:     RawAddressHandle,
-    peer_dct_num:  u32,
-    peer_dc_key:   u64,
-    disk_idx:      u16,
-    volume:        String,
-    path:          String,
-    offset:        u64,
-    length:        u32,
-    target:        RdmaRemoteBuf,
-) -> Response {
-    let server_buffer_size = rdma_node.bulk_pool.buf_size();
-    if length as usize > server_buffer_size {
-        return Response::Err(WireError::Other(format!(
-            "read_file_chunk length {length} exceeds server bulk_buf_size {server_buffer_size}",
-        )));
-    }
-    if length > target.len {
-        return Response::Err(WireError::Other(format!(
-            "read_file_chunk length {length} exceeds client target.len {}",
-            target.len,
-        )));
-    }
-
-    let disk = match local_disks.get(disk_idx as usize) {
-        Some(disk) => disk.clone(),
-        None => {
-            return Response::Err(WireError::from(IoError::Io(std::io::Error::other(
-                format!("disk_idx {disk_idx} out of range"),
-            ))));
-        }
-    };
-
-    let mut bounce_buffer = match rdma_node.bulk_pool.acquire().await {
-        Ok(buffer) => buffer,
-        Err(error) => return Response::Err(IoError::Io(error).into()),
-    };
-
-    let bytes_filled = {
-        let mut stream = match disk.read_file_stream(&volume, &path, offset, length as u64).await {
-            Ok(stream) => stream,
-            Err(error) => return Response::Err(error.into()),
         };
-        let destination_slice = &mut bounce_buffer.as_slice_mut()[..length as usize];
-        match stream.read_buffer(destination_slice).await {
-            Ok(count)  => count,
-            Err(error) => return Response::Err(error.into()),
+
+        match envelope {
+            Envelope::Req { magic, from_node_id, request_id, payload } => {
+                if magic != ENVELOPE_MAGIC {
+                    eprintln!("rdma_loopback: rejected request envelope with bad magic {magic:#x}");
+                    return;
+                }
+                let peer_endpoint = match rdma_node.peer(from_node_id) {
+                    Some(peer) => peer.clone(),
+                    None => {
+                        eprintln!("rdma_loopback: unknown sender node_id {from_node_id}");
+                        return;
+                    }
+                };
+                let address_handle = match rdma_node.ah_cache.get_or_create(&peer_endpoint) {
+                    Ok(handle) => handle,
+                    Err(error) => {
+                        eprintln!(
+                            "rdma_loopback: failed to resolve address handle for peer {from_node_id}: {error}",
+                        );
+                        return;
+                    }
+                };
+
+                let response = match payload {
+                    Request::StatVol { disk_idx, volume } => {
+                        match local_disks.get(disk_idx as usize) {
+                            Some(disk) => match disk.stat_vol(&volume).await {
+                                Ok(info)   => Response::Vol(info),
+                                Err(error) => Response::Err(error.into()),
+                            },
+                            None => Response::Err(WireError::from(IoError::Io(
+                                std::io::Error::other(format!("disk_idx {disk_idx} out of range")),
+                            ))),
+                        }
+                    }
+                    Request::ReadFileChunk { disk_idx, volume, path, offset, length, target } => {
+                        handle_read_file_chunk(
+                            rdma_node,
+                            local_disks,
+                            address_handle,
+                            peer_endpoint.dct_num,
+                            peer_endpoint.dc_key,
+                            disk_idx,
+                            volume,
+                            path,
+                            offset,
+                            length,
+                            target,
+                        )
+                        .await
+                    }
+                    other => {
+                        eprintln!(
+                            "rdma_loopback: dispatcher does not support request variant {other:?}",
+                        );
+                        return;
+                    }
+                };
+
+                let encoded_response = match encode(&Envelope::Rsp {
+                    magic: ENVELOPE_MAGIC,
+                    request_id,
+                    payload: response,
+                }) {
+                    Ok(encoded) => encoded,
+                    Err(error)  => {
+                        eprintln!("rdma_loopback: failed to encode response: {error}");
+                        return;
+                    }
+                };
+
+                if let Err(error) = rdma_node.sock.send(
+                    &encoded_response,
+                    address_handle,
+                    peer_endpoint.dct_num,
+                    peer_endpoint.dc_key,
+                ) {
+                    eprintln!("rdma_loopback: failed to send response: {error}");
+                }
+            }
+            Envelope::Rsp { magic, request_id, payload } => {
+                if magic != ENVELOPE_MAGIC {
+                    eprintln!("rdma_loopback: rejected response envelope with bad magic {magic:#x}");
+                    return;
+                }
+                if let Some(sender) = rdma_node
+                    .pending_responses
+                    .borrow_mut()
+                    .remove(&request_id)
+                {
+                    let _ = sender.send(payload);
+                } else {
+                    eprintln!(
+                        "rdma_loopback: received response for unknown request_id {request_id}",
+                    );
+                }
+            }
         }
-    };
-
-    if bytes_filled == 0 {
-        return Response::ChunkReady { bytes_written: 0 };
     }
 
-    if let Err(error) = rdma_node.sock.rdma_write(
-        bounce_buffer.addr(),
-        bytes_filled as u32,
-        bounce_buffer.lkey(),
-        target.addr,
-        target.rkey,
-        sender_ah,
-        peer_dct_num,
-        peer_dc_key,
-    ).await {
-        return Response::Err(IoError::Io(error).into());
-    }
+    #[allow(clippy::too_many_arguments)]
+    async fn handle_read_file_chunk(
+        rdma_node:     &Rc<RdmaNode>,
+        local_disks:   &Rc<Vec<Rc<dyn StorageBackend>>>,
+        sender_ah:     RawAddressHandle,
+        peer_dct_num:  u32,
+        peer_dc_key:   u64,
+        disk_idx:      u16,
+        volume:        String,
+        path:          String,
+        offset:        u64,
+        length:        u32,
+        target:        RdmaRemoteBuf,
+    ) -> Response {
+        let server_buffer_size = rdma_node.bulk_pool.buf_size();
+        if length as usize > server_buffer_size {
+            return Response::Err(WireError::Other(format!(
+                "read_file_chunk length {length} exceeds server bulk_buf_size {server_buffer_size}",
+            )));
+        }
+        if length > target.len {
+            return Response::Err(WireError::Other(format!(
+                "read_file_chunk length {length} exceeds client target.len {}",
+                target.len,
+            )));
+        }
 
-    Response::ChunkReady { bytes_written: bytes_filled as u32 }
+        let disk = match local_disks.get(disk_idx as usize) {
+            Some(disk) => disk.clone(),
+            None => {
+                return Response::Err(WireError::from(IoError::Io(std::io::Error::other(
+                    format!("disk_idx {disk_idx} out of range"),
+                ))));
+            }
+        };
+
+        let mut bounce_buffer = match rdma_node.bulk_pool.acquire().await {
+            Ok(buffer) => buffer,
+            Err(error) => return Response::Err(IoError::Io(error).into()),
+        };
+
+        let bytes_filled = {
+            let mut stream = match disk.read_file_stream(&volume, &path, offset, length as u64).await {
+                Ok(stream) => stream,
+                Err(error) => return Response::Err(error.into()),
+            };
+            let destination_slice = &mut bounce_buffer.as_slice_mut()[..length as usize];
+            match stream.read_buffer(destination_slice).await {
+                Ok(count)  => count,
+                Err(error) => return Response::Err(error.into()),
+            }
+        };
+
+        if bytes_filled == 0 {
+            return Response::ChunkReady { bytes_written: 0 };
+        }
+
+        if let Err(error) = rdma_node.sock.rdma_write(
+            bounce_buffer.addr(),
+            bytes_filled as u32,
+            bounce_buffer.lkey(),
+            target.addr,
+            target.rkey,
+            sender_ah,
+            peer_dct_num,
+            peer_dc_key,
+        ).await {
+            return Response::Err(IoError::Io(error).into());
+        }
+
+        Response::ChunkReady { bytes_written: bytes_filled as u32 }
+    }
 }

--- a/crates/phenomenal_io/src/rdma_backend.rs
+++ b/crates/phenomenal_io/src/rdma_backend.rs
@@ -29,11 +29,18 @@ pub struct RdmaBackend {
     node:     Rc<RdmaNode>,
     peer_id:  u16,
     disk_idx: u16,
+    rpc_backend: Rc<dyn StorageBackend>,
 }
 
 impl RdmaBackend {
-    pub fn new(node: Rc<RdmaNode>, peer_id: u16, disk_idx: u16) -> Self {
-        Self { node, peer_id, disk_idx }
+    /// Temporary: `rpc_backend` is the H2 fallback for ops the RDMA endpoint
+    /// does not yet implement (currently everything except `stat_vol` and
+    /// `read_file_stream`). Remove this parameter and the coupling once the
+    /// RDMA backend implements every `StorageBackend` op natively.
+    pub fn new(
+        node: Rc<RdmaNode>, peer_id: u16, disk_idx: u16, rpc_backend: Rc<dyn StorageBackend>,
+    ) -> Self {
+        Self { node, peer_id, disk_idx, rpc_backend }
     }
 
     async fn unary(&self, payload: Request) -> IoResult<Response> {
@@ -139,58 +146,72 @@ impl RdmaBackend {
     }
 }
 
-fn ns(op: &'static str) -> IoError {
-    IoError::Io(io::Error::other(format!("rdma backend: {op} not yet implemented")))
+macro_rules! rdma_backend_storage_impl {
+    (
+        ib { $($ib:item)* }
+        via_rpc { $( async fn $name:ident ( &self $(, $arg:ident : $aty:ty )* ) -> $ret:ty ; )* }
+    ) => {
+        #[async_trait(?Send)]
+        impl StorageBackend for RdmaBackend {
+            fn label(&self) -> String { format!("rdma:n{}d{}", self.peer_id, self.disk_idx) }
+            $($ib)*
+            $(
+                async fn $name(&self $(, $arg: $aty)*) -> $ret {
+                    self.rpc_backend.$name($($arg),*).await
+                }
+            )*
+        }
+    };
 }
 
-#[async_trait(?Send)]
-impl StorageBackend for RdmaBackend {
-    fn label(&self) -> String { format!("rdma:n{}d{}", self.peer_id, self.disk_idx) }
+rdma_backend_storage_impl! {
+    ib {
+        async fn stat_vol(&self, volume: &str) -> IoResult<VolInfo> {
+            match self.unary(Request::StatVol { disk_idx: self.disk_idx, volume: volume.into() }).await? {
+                Response::Vol(v) => Ok(v),
+                Response::Err(e) => Err(IoError::from(e)),
+                other            => Err(IoError::Decode(format!("expected Vol, got {other:?}"))),
+            }
+        }
 
-    async fn stat_vol(&self, volume: &str) -> IoResult<VolInfo> {
-        match self.unary(Request::StatVol { disk_idx: self.disk_idx, volume: volume.into() }).await? {
-            Response::Vol(v) => Ok(v),
-            Response::Err(e) => Err(IoError::from(e)),
-            other            => Err(IoError::Decode(format!("expected Vol, got {other:?}"))),
+        async fn read_file_stream(
+            &self, volume: &str, path: &str, offset: u64, length: u64,
+        ) -> IoResult<Box<dyn ByteStream>> {
+            let chunk_size = self.node.bulk_pool.buf_size() as u32;
+            Ok(Box::new(RdmaReadStream {
+                backend:    self.clone(),
+                volume:     volume.into(),
+                path:       path.into(),
+                offset,
+                remaining:  length,
+                chunk_size,
+            }))
         }
     }
-
-    async fn read_file_stream(
-        &self, volume: &str, path: &str, offset: u64, length: u64,
-    ) -> IoResult<Box<dyn ByteStream>> {
-        let chunk_size = self.node.bulk_pool.buf_size() as u32;
-        Ok(Box::new(RdmaReadStream {
-            backend:    self.clone(),
-            volume:     volume.into(),
-            path:       path.into(),
-            offset,
-            remaining:  length,
-            chunk_size,
-        }))
+    via_rpc {
+        async fn disk_info(&self) -> IoResult<DiskInfo>;
+        async fn make_vol(&self, volume: &str) -> IoResult<()>;
+        async fn list_vols(&self) -> IoResult<Vec<VolInfo>>;
+        async fn delete_vol(&self, volume: &str, force: bool) -> IoResult<()>;
+        async fn list_dir(&self, volume: &str, dir: &str, count: usize) -> IoResult<Vec<String>>;
+        async fn create_file_writer(&self, volume: &str, path: &str, size: u64) -> IoResult<Box<dyn ByteSink>>;
+        async fn rename_file(&self, src_volume: &str, src_path: &str, dst_volume: &str, dst_path: &str) -> IoResult<()>;
+        async fn check_file(&self, volume: &str, path: &str) -> IoResult<()>;
+        async fn delete(&self, volume: &str, path: &str, recursive: bool) -> IoResult<()>;
+        async fn delete_batch(&self, volume: &str, paths: &[&str], recursive: bool) -> IoResult<Vec<IoResult<()>>>;
+        async fn walk_dir(&self, volume: &str, base_dir: &str, recursive: bool, prefix: &str, start_after: Option<&str>, max_keys: Option<usize>) -> IoResult<Vec<(String, FileInfo)>>;
+        async fn write_metadata(&self, orig_volume: &str, volume: &str, path: &str, fi: &FileInfo) -> IoResult<()>;
+        async fn read_version(&self, orig_volume: &str, volume: &str, path: &str, version_id: Option<&str>, read_data: bool) -> IoResult<FileInfo>;
+        async fn update_metadata(&self, volume: &str, path: &str, fi: &FileInfo, opts: &UpdateMetadataOpts) -> IoResult<()>;
+        async fn delete_version(&self, volume: &str, path: &str, fi: &FileInfo, force_del_marker: bool, opts: &DeleteOptions) -> IoResult<()>;
+        async fn rename_data(&self, src_volume: &str, src_path: &str, fi: &FileInfo, dst_volume: &str, dst_path: &str, opts: &RenameOptions) -> IoResult<RenameDataResp>;
+        async fn verify_file(&self, volume: &str, path: &str, fi: &FileInfo) -> IoResult<()>;
+        async fn read_format(&self) -> IoResult<Option<FormatJson>>;
+        async fn write_format(&self, fmt: &FormatJson) -> IoResult<()>;
+        async fn write_file(&self, volume: &str, path: &str, bytes: Vec<u8>) -> IoResult<()>;
+        async fn read_file(&self, volume: &str, path: &str) -> IoResult<Option<Vec<u8>>>;
+        async fn make_dir_all(&self, volume: &str, path: &str) -> IoResult<()>;
     }
-
-    async fn disk_info(&self)                          -> IoResult<DiskInfo>     { Err(ns("disk_info")) }
-    async fn make_vol(&self, _v: &str)                 -> IoResult<()>           { Err(ns("make_vol")) }
-    async fn list_vols(&self)                          -> IoResult<Vec<VolInfo>> { Err(ns("list_vols")) }
-    async fn delete_vol(&self, _v: &str, _f: bool)     -> IoResult<()>           { Err(ns("delete_vol")) }
-    async fn list_dir(&self, _v: &str, _d: &str, _c: usize) -> IoResult<Vec<String>> { Err(ns("list_dir")) }
-    async fn create_file_writer(&self, _v: &str, _p: &str, _s: u64)        -> IoResult<Box<dyn ByteSink>>   { Err(ns("create_file_writer")) }
-    async fn rename_file(&self, _: &str, _: &str, _: &str, _: &str)        -> IoResult<()> { Err(ns("rename_file")) }
-    async fn check_file(&self, _: &str, _: &str)                            -> IoResult<()> { Err(ns("check_file")) }
-    async fn delete(&self, _: &str, _: &str, _: bool)                       -> IoResult<()> { Err(ns("delete")) }
-    async fn delete_batch(&self, _: &str, _: &[&str], _: bool) -> IoResult<Vec<IoResult<()>>> { Err(ns("delete_batch")) }
-    async fn walk_dir(&self, _: &str, _: &str, _: bool, _: &str, _: Option<&str>, _: Option<usize>) -> IoResult<Vec<(String, FileInfo)>> { Err(ns("walk_dir")) }
-    async fn write_metadata(&self, _: &str, _: &str, _: &str, _: &FileInfo) -> IoResult<()> { Err(ns("write_metadata")) }
-    async fn read_version(&self, _: &str, _: &str, _: &str, _: Option<&str>, _: bool) -> IoResult<FileInfo> { Err(ns("read_version")) }
-    async fn update_metadata(&self, _: &str, _: &str, _: &FileInfo, _: &UpdateMetadataOpts) -> IoResult<()> { Err(ns("update_metadata")) }
-    async fn delete_version(&self, _: &str, _: &str, _: &FileInfo, _: bool, _: &DeleteOptions) -> IoResult<()> { Err(ns("delete_version")) }
-    async fn rename_data(&self, _: &str, _: &str, _: &FileInfo, _: &str, _: &str, _: &RenameOptions) -> IoResult<RenameDataResp> { Err(ns("rename_data")) }
-    async fn verify_file(&self, _: &str, _: &str, _: &FileInfo) -> IoResult<()> { Err(ns("verify_file")) }
-    async fn read_format(&self) -> IoResult<Option<FormatJson>> { Err(ns("read_format")) }
-    async fn write_format(&self, _: &FormatJson)             -> IoResult<()> { Err(ns("write_format")) }
-    async fn write_file(&self, _: &str, _: &str, _: Vec<u8>) -> IoResult<()> { Err(ns("write_file")) }
-    async fn read_file(&self, _: &str, _: &str)              -> IoResult<Option<Vec<u8>>> { Err(ns("read_file")) }
-    async fn make_dir_all(&self, _: &str, _: &str)           -> IoResult<()> { Err(ns("make_dir_all")) }
 }
 
 struct RdmaReadStream {

--- a/crates/phenomenal_server/src/main.rs
+++ b/crates/phenomenal_server/src/main.rs
@@ -353,8 +353,10 @@ async fn run_runtime(
                 config::TransportMode::Rdma => {
                     let node = rdma_node.as_ref().expect("rdma node built in rdma mode").clone();
                     for disk_idx in 0..n.disk_count {
+                        let rpc_backend: Rc<dyn StorageBackend> =
+                            Rc::new(RemoteBackend::new(peer.clone(), disk_idx));
                         let rb = Rc::new(phenomenal_io::rdma_backend::RdmaBackend::new(
-                            node.clone(), n.id, disk_idx,
+                            node.clone(), n.id, disk_idx, rpc_backend,
                         ));
                         backends.insert(
                             DiskAddr { node_id: n.id, disk_idx },


### PR DESCRIPTION
 - Rdma backend may not have all APIs rdma supported.
 - If rdma api is unavailable but rdma backend is enabled, have the ability to fallback to the rpc path gracefully
