### PR TITLE
(#32) [v0.1] Support dynamic DC exchange for inter node RDMA

### DIFF
--- a/crates/phenomenal_io/src/rdma/bootstrap.rs
+++ b/crates/phenomenal_io/src/rdma/bootstrap.rs
@@ -1,0 +1,34 @@
+use std::collections::HashMap;
+
+use crate::rdma::node::PeerEndpoint;
+use crate::rpc::LocalRdmaEndpoint;
+
+pub type LocalEndpoint = LocalRdmaEndpoint;
+
+#[derive(Debug, Default)]
+pub struct ClusterRoutingTable {
+    pub self_node_id: u16,
+    entries: HashMap<(u16, u16), PeerEndpoint>,
+}
+
+impl ClusterRoutingTable {
+    pub fn new(self_node_id: u16) -> Self {
+        Self { self_node_id, entries: HashMap::new() }
+    }
+
+    pub fn insert(&mut self, peer_node: u16, ep: &LocalEndpoint) {
+        self.entries.insert((peer_node, ep.runtime_id), PeerEndpoint {
+            node_id: peer_node,
+            gid:     ep.gid,
+            dct_num: ep.dct_num,
+            dc_key:  ep.dc_key,
+        });
+    }
+
+    pub fn get(&self, peer_node: u16, peer_runtime: u16) -> Option<&PeerEndpoint> {
+        self.entries.get(&(peer_node, peer_runtime))
+    }
+
+    pub fn len(&self) -> usize { self.entries.len() }
+    pub fn is_empty(&self) -> bool { self.entries.is_empty() }
+}

--- a/crates/phenomenal_io/src/rdma/mod.rs
+++ b/crates/phenomenal_io/src/rdma/mod.rs
@@ -11,7 +11,7 @@ pub mod wire;
 mod wr;
 
 pub use ah_cache::AhCache;
-pub use bootstrap::{bootstrap, ClusterRoutingTable, LocalEndpoint};
+pub use bootstrap::{ClusterRoutingTable, LocalEndpoint};
 pub use buffers::BUF_SIZE;
 pub use device::IbDevice;
 pub use node::{PeerEndpoint, RdmaConfig, RdmaNode, RdmaQos};

--- a/crates/phenomenal_io/src/rdma/node.rs
+++ b/crates/phenomenal_io/src/rdma/node.rs
@@ -2,11 +2,13 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::io;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use futures::channel::oneshot;
 use serde::{Deserialize, Serialize};
 
 use super::ah_cache::AhCache;
+use super::bootstrap::{ClusterRoutingTable, LocalEndpoint};
 use super::device::IbDevice;
 use super::rdma_buf::RdmaBufPool;
 use super::socket::{CqPump, IbSocket};
@@ -20,38 +22,40 @@ pub struct PeerEndpoint {
     pub dc_key:  u64,
 }
 
-/// QoS for outbound RDMA traffic. Stamped onto every `ibv_ah_attr` we
-/// build (peer AH cache + DCT/DCI RTR transitions). Operator-set,
-/// no default: lossless RoCE deployments REQUIRE these to match the
-/// switch fabric's PFC/ECN configuration. Values of 0 give best-effort.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct RdmaQos {
-    /// 8-bit IP TOS byte. Upper 6 bits = DSCP. Switch fabric maps this
-    /// DSCP to the PFC priority queue (priority 3 lossless RoCE is
-    /// typically traffic_class = 96, i.e. DSCP 24 << 2).
     pub traffic_class: u8,
-    /// Service Level. Mellanox HCAs use this to select the egress TC
-    /// queue in SL-based PFC mode. For PFC priority 3 set sl=3.
     pub service_level: u8,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug)]
 pub struct RdmaConfig {
-    pub self_node_id: u16,
-    pub dev_name:     String,
-    pub dc_key:       u64,
-    pub qos:          RdmaQos,
-    pub peers:        Vec<PeerEndpoint>,
+    pub self_node_id:  u16,
+    pub runtime_id:    u16,
+    pub dev_name:      String,
+    pub dc_key:        u64,
+    pub qos:           RdmaQos,
     pub bulk_buf_size: usize,
     pub bulk_pool_cap: usize,
 }
 
