### PR TITLE
#28 Use TCP_NODELAY for inter node H2 rpc for improved latency

### DIFF
--- a/vendor/cyper/src/stream.rs
+++ b/vendor/cyper/src/stream.rs
@@ -68,7 +68,7 @@ impl HttpStream {
                 TcpStream::connect(addrs.as_slice()).await?
             }
         };
-
+        let _ = stream.set_nodelay(true);
         Ok(stream)
     }
 }


### PR DESCRIPTION
Coalescing small outbound packets comes at a latency expense, set TCP_NODELAY on the socket for immediate flushing of data packets.