+pub struct RdmaSetup {
+    pub dev:       Rc<IbDevice>,
+    pub sock:      Rc<IbSocket>,
+    pub ah_cache:  Rc<AhCache>,
+    pub pump:      CqPump,
+    pub bulk_pool: Rc<RdmaBufPool>,
+    pub self_gid:  [u8; 16],
+    pub self_dct:  u32,
+}
+
 pub struct RdmaNode {
     pub self_id:           u16,
+    pub runtime_id:        u16,
     pub dev:               Rc<IbDevice>,
     pub sock:              Rc<IbSocket>,
     pub ah_cache:          Rc<AhCache>,
-    pub peers:             HashMap<u16, PeerEndpoint>,
+    pub routing:           Arc<ClusterRoutingTable>,
     pub pump:              CqPump,
     pub next_request_id:   Cell<u64>,
     pub pending_responses: RefCell<HashMap<u64, oneshot::Sender<RdmaResponse>>>,
@@ -59,35 +63,48 @@ pub struct RdmaNode {
 }
 
 impl RdmaNode {
-    pub fn start(cfg: RdmaConfig) -> io::Result<Self> {
-        let dev      = Rc::new(IbDevice::open(&cfg.dev_name)?);
-        let sock     = Rc::new(IbSocket::new(dev.clone(), cfg.dc_key, cfg.qos)?);
-        let ah_cache = Rc::new(AhCache::new(dev.pd.as_ptr(), cfg.qos, dev.gid_index, dev.port_attr.lid));
-        let pump     = CqPump::start(sock.clone())?;
-        let self_dct_identifier = sock.self_dct_identifier;
-        let my_gid     = dev.gid;
-        let mut peers = HashMap::with_capacity(cfg.peers.len());
-        for mut p in cfg.peers {
-            // Loopback: a peer entry referencing ourselves gets its
-            // gid + dct_num patched with the real values discovered at
-            // boot (TOML can't predict the DCT number we get from the HCA).
-            if p.node_id == cfg.self_node_id {
-                p.gid     = my_gid;
-                p.dct_num = self_dct_identifier;
-                p.dc_key  = cfg.dc_key;
-            }
-            peers.insert(p.node_id, p);
-        }
+    pub fn start_local(cfg: &RdmaConfig) -> io::Result<(RdmaSetup, LocalEndpoint)> {
+        let dev       = Rc::new(IbDevice::open(&cfg.dev_name)?);
+        let sock      = Rc::new(IbSocket::new(dev.clone(), cfg.dc_key, cfg.qos)?);
+        let ah_cache  = Rc::new(AhCache::new(dev.pd.as_ptr(), cfg.qos, dev.gid_index, dev.port_attr.lid));
+        let pump      = CqPump::start(sock.clone())?;
+        let self_dct  = sock.self_dct_identifier;
+        let self_gid  = dev.gid;
         let bulk_pool = RdmaBufPool::new(dev.pd.as_ptr(), cfg.bulk_pool_cap, cfg.bulk_buf_size);
-        Ok(RdmaNode {
-            self_id: cfg.self_node_id, dev, sock, ah_cache, peers, pump,
-            next_request_id:   Cell::new(1),
-            pending_responses: RefCell::new(HashMap::new()),
-            bulk_pool,
-        })
+        let setup = RdmaSetup { dev, sock, ah_cache, pump, bulk_pool, self_gid, self_dct };
+        let endpoint = LocalEndpoint {
+            runtime_id: cfg.runtime_id,
+            dct_num:    self_dct,
+            gid:        self_gid,
+            dc_key:     cfg.dc_key,
+        };
+        Ok((setup, endpoint))
     }
 
-    pub fn peer(&self, node_id: u16) -> Option<&PeerEndpoint> {
-        self.peers.get(&node_id)
+    pub fn finalize(
+        cfg:     &RdmaConfig,
+        setup:   RdmaSetup,
+        routing: Arc<ClusterRoutingTable>,
+    ) -> Self {
+        RdmaNode {
+            self_id:           cfg.self_node_id,
+            runtime_id:        cfg.runtime_id,
+            dev:               setup.dev,
+            sock:              setup.sock,
+            ah_cache:          setup.ah_cache,
+            routing,
+            pump:              setup.pump,
+            next_request_id:   Cell::new(1),
+            pending_responses: RefCell::new(HashMap::new()),
+            bulk_pool:         setup.bulk_pool,
+        }
+    }
+
+    pub fn peer(&self, peer_node: u16) -> Option<&PeerEndpoint> {
+        self.routing.get(peer_node, self.runtime_id)
+    }
+
+    pub fn peer_at(&self, peer_node: u16, peer_runtime: u16) -> Option<&PeerEndpoint> {
+        self.routing.get(peer_node, peer_runtime)
     }
 }

--- a/crates/phenomenal_io/src/rdma/wire.rs
+++ b/crates/phenomenal_io/src/rdma/wire.rs
@@ -29,6 +29,6 @@ pub enum RdmaResponse {
 
 #[derive(Serialize, Deserialize)]
 pub enum Envelope {
-    Req { magic: u32, from_node_id: u16, request_id: u64, payload: RdmaRequest  },
-    Rsp { magic: u32, request_id: u64,                   payload: RdmaResponse },
+    Req { magic: u32, from_node_id: u16, from_runtime_id: u16, request_id: u64, payload: RdmaRequest  },
+    Rsp { magic: u32, request_id: u64,                                          payload: RdmaResponse },
 }

--- a/crates/phenomenal_io/src/rdma_backend.rs
+++ b/crates/phenomenal_io/src/rdma_backend.rs
@@ -52,7 +52,8 @@ impl RdmaBackend {
 
         let env = Envelope::Req {
             magic: ENVELOPE_MAGIC,
-            from_node_id: self.node.self_id,
+            from_node_id:    self.node.self_id,
+            from_runtime_id: self.node.runtime_id,
             request_id,
             payload: RdmaRequest::Generic(payload),
         };
@@ -93,7 +94,8 @@ impl RdmaBackend {
 
         let env = Envelope::Req {
             magic: ENVELOPE_MAGIC,
-            from_node_id: node.self_id,
+            from_node_id:    node.self_id,
+            from_runtime_id: node.runtime_id,
             request_id,
             payload: RdmaRequest::ReadFileChunk {
                 disk_idx: self.disk_idx,
@@ -170,7 +172,8 @@ impl RdmaBackend {
 
         let env = Envelope::Req {
             magic: ENVELOPE_MAGIC,
-            from_node_id: node.self_id,
+            from_node_id:    node.self_id,
+            from_runtime_id: node.runtime_id,
             request_id,
             payload: RdmaRequest::WriteFileChunk {
                 disk_idx: self.disk_idx,

--- a/crates/phenomenal_io/src/remote_fs.rs
+++ b/crates/phenomenal_io/src/remote_fs.rs
@@ -234,6 +234,14 @@ impl RemoteBackend {
             other                   => Err(unexpected(other)),
         }
     }
+
+    pub async fn get_rdma_endpoints(&self) -> IoResult<rpc::RdmaEndpointsReply> {
+        match self.unary(Request::GetRdmaEndpoints).await? {
+            Response::RdmaEndpoints(r) => Ok(r),
+            Response::Err(e)           => Err(e.into()),
+            other                      => Err(unexpected(other)),
+        }
+    }
 }
 
 // `call_unit!` / `call_typed!` are thin wrappers that the 22-method

--- a/crates/phenomenal_io/src/rpc.rs
+++ b/crates/phenomenal_io/src/rpc.rs
@@ -93,6 +93,12 @@ pub enum Request {
     LockRelease { resource: String, uid: String },
     /// Periodic lease refresh. Reply: `LockRefreshed` or `LockNotFound`.
     LockRefresh { resource: String, uid: String },
+
+    /// Cluster-wide RDMA peer-endpoint exchange. Polled by peers
+    /// during startup; reply carries every local runtime's
+    /// `(runtime_id, dct_num, gid, dc_key)`. Until every runtime on
+    /// this node has published, `complete = false` and peers retry.
+    GetRdmaEndpoints,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -115,7 +121,22 @@ pub enum Response {
     LockDenied,
     LockRefreshed,
     LockNotFound,
+    RdmaEndpoints(RdmaEndpointsReply),
     Err(WireError),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocalRdmaEndpoint {
+    pub runtime_id: u16,
+    pub dct_num:    u32,
+    pub gid:        [u8; 16],
+    pub dc_key:     u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RdmaEndpointsReply {
+    pub complete:  bool,
+    pub endpoints: Vec<LocalRdmaEndpoint>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/phenomenal_server/src/config.rs
+++ b/crates/phenomenal_server/src/config.rs
@@ -147,7 +147,6 @@ pub struct RdmaToml {
     pub dev_name:      String,
     pub dc_key:        u64,
     pub qos:           RdmaQosToml,
-    pub peers:         Vec<RdmaPeerToml>,
     #[serde(default = "default_bulk_pool_cap")]
     pub bulk_pool_cap: usize,
 }
@@ -158,14 +157,6 @@ fn default_bulk_pool_cap() -> usize { 64 }
 pub struct RdmaQosToml {
     pub traffic_class: u8,
     pub service_level: u8,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct RdmaPeerToml {
-    pub node_id: u16,
-    pub gid:     [u8; 16],
-    pub dct_num: u32,
-    pub dc_key:  u64,
 }
 
 /// TOML-friendly mirror of `phenomenal_io::MemoryPoolConfig`. Defaults

--- a/crates/phenomenal_server/src/main.rs
+++ b/crates/phenomenal_server/src/main.rs
@@ -111,20 +111,31 @@ fn main() -> anyhow::Result<()> {
 
     let bootstrap_id: Arc<OnceLock<Uuid>> = Arc::new(OnceLock::new());
 
+    let endpoint_registry: Arc<std::sync::Mutex<phenomenal_io::rpc::RdmaEndpointsReply>> =
+        Arc::new(std::sync::Mutex::new(phenomenal_io::rpc::RdmaEndpointsReply {
+            complete:  num_runtimes == 0,
+            endpoints: Vec::with_capacity(num_runtimes),
+        }));
+
     let mut handles = Vec::with_capacity(num_runtimes);
     for (runtime_id, cpu) in cpus.into_iter().enumerate() {
-        let cfg          = cfg.clone();
-        let done_tx      = done_tx.clone();
-        let lock_server  = lock_server.clone();
-        let tls          = tls.clone();
-        let bootstrap_id = bootstrap_id.clone();
-        let handle       = thread::Builder::new()
+        let cfg              = cfg.clone();
+        let done_tx          = done_tx.clone();
+        let lock_server      = lock_server.clone();
+        let tls              = tls.clone();
+        let bootstrap_id     = bootstrap_id.clone();
+        let endpoint_registry = endpoint_registry.clone();
+        let handle           = thread::Builder::new()
             .name(format!("runtime-{runtime_id}"))
             .spawn(move || {
                 let result = (|| -> anyhow::Result<()> {
                     bind_cpu(cpu)?;
                     let rt = create_runtime()?;
-                    rt.block_on(run_runtime(runtime_id, cfg, lock_server, tls, bootstrap_id))
+                    rt.block_on(run_runtime(
+                        runtime_id, num_runtimes,
+                        cfg, lock_server, tls, bootstrap_id,
+                        endpoint_registry,
+                    ))
                 })();
                 if let Err(e) = &result {
                     tracing::error!(runtime_id, cpu, "runtime exited with error: {e:#}");
@@ -136,9 +147,6 @@ fn main() -> anyhow::Result<()> {
     }
     drop(done_tx);
 
-    // Block until every runtime thread exits. If one dies, the others
-    // keep running — operator decides whether to restart the process
-    // (systemd, k8s, etc.). Phenomenald doesn't try to respawn.
     while let Ok((runtime_id, result)) = done_rx.recv() {
         match result {
             Ok(())   => tracing::info!(runtime_id, "runtime exited cleanly"),
@@ -253,11 +261,14 @@ fn create_runtime() -> anyhow::Result<compio::runtime::Runtime> {
 /// Returns only when both accept loops exit (normally: never, until
 /// shutdown).
 async fn run_runtime(
-    runtime_id:   usize,
-    cfg:          Arc<config::Config>,
-    lock_server:  Arc<LockServer>,
-    tls:          TlsMaterial,
-    bootstrap_id: Arc<OnceLock<Uuid>>,
+    runtime_id:        usize,
+    #[cfg_attr(not(all(feature = "rdma", target_os = "linux")), allow(unused_variables))]
+    num_runtimes:      usize,
+    cfg:               Arc<config::Config>,
+    lock_server:       Arc<LockServer>,
+    tls:               TlsMaterial,
+    bootstrap_id:      Arc<OnceLock<Uuid>>,
+    endpoint_registry: Arc<std::sync::Mutex<phenomenal_io::rpc::RdmaEndpointsReply>>,
 ) -> anyhow::Result<()> {
     // Extract the three TLS handles from the shared material.
     //
@@ -316,17 +327,10 @@ async fn run_runtime(
     let local_lock_peer: Rc<dyn LockPeer> =
         Rc::new(LocalLockPeer::new(lock_server.clone()));
 
-    #[cfg(all(feature = "rdma", target_os = "linux"))]
-    let rdma_node: Option<std::rc::Rc<phenomenal_io::rdma::RdmaNode>> = match cfg.transport {
-        config::TransportMode::Rdma => Some(std::rc::Rc::new(
-            phenomenal_io::rdma::RdmaNode::start(build_rdma_config(cfg.rdma.as_ref().unwrap()))?
-        )),
-        config::TransportMode::H2 => None,
-    };
-
+    let mut peer_clients: std::collections::HashMap<phenomenal_storage::cluster::NodeId, Rc<PeerClient>> =
+        std::collections::HashMap::with_capacity(cfg.nodes.len().saturating_sub(1));
     for n in &cfg.nodes {
         if n.id == cfg.self_id {
-            // Local node — register every local disk.
             for (idx, disk_be) in local_disks.iter().enumerate() {
                 backends.insert(
                     DiskAddr { node_id: n.id, disk_idx: idx as u16 },
@@ -335,46 +339,32 @@ async fn run_runtime(
             }
             lock_peer_by_node.insert(n.id, local_lock_peer.clone());
         } else {
-            // `rpc_connector` is `Some` when rpc_tls is configured, `None`
-            // for plaintext h2c clusters. PeerClient handles both.
             let peer = Rc::new(PeerClient::new(n.rpc_addr, rpc_connector.clone()));
-
             let lock_rb = Rc::new(RemoteBackend::new(peer.clone(), 0));
             lock_peer_by_node.insert(n.id, lock_rb as Rc<dyn LockPeer>);
-
-            // Data plane backends: pick per transport.
-            match cfg.transport {
-                config::TransportMode::H2 => {
-                    for disk_idx in 0..n.disk_count {
-                        let rb = Rc::new(RemoteBackend::new(peer.clone(), disk_idx));
-                        backends.insert(
-                            DiskAddr { node_id: n.id, disk_idx },
-                            rb as Rc<dyn StorageBackend>,
-                        );
-                    }
-                }
-                #[cfg(all(feature = "rdma", target_os = "linux"))]
-                config::TransportMode::Rdma => {
-                    let node = rdma_node.as_ref().expect("rdma node built in rdma mode").clone();
-                    for disk_idx in 0..n.disk_count {
-                        let rpc_backend: Rc<dyn StorageBackend> =
-                            Rc::new(RemoteBackend::new(peer.clone(), disk_idx));
-                        let rb = Rc::new(phenomenal_io::rdma_backend::RdmaBackend::new(
-                            node.clone(), n.id, disk_idx, rpc_backend,
-                        ));
-                        backends.insert(
-                            DiskAddr { node_id: n.id, disk_idx },
-                            rb as Rc<dyn StorageBackend>,
-                        );
-                    }
-                }
-                #[cfg(not(all(feature = "rdma", target_os = "linux")))]
-                config::TransportMode::Rdma => {
-                    anyhow::bail!("rdma transport selected but build lacks rdma feature");
-                }
-            }
+            peer_clients.insert(n.id, peer);
         }
     }
+
+    #[cfg(all(feature = "rdma", target_os = "linux"))]
+    let rdma_pending: Option<(phenomenal_io::rdma::RdmaSetup, phenomenal_io::rdma::RdmaConfig)> =
+        match cfg.transport {
+            config::TransportMode::Rdma => {
+                let rdma_cfg = build_rdma_config(
+                    cfg.rdma.as_ref().expect("rdma transport requires [rdma]"),
+                    runtime_id as u16,
+                );
+                let (setup, my_endpoint) = phenomenal_io::rdma::RdmaNode::start_local(&rdma_cfg)
+                    .context("rdma start_local")?;
+                {
+                    let mut reg = endpoint_registry.lock().unwrap();
+                    reg.endpoints.push(my_endpoint);
+                    if reg.endpoints.len() >= num_runtimes { reg.complete = true; }
+                }
+                Some((setup, rdma_cfg))
+            }
+            config::TransportMode::H2 => None,
+        };
 
     let auth_state = Rc::new(auth::AuthState::new(
         cfg.region.clone(),
@@ -402,26 +392,97 @@ async fn run_runtime(
     let rpc_disks      = Rc::new(local_disks.clone());
     let rpc_locks      = lock_server.clone();
     let rpc_acceptor_t = rpc_acceptor.clone();
+    let rpc_endpoints  = endpoint_registry.clone();
     let rpc_task = compio::runtime::spawn(async move {
-        if let Err(e) = rpc_server::serve(rpc_listener, rpc_disks, rpc_locks, rpc_acceptor_t).await {
+        if let Err(e) = rpc_server::serve(rpc_listener, rpc_disks, rpc_locks, rpc_acceptor_t, rpc_endpoints).await {
             tracing::error!(runtime_id, "rpc serve error: {e:#}");
         }
     });
 
     #[cfg(all(feature = "rdma", target_os = "linux"))]
-    let _rdma_task = match cfg.transport {
-        config::TransportMode::Rdma => {
-            let node        = rdma_node.as_ref().expect("rdma node built in rdma mode").clone();
+    let rdma_node: Option<Rc<phenomenal_io::rdma::RdmaNode>> = if let Some((setup, rdma_cfg)) = rdma_pending {
+        let mut routing = phenomenal_io::rdma::ClusterRoutingTable::new(cfg.self_id);
+        for ep in endpoint_registry.lock().unwrap().endpoints.iter() {
+            routing.insert(cfg.self_id, ep);
+        }
+        let mut remaining: std::collections::HashSet<phenomenal_storage::cluster::NodeId> =
+            peer_clients.keys().copied().collect();
+        while !remaining.is_empty() {
+            for peer_id in remaining.clone() {
+                let peer = peer_clients.get(&peer_id).expect("peer_id present");
+                let rb = RemoteBackend::new(peer.clone(), 0);
+                match rb.get_rdma_endpoints().await {
+                    Ok(reply) if reply.complete => {
+                        for ep in &reply.endpoints {
+                            routing.insert(peer_id, ep);
+                        }
+                        remaining.remove(&peer_id);
+                    }
+                    Ok(_) => {}
+                    Err(e) => tracing::debug!(?peer_id, "rdma discover retry: {e}"),
+                }
+            }
+            if !remaining.is_empty() {
+                compio::time::sleep(Duration::from_millis(200)).await;
+            }
+        }
+        let routing = Arc::new(routing);
+        tracing::info!(runtime_id, entries = routing.len(), "rdma routing table populated");
+        Some(Rc::new(phenomenal_io::rdma::RdmaNode::finalize(&rdma_cfg, setup, routing)))
+    } else {
+        None
+    };
+
+    for n in &cfg.nodes {
+        if n.id == cfg.self_id { continue; }
+        let peer = peer_clients.get(&n.id).expect("peer_id present").clone();
+        match cfg.transport {
+            config::TransportMode::H2 => {
+                for disk_idx in 0..n.disk_count {
+                    let rb = Rc::new(RemoteBackend::new(peer.clone(), disk_idx));
+                    backends.insert(
+                        DiskAddr { node_id: n.id, disk_idx },
+                        rb as Rc<dyn StorageBackend>,
+                    );
+                }
+            }
+            #[cfg(all(feature = "rdma", target_os = "linux"))]
+            config::TransportMode::Rdma => {
+                let node = rdma_node.as_ref().expect("rdma node finalized").clone();
+                for disk_idx in 0..n.disk_count {
+                    let rpc_backend: Rc<dyn StorageBackend> =
+                        Rc::new(RemoteBackend::new(peer.clone(), disk_idx));
+                    let rb = Rc::new(phenomenal_io::rdma_backend::RdmaBackend::new(
+                        node.clone(), n.id, disk_idx, rpc_backend,
+                    ));
+                    backends.insert(
+                        DiskAddr { node_id: n.id, disk_idx },
+                        rb as Rc<dyn StorageBackend>,
+                    );
+                }
+            }
+            #[cfg(not(all(feature = "rdma", target_os = "linux")))]
+            config::TransportMode::Rdma => {
+                anyhow::bail!("rdma transport selected but build lacks rdma feature");
+            }
+        }
+    }
+
+    #[cfg(all(feature = "rdma", target_os = "linux"))]
+    let _rdma_task = match (cfg.transport, rdma_node.as_ref()) {
+        (config::TransportMode::Rdma, Some(node)) => {
+            let node        = node.clone();
             let disks       = Rc::new(local_disks.clone());
             let local_disks = Rc::new(local_fs_disks.clone());
             let locks       = lock_server.clone();
+            let endpoints   = endpoint_registry.clone();
             Some(compio::runtime::spawn(async move {
-                if let Err(e) = rdma_server::serve(node, disks, local_disks, locks).await {
+                if let Err(e) = rdma_server::serve(node, disks, local_disks, locks, endpoints).await {
                     tracing::error!(runtime_id, "rdma serve error: {e:#}");
                 }
             }))
         }
-        config::TransportMode::H2 => None,
+        _ => None,
     };
 
     let deployment_id: Uuid = if runtime_id == 0 {
@@ -503,22 +564,18 @@ async fn run_runtime(
 }
 
 #[cfg(all(feature = "rdma", target_os = "linux"))]
-fn build_rdma_config(t: &config::RdmaToml) -> phenomenal_io::rdma::RdmaConfig {
+fn build_rdma_config(t: &config::RdmaToml, runtime_id: u16) -> phenomenal_io::rdma::RdmaConfig {
     phenomenal_io::rdma::RdmaConfig {
         self_node_id: t.self_node_id,
+        runtime_id,
         dev_name:     t.dev_name.clone(),
         dc_key:       t.dc_key,
         qos: phenomenal_io::rdma::RdmaQos {
             traffic_class: t.qos.traffic_class,
             service_level: t.qos.service_level,
         },
-        peers: t.peers.iter().map(|p| phenomenal_io::rdma::PeerEndpoint {
-            node_id: p.node_id,
-            gid:     p.gid,
-            dct_num: p.dct_num,
-            dc_key:  p.dc_key,
-        }).collect(),
         bulk_buf_size: phenomenal_storage::DEFAULT_EC_PER_SHARD_BYTES,
         bulk_pool_cap: t.bulk_pool_cap,
     }
 }
+

--- a/crates/phenomenal_server/src/rdma_server.rs
+++ b/crates/phenomenal_server/src/rdma_server.rs
@@ -19,16 +19,16 @@ pub async fn serve(
     disks:       Rc<Vec<Rc<dyn StorageBackend>>>,
     local_disks: Rc<Vec<Rc<LocalFsBackend>>>,
     locks:       Arc<LockServer>,
+    endpoints:   Arc<std::sync::Mutex<phenomenal_io::rpc::RdmaEndpointsReply>>,
 ) -> anyhow::Result<()> {
     let mut rx = node.pump.take_recv_rx()
         .ok_or_else(|| anyhow::anyhow!("rdma_server: pump recv_rx already taken"))?;
     let mut buf = Vec::with_capacity(BUF_SIZE);
     loop {
-        // Drain every envelope queued before parking again.
         loop {
             buf.clear();
             if node.sock.attempt_singular_rcv(&mut buf).is_none() { break; }
-            handle(&node, &disks, &local_disks, &locks, &buf).await;
+            handle(&node, &disks, &local_disks, &locks, &endpoints, &buf).await;
         }
         if rx.next().await.is_none() { return Ok(()); }
     }
@@ -39,6 +39,7 @@ async fn handle(
     disks:       &Rc<Vec<Rc<dyn StorageBackend>>>,
     local_disks: &Rc<Vec<Rc<LocalFsBackend>>>,
     locks:       &Arc<LockServer>,
+    endpoints:   &Arc<std::sync::Mutex<phenomenal_io::rpc::RdmaEndpointsReply>>,
     bytes:       &[u8],
 ) {
     let env: Envelope = match decode(bytes) {
@@ -46,14 +47,17 @@ async fn handle(
         Err(e) => { tracing::warn!("rdma_server: decode envelope: {e}"); return; }
     };
     match env {
-        Envelope::Req { magic, from_node_id, request_id, payload } => {
+        Envelope::Req { magic, from_node_id, from_runtime_id, request_id, payload } => {
             if magic != ENVELOPE_MAGIC {
                 tracing::warn!("rdma_server: bad request magic {:#x}", magic);
                 return;
             }
-            let sender = match node.peer(from_node_id) {
+            let sender = match node.peer_at(from_node_id, from_runtime_id) {
                 Some(p) => p.clone(),
-                None    => { tracing::warn!("rdma_server: unknown sender {from_node_id}"); return; }
+                None    => {
+                    tracing::warn!("rdma_server: unknown sender (node={from_node_id}, runtime={from_runtime_id})");
+                    return;
+                }
             };
             let sender_ah = match node.ah_cache.get_or_create(&sender) {
                 Ok(ah) => ah,
@@ -73,7 +77,7 @@ async fn handle(
                         sender.dct_num, sender.dc_key,
                         disk_idx, volume, path, offset, length, source,
                     ).await,
-                RdmaRequest::Generic(req) => RdmaResponse::Generic(dispatch(disks, locks, req).await),
+                RdmaRequest::Generic(req) => RdmaResponse::Generic(dispatch(disks, locks, endpoints, req).await),
             };
             let body = match encode(&Envelope::Rsp {
                 magic: ENVELOPE_MAGIC, request_id, payload: resp,

--- a/crates/phenomenal_server/src/rpc_server.rs
+++ b/crates/phenomenal_server/src/rpc_server.rs
@@ -118,8 +118,9 @@ pub struct RpcAppState {
 }
 
 struct RpcAppStateInner {
-    disks: Vec<Rc<dyn StorageBackend>>,
-    locks: Arc<LockServer>,
+    disks:     Vec<Rc<dyn StorageBackend>>,
+    locks:     Arc<LockServer>,
+    endpoints: Arc<std::sync::Mutex<phenomenal_io::rpc::RdmaEndpointsReply>>,
 }
 
 // SAFETY: every `RpcAppState` clone stays on the runtime that
@@ -128,11 +129,18 @@ unsafe impl Send for RpcAppState {}
 unsafe impl Sync for RpcAppState {}
 
 impl RpcAppState {
-    fn new(disks: Vec<Rc<dyn StorageBackend>>, locks: Arc<LockServer>) -> Self {
-        Self { inner: Rc::new(RpcAppStateInner { disks, locks }) }
+    fn new(
+        disks: Vec<Rc<dyn StorageBackend>>,
+        locks: Arc<LockServer>,
+        endpoints: Arc<std::sync::Mutex<phenomenal_io::rpc::RdmaEndpointsReply>>,
+    ) -> Self {
+        Self { inner: Rc::new(RpcAppStateInner { disks, locks, endpoints }) }
     }
     fn disks(&self) -> &[Rc<dyn StorageBackend>] { &self.inner.disks }
     fn locks(&self) -> &Arc<LockServer> { &self.inner.locks }
+    fn endpoints(&self) -> &Arc<std::sync::Mutex<phenomenal_io::rpc::RdmaEndpointsReply>> {
+        &self.inner.endpoints
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -140,12 +148,13 @@ impl RpcAppState {
 // -----------------------------------------------------------------------------
 
 pub async fn serve(
-    listener: TcpListener,
-    disks:    Rc<Vec<Rc<dyn StorageBackend>>>,
-    locks:    Arc<LockServer>,
-    tls:      Option<Rc<TlsAcceptor>>,
+    listener:  TcpListener,
+    disks:     Rc<Vec<Rc<dyn StorageBackend>>>,
+    locks:     Arc<LockServer>,
+    tls:       Option<Rc<TlsAcceptor>>,
+    endpoints: Arc<std::sync::Mutex<phenomenal_io::rpc::RdmaEndpointsReply>>,
 ) -> anyhow::Result<()> {
-    let state = RpcAppState::new(disks.iter().cloned().collect(), locks);
+    let state = RpcAppState::new(disks.iter().cloned().collect(), locks, endpoints);
     let app: Router = Router::new()
         .route("/v1/rpc",              post(handle_unary))
         .route("/v1/rpc/stream-write", put (handle_stream_write))
@@ -212,7 +221,7 @@ async fn handle_unary(
         );
     }
     let resp = SendWrapper::new(async move {
-        dispatch(state.disks(), state.locks(), req).await
+        dispatch(state.disks(), state.locks(), state.endpoints(), req).await
     }).await;
     let body_bytes = rpc::encode(&resp).unwrap_or_default();
     rpc_ok(body_bytes)
@@ -449,9 +458,10 @@ fn disk_at<'a>(
 /// variants are handled by their dedicated routes (and rejected
 /// here as a wire-protocol bug).
 pub(crate) async fn dispatch(
-    disks: &[Rc<dyn StorageBackend>],
-    locks: &Arc<LockServer>,
-    req:   Request,
+    disks:     &[Rc<dyn StorageBackend>],
+    locks:     &Arc<LockServer>,
+    endpoints: &Arc<std::sync::Mutex<phenomenal_io::rpc::RdmaEndpointsReply>>,
+    req:       Request,
 ) -> RpcResponse {
     use phenomenal_io::{DeleteOptions, RenameOptions, UpdateMetadataOpts};
     use Request::*;
@@ -560,6 +570,10 @@ pub(crate) async fn dispatch(
             } else {
                 RpcResponse::LockNotFound
             }
+        }
+
+        GetRdmaEndpoints => {
+            RpcResponse::RdmaEndpoints(endpoints.lock().unwrap().clone())
         }
     }
 }


### PR DESCRIPTION
 - Ensure each node can advertise it's routing table and DC to all nodes in the cluster for dynamic discovery.
 - Once DCs are known, the nodes can fully rely on RDMA for all endpoints, however the initial bootstrap and metadata exchange piggybacks over cyper h2 rpc