### PR TITLE
(#36) [v0.1] Fix RDMA send pool leak that drained credit under inter node traffic

### DIFF
--- a/crates/phenomenal_io/build.rs
+++ b/crates/phenomenal_io/build.rs
@@ -30,6 +30,8 @@ mod rdma {
             .blocklist_function("mlx5dv_destroy_flow.*")
             .blocklist_function("mlx5dv_dr_.*")
             .blocklist_function("mlx5dv_flow.*")
+            .blocklist_type    ("mlx5dv_context_attr")
+            .blocklist_function("mlx5dv_open_device")
             .layout_tests(false)
             .derive_default(true)
             .generate().expect("bindgen mlx5dv.h")

--- a/crates/phenomenal_io/examples/rdma_loopback.rs
+++ b/crates/phenomenal_io/examples/rdma_loopback.rs
@@ -105,6 +105,7 @@ mod linux {
                     gid:     [0u8; 16],
                     dct_num: 0,
                     dc_key:  0,
+                    lid:     0,
                 }],
                 bulk_buf_size: BULK_BUFFER_SIZE_BYTES,
                 bulk_pool_cap: BULK_POOL_CAPACITY,

--- a/crates/phenomenal_io/src/rdma/ah_cache.rs
+++ b/crates/phenomenal_io/src/rdma/ah_cache.rs
@@ -3,23 +3,25 @@ use std::collections::HashMap;
 use std::io;
 use std::mem;
 use std::ptr::NonNull;
+use std::rc::Rc;
 
 use rdma_mummy_sys::{ibv_ah, ibv_ah_attr, ibv_create_ah, ibv_destroy_ah, ibv_pd};
 
-use super::device::PORT_NUM;
+use super::device::{IbDevice, PORT_NUM};
 use super::node::{PeerEndpoint, RdmaQos};
 
 pub struct AhCache {
     pd:        *mut ibv_pd,
     qos:       RdmaQos,
     gid_index: u8,
-    local_lid: u16,
     table:     RefCell<HashMap<u16, NonNull<ibv_ah>>>,
+    _dev:      Rc<IbDevice>,
 }
 
 impl AhCache {
-    pub fn new(pd: *mut ibv_pd, qos: RdmaQos, gid_index: u8, local_lid: u16) -> Self {
-        Self { pd, qos, gid_index, local_lid, table: RefCell::new(HashMap::new()) }
+    pub fn new(dev: Rc<IbDevice>, qos: RdmaQos, gid_index: u8, _local_lid: u16) -> Self {
+        let pd = dev.pd.as_ptr();
+        Self { pd, qos, gid_index, table: RefCell::new(HashMap::new()), _dev: dev }
     }
 
     pub fn get_or_create(&self, peer: &PeerEndpoint) -> io::Result<*mut ibv_ah> {
@@ -29,7 +31,7 @@ impl AhCache {
         let ah = unsafe {
             let mut a: ibv_ah_attr = mem::zeroed();
             a.is_global           = 1;
-            a.dlid                = self.local_lid;
+            a.dlid                = peer.lid;
             a.port_num            = PORT_NUM;
             a.sl                  = self.qos.service_level;
             a.grh.dgid.raw        = peer.gid;

--- a/crates/phenomenal_io/src/rdma/bootstrap.rs
+++ b/crates/phenomenal_io/src/rdma/bootstrap.rs
@@ -22,6 +22,7 @@ impl ClusterRoutingTable {
             gid:     ep.gid,
             dct_num: ep.dct_num,
             dc_key:  ep.dc_key,
+            lid:     ep.lid,
         });
     }
 

--- a/crates/phenomenal_io/src/rdma/buffers.rs
+++ b/crates/phenomenal_io/src/rdma/buffers.rs
@@ -3,28 +3,33 @@ use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
 use std::io;
 use std::ptr::NonNull;
+use std::rc::Rc;
 
 use rdma_mummy_sys::{
-    ibv_access_flags, ibv_dereg_mr, ibv_mr, ibv_pd, ibv_reg_mr,
+    ibv_access_flags, ibv_dereg_mr, ibv_mr, ibv_reg_mr,
 };
 
-pub const BUF_SIZE:         usize = 16 * 1024;   // 16 KiB per slot
-pub const SEND_BUF_CNT:     usize = 32;          // slots per direction per QP
-pub const BUF_ACK_BATCH:    u32   = 8;           // credit ACK every 8 consumed RECVs
-pub const BUF_SIGNAL_BATCH: u32   = 8;           // signal every 8th SEND
-const PAGE_ALIGN:           usize = 4096;        // ibv_reg_mr page alignment
+use super::device::IbDevice;
+
+pub const BUF_SIZE:         usize = 16 * 1024;
+pub const SEND_BUF_CNT:     usize = 64;
+pub const BUF_ACK_BATCH:    u32   = 8;
+pub const BUF_SIGNAL_BATCH: u32   = 8;
+const PAGE_ALIGN:           usize = 4096;
 
 pub struct BufferMem {
     base:   NonNull<u8>,
     layout: Layout,
     mr:     NonNull<ibv_mr>,
+    _dev:   Rc<IbDevice>,
 }
 
 unsafe impl Send for BufferMem {}
 unsafe impl Sync for BufferMem {}
 
 impl BufferMem {
-    pub fn new(pd: *mut ibv_pd, total: usize) -> io::Result<Self> {
+    pub fn new(dev: Rc<IbDevice>, total: usize) -> io::Result<Self> {
+        let pd = dev.pd.as_ptr();
         let layout = Layout::from_size_align(total, PAGE_ALIGN)
             .map_err(|e| io::Error::other(format!("layout: {e}")))?;
         unsafe {
@@ -39,7 +44,7 @@ impl BufferMem {
                 Some(m) => m,
                 None => { let e = io::Error::last_os_error(); dealloc(base.as_ptr(), layout); return Err(e); }
             };
-            Ok(BufferMem { base, layout, mr })
+            Ok(BufferMem { base, layout, mr, _dev: dev })
         }
     }
     pub fn lkey(&self) -> u32 { unsafe { (*self.mr.as_ptr()).lkey } }
@@ -60,8 +65,8 @@ pub struct Buffers {
 }
 
 impl Buffers {
-    pub fn new(pd: *mut ibv_pd, buf_cnt: usize, buf_size: usize) -> io::Result<Self> {
-        Ok(Buffers { mem: BufferMem::new(pd, buf_cnt * buf_size)?, buf_size, buf_cnt })
+    pub fn new(dev: Rc<IbDevice>, buf_cnt: usize, buf_size: usize) -> io::Result<Self> {
+        Ok(Buffers { mem: BufferMem::new(dev, buf_cnt * buf_size)?, buf_size, buf_cnt })
     }
     pub fn slot_ptr(&self, idx: usize) -> *mut u8 { unsafe { self.mem.ptr().add(idx * self.buf_size) } }
     pub fn slot_addr(&self, idx: usize) -> u64 { self.slot_ptr(idx) as u64 }
@@ -77,9 +82,9 @@ pub struct SendBuffers {
 }
 
 impl SendBuffers {
-    pub fn new(pd: *mut ibv_pd, buf_cnt: usize, buf_size: usize) -> io::Result<Self> {
+    pub fn new(dev: Rc<IbDevice>, buf_cnt: usize, buf_size: usize) -> io::Result<Self> {
         Ok(SendBuffers {
-            base:  Buffers::new(pd, buf_cnt, buf_size)?,
+            base:  Buffers::new(dev, buf_cnt, buf_size)?,
             front: Cell::new(0),
             tail:  Cell::new(buf_cnt as u64),
         })
@@ -103,9 +108,9 @@ pub struct RecvBuffers {
 }
 
 impl RecvBuffers {
-    pub fn new(pd: *mut ibv_pd, buf_cnt: usize, buf_size: usize) -> io::Result<Self> {
+    pub fn new(dev: Rc<IbDevice>, buf_cnt: usize, buf_size: usize) -> io::Result<Self> {
         Ok(RecvBuffers {
-            base:  Buffers::new(pd, buf_cnt, buf_size)?,
+            base:  Buffers::new(dev, buf_cnt, buf_size)?,
             queue: RefCell::new(VecDeque::with_capacity(buf_cnt)),
         })
     }

--- a/crates/phenomenal_io/src/rdma/mod.rs
+++ b/crates/phenomenal_io/src/rdma/mod.rs
@@ -14,7 +14,7 @@ pub use ah_cache::AhCache;
 pub use bootstrap::{ClusterRoutingTable, LocalEndpoint};
 pub use buffers::BUF_SIZE;
 pub use device::IbDevice;
-pub use node::{PeerEndpoint, RdmaConfig, RdmaNode, RdmaQos};
+pub use node::{PeerEndpoint, RdmaConfig, RdmaNode, RdmaQos, RdmaSetup};
 pub use rdma_buf::{RdmaBuf, RdmaBufPool};
 pub use socket::{CqPump, IbSocket};
 

--- a/crates/phenomenal_io/src/rdma/node.rs
+++ b/crates/phenomenal_io/src/rdma/node.rs
@@ -20,6 +20,7 @@ pub struct PeerEndpoint {
     pub gid:     [u8; 16],
     pub dct_num: u32,
     pub dc_key:  u64,
+    pub lid:     u16,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
@@ -66,17 +67,18 @@ impl RdmaNode {
     pub fn start_local(cfg: &RdmaConfig) -> io::Result<(RdmaSetup, LocalEndpoint)> {
         let dev       = Rc::new(IbDevice::open(&cfg.dev_name)?);
         let sock      = Rc::new(IbSocket::new(dev.clone(), cfg.dc_key, cfg.qos)?);
-        let ah_cache  = Rc::new(AhCache::new(dev.pd.as_ptr(), cfg.qos, dev.gid_index, dev.port_attr.lid));
+        let ah_cache  = Rc::new(AhCache::new(dev.clone(), cfg.qos, dev.gid_index, dev.port_attr.lid));
         let pump      = CqPump::start(sock.clone())?;
         let self_dct  = sock.self_dct_identifier;
         let self_gid  = dev.gid;
-        let bulk_pool = RdmaBufPool::new(dev.pd.as_ptr(), cfg.bulk_pool_cap, cfg.bulk_buf_size);
+        let bulk_pool = RdmaBufPool::new(dev.clone(), cfg.bulk_pool_cap, cfg.bulk_buf_size);
         let setup = RdmaSetup { dev, sock, ah_cache, pump, bulk_pool, self_gid, self_dct };
         let endpoint = LocalEndpoint {
             runtime_id: cfg.runtime_id,
             dct_num:    self_dct,
             gid:        self_gid,
             dc_key:     cfg.dc_key,
+            lid:        setup.dev.port_attr.lid,
         };
         Ok((setup, endpoint))
     }

--- a/crates/phenomenal_io/src/rdma/rdma_buf.rs
+++ b/crates/phenomenal_io/src/rdma/rdma_buf.rs
@@ -8,10 +8,11 @@ use std::rc::{Rc, Weak};
 use bytes::Bytes;
 use futures::channel::oneshot;
 use rdma_mummy_sys::{
-    ibv_access_flags, ibv_dereg_mr, ibv_mr, ibv_pd, ibv_reg_mr,
+    ibv_access_flags, ibv_dereg_mr, ibv_mr, ibv_reg_mr,
 };
 
-use crate::rpc::RdmaRemoteBuf;
+use crate::rdma::device::IbDevice;
+use crate::rdma::wire::RdmaRemoteBuf;
 
 const PAGE_ALIGN: usize = 4096;
 
@@ -21,6 +22,7 @@ struct RdmaBufInner {
     mr:       NonNull<ibv_mr>,
     capacity: usize,
     pool:     Weak<RdmaBufPool>,
+    _dev:     Rc<IbDevice>,
 }
 
 // Required by `Bytes::from_owner`. Compio is thread-per-core; RdmaBuf
@@ -28,7 +30,8 @@ struct RdmaBufInner {
 unsafe impl Send for RdmaBufInner {}
 
 impl RdmaBufInner {
-    fn new(pd: *mut ibv_pd, capacity: usize, pool: Weak<RdmaBufPool>) -> io::Result<Self> {
+    fn new(dev: Rc<IbDevice>, capacity: usize, pool: Weak<RdmaBufPool>) -> io::Result<Self> {
+        let pd = dev.pd.as_ptr();
         let layout = Layout::from_size_align(capacity, PAGE_ALIGN)
             .map_err(|e| io::Error::other(format!("layout: {e}")))?;
         unsafe {
@@ -47,7 +50,7 @@ impl RdmaBufInner {
                     return Err(e);
                 }
             };
-            Ok(RdmaBufInner { base, layout, mr, capacity, pool })
+            Ok(RdmaBufInner { base, layout, mr, capacity, pool, _dev: dev })
         }
     }
 }
@@ -114,16 +117,16 @@ struct PoolState {
 }
 
 pub struct RdmaBufPool {
-    pd:       *mut ibv_pd,
+    dev:      Rc<IbDevice>,
     buf_size: usize,
     cap:      usize,
     state:    RefCell<PoolState>,
 }
 
 impl RdmaBufPool {
-    pub fn new(pd: *mut ibv_pd, cap: usize, buf_size: usize) -> Rc<Self> {
+    pub fn new(dev: Rc<IbDevice>, cap: usize, buf_size: usize) -> Rc<Self> {
         Rc::new(Self {
-            pd, buf_size, cap,
+            dev, buf_size, cap,
             state: RefCell::new(PoolState {
                 free:      Vec::new(),
                 waiters:   VecDeque::new(),
@@ -146,7 +149,7 @@ impl RdmaBufPool {
             }
         };
         if needs_alloc {
-            match RdmaBufInner::new(self.pd, self.buf_size, Rc::downgrade(self)) {
+            match RdmaBufInner::new(self.dev.clone(), self.buf_size, Rc::downgrade(self)) {
                 Ok(inner) => return Ok(RdmaBuf { inner: Some(Box::new(inner)) }),
                 Err(e) => {
                     self.state.borrow_mut().allocated -= 1;

--- a/crates/phenomenal_io/src/rdma/socket.rs
+++ b/crates/phenomenal_io/src/rdma/socket.rs
@@ -103,8 +103,8 @@ impl IbSocket {
             transition_dci(dci.as_ptr(), &dev, qos)
                 .map_err(|e| io::Error::other(format!("transition_dci: {e}")))?;
 
-            let send_bufs = SendBuffers::new(dev.pd.as_ptr(), SEND_BUF_CNT, BUF_SIZE)?;
-            let recv_bufs = RecvBuffers::new(dev.pd.as_ptr(), SEND_BUF_CNT, BUF_SIZE)?;
+            let send_bufs = SendBuffers::new(dev.clone(), SEND_BUF_CNT, BUF_SIZE)?;
+            let recv_bufs = RecvBuffers::new(dev.clone(), SEND_BUF_CNT, BUF_SIZE)?;
 
             let sock = IbSocket {
                 dev, cq, comp_channel, srq, dct, dci,
@@ -130,7 +130,6 @@ impl IbSocket {
             let Some(idx) = self.send_bufs.try_pop() else { break; };
             let n = buf.len().min(bs);
             unsafe {
-                // todo: @arnav revisit memcp here
                 ptr::copy_nonoverlapping(
                     buf.as_ptr(),
                     self.send_bufs.base().slot_ptr(idx),
@@ -251,18 +250,14 @@ impl IbSocket {
     pub(super) fn post_send(
         &self, buf_idx: u32, len: u32, ah: *mut ibv_ah, peer_dct_num: u32, peer_dc_key: u64,
     ) -> io::Result<()> {
-        let prev = self.send_not_signaled.get() + 1;
-        self.send_not_signaled.set(prev);
-        let signal = if prev >= BUF_SIGNAL_BATCH {
-            self.send_not_signaled.set(0);
-            prev
-        } else { 0 };
+        let signal = 1u32;
+        let wr_id = WrId::send(signal).0;
         unsafe {
             let qpx  = ibv_qp_to_qp_ex(self.dci.as_ptr());
             let mqpx = mlx5dv_qp_ex_from_ibv_qp_ex(qpx);
             ibv_wr_start(qpx);
-            (*qpx).wr_id    = WrId::send(signal).0;
-            (*qpx).wr_flags = if signal > 0 { ibv_send_flags::IBV_SEND_SIGNALED.0 as u32 } else { 0 };
+            (*qpx).wr_id    = wr_id;
+            (*qpx).wr_flags = ibv_send_flags::IBV_SEND_SIGNALED.0 as u32;
             ibv_wr_send(qpx);
             ibv_wr_set_sge(qpx, self.send_bufs.base().lkey(),
                            self.send_bufs.base().slot_addr(buf_idx as usize), len);
@@ -465,7 +460,7 @@ fn handle_wc(sock: &IbSocket, wc: &ibv_wc, recv_tx: &mpsc::UnboundedSender<()>) 
         ibv_wc_opcode::IBV_WC_SEND => {
             if status_ok && wr.ty() == WrType::Send {
                 let n = wr.signal_count() as u64;
-                if n > 0 { sock.send_signaled.set(sock.send_signaled.get() + n); }
+                if n > 0 { sock.send_bufs.push(n); }
             }
         }
         ibv_wc_opcode::IBV_WC_RDMA_WRITE | ibv_wc_opcode::IBV_WC_RDMA_READ => {

--- a/crates/phenomenal_io/src/rpc.rs
+++ b/crates/phenomenal_io/src/rpc.rs
@@ -131,6 +131,7 @@ pub struct LocalRdmaEndpoint {
     pub dct_num:    u32,
     pub gid:        [u8; 16],
     pub dc_key:     u64,
+    pub lid:        u16,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/phenomenal_server/src/main.rs
+++ b/crates/phenomenal_server/src/main.rs
@@ -243,8 +243,11 @@ fn create_runtime() -> anyhow::Result<compio::runtime::Runtime> {
         .coop_taskrun(false)
         .taskrun_flag(false);
 
+    // Only cyper's HTTP client initialisation uses compio's asyncify pool (for getaddrinfo).
+    // No other flow should land here. Capped at 1.
+    // TODO: route cyper through compio natively and drop this pool entirely.
     #[cfg(not(target_os = "macos"))]
-    proactor.thread_pool_limit(0);
+    proactor.thread_pool_limit(1);
 
     compio::runtime::RuntimeBuilder::new()
         .with_proactor(proactor)
@@ -402,8 +405,16 @@ async fn run_runtime(
     #[cfg(all(feature = "rdma", target_os = "linux"))]
     let rdma_node: Option<Rc<phenomenal_io::rdma::RdmaNode>> = if let Some((setup, rdma_cfg)) = rdma_pending {
         let mut routing = phenomenal_io::rdma::ClusterRoutingTable::new(cfg.self_id);
-        for ep in endpoint_registry.lock().unwrap().endpoints.iter() {
-            routing.insert(cfg.self_id, ep);
+        loop {
+            let reg = endpoint_registry.lock().unwrap();
+            if reg.complete {
+                for ep in reg.endpoints.iter() {
+                    routing.insert(cfg.self_id, ep);
+                }
+                break;
+            }
+            drop(reg);
+            compio::time::sleep(Duration::from_millis(50)).await;
         }
         let mut remaining: std::collections::HashSet<phenomenal_storage::cluster::NodeId> =
             peer_clients.keys().copied().collect();
@@ -419,7 +430,7 @@ async fn run_runtime(
                         remaining.remove(&peer_id);
                     }
                     Ok(_) => {}
-                    Err(e) => tracing::debug!(?peer_id, "rdma discover retry: {e}"),
+                    Err(_) => {}
                 }
             }
             if !remaining.is_empty() {

--- a/crates/phenomenal_server/src/rdma_server.rs
+++ b/crates/phenomenal_server/src/rdma_server.rs
@@ -77,7 +77,9 @@ async fn handle(
                         sender.dct_num, sender.dc_key,
                         disk_idx, volume, path, offset, length, source,
                     ).await,
-                RdmaRequest::Generic(req) => RdmaResponse::Generic(dispatch(disks, locks, endpoints, req).await),
+                RdmaRequest::Generic(req) => {
+                    RdmaResponse::Generic(dispatch(disks, locks, endpoints, req).await)
+                }
             };
             let body = match encode(&Envelope::Rsp {
                 magic: ENVELOPE_MAGIC, request_id, payload: resp,

--- a/crates/phenomenal_server/src/rpc_server.rs
+++ b/crates/phenomenal_server/src/rpc_server.rs
@@ -442,7 +442,7 @@ fn error_response(status: StatusCode, e: IoError) -> Response {
 /// backend on success, or an `IoError::InvalidArgument` to surface
 /// in the response body when the peer references a disk this node
 /// doesn't own.
-fn disk_at<'a>(
+pub(crate) fn disk_at<'a>(
     disks:    &'a [Rc<dyn StorageBackend>],
     disk_idx: DiskIdx,
 ) -> Result<&'a Rc<dyn StorageBackend>, IoError> {

--- a/vendor/h2/src/proto/streams/prioritize.rs
+++ b/vendor/h2/src/proto/streams/prioritize.rs
@@ -378,7 +378,6 @@ impl Prioritize {
         let span = tracing::trace_span!("assign_connection_capacity", inc);
         let _e = span.enter();
 
-        tracing::warn!(target: "phen_h2", "PHEN_H2_CONN_CREDIT_REFRESH inc={} conn_avail_before={}", inc, self.flow.available().as_size());
         let _res = self.flow.assign_capacity(inc);
         debug_assert!(_res.is_ok());
 
@@ -447,16 +446,12 @@ impl Prioritize {
         }
 
         let conn_available = self.flow.available().as_size();
-        tracing::warn!(target: "phen_h2", "PHEN_H2_TRY_ASSIGN stream={:?} req={} stream_avail={} stream_win={} conn_avail={} additional={}", stream.id, total_requested, stream.send_flow.available().as_size(), stream.send_flow.window_size(), conn_available, additional);
 
         if conn_available > 0 {
             let assign = cmp::min(conn_available, additional);
-            tracing::warn!(target: "phen_h2", "PHEN_H2_ASSIGN stream={:?} assigned={} conn_avail_after={}", stream.id, assign, conn_available - assign);
             stream.assign_capacity(assign, self.max_buffer_size);
             let _res = self.flow.claim_capacity(assign);
             debug_assert!(_res.is_ok());
-        } else {
-            tracing::warn!(target: "phen_h2", "PHEN_H2_STARVED stream={:?} req={} conn_avail=0 STREAM_QUEUED_PENDING_CAPACITY", stream.id, total_requested);
         }
 
         tracing::trace!(
@@ -737,7 +732,6 @@ impl Prioritize {
                             // Zero length data frames always have capacity to
                             // be sent.
                             if sz > 0 && stream_capacity == 0 {
-                                tracing::warn!(target: "phen_h2", "PHEN_H2_SEND_STALL_STREAM_CAP_0 stream={:?} sz={} send_window={} conn_window={}", stream.id, sz, stream.send_flow.window_size(), self.flow.window_size());
                                 tracing::trace!("stream capacity is 0");
 
                                 // Ensure that the stream is waiting for
@@ -770,7 +764,6 @@ impl Prioritize {
                             // scenarios, maybe the window we know is available but the window which
                             // peer knows is not.
                             if len > 0 && len > stream.send_flow.window_size() {
-                                tracing::warn!(target: "phen_h2", "PHEN_H2_SEND_STALL_PEER_WINDOW stream={:?} len={} send_window={}", stream.id, len, stream.send_flow.window_size());
                                 stream.pending_send.push_front(buffer, frame.into());
                                 continue;
                             }

--- a/vendor/h2/src/proto/streams/recv.rs
+++ b/vendor/h2/src/proto/streams/recv.rs
@@ -443,12 +443,9 @@ impl Recv {
         debug_assert!(_res.is_ok());
 
         if self.flow.unclaimed_capacity().is_some() {
-            tracing::warn!(target: "phen_h2", "PHEN_H2_CONN_RELEASE_ENQUEUE cap={} unclaimed={:?} task_present={}", capacity, self.flow.unclaimed_capacity(), task.is_some());
             if let Some(task) = task.take() {
                 task.wake();
             }
-        } else {
-            tracing::warn!(target: "phen_h2", "PHEN_H2_CONN_RELEASE_NO_ENQUEUE cap={}", capacity);
         }
     }
 
@@ -476,14 +473,11 @@ impl Recv {
         debug_assert!(_res.is_ok());
 
         if stream.recv_flow.unclaimed_capacity().is_some() {
-            tracing::warn!(target: "phen_h2", "PHEN_H2_RELEASE_CAP_ENQUEUE stream={:?} cap={} unclaimed={:?} task_present={}", stream.id, capacity, stream.recv_flow.unclaimed_capacity(), task.is_some());
             self.pending_window_updates.push(stream);
 
             if let Some(task) = task.take() {
                 task.wake();
             }
-        } else {
-            tracing::warn!(target: "phen_h2", "PHEN_H2_RELEASE_CAP_NO_ENQUEUE stream={:?} cap={} unclaimed=None", stream.id, capacity);
         }
 
         Ok(())
@@ -750,8 +744,6 @@ impl Recv {
 
         let event = Event::Data(frame.into_payload());
 
-        let payload_len = match &event { Event::Data(p) => p.len(), _ => 0 };
-        tracing::warn!(target: "phen_h2", "PHEN_H2_RECV_DATA stream={:?} len={} pushing_to_pending_recv", stream.id, payload_len);
         stream.pending_recv.push_back(&mut self.buffer, event);
         stream.notify_recv();
 
@@ -1107,9 +1099,7 @@ impl Recv {
         T: AsyncWrite + Unpin,
         B: Buf,
     {
-        tracing::warn!(target: "phen_h2", "PHEN_H2_SCWU_ENTER unclaimed={:?}", self.flow.unclaimed_capacity());
         if let Some(incr) = self.flow.unclaimed_capacity() {
-            tracing::warn!(target: "phen_h2", "PHEN_H2_SEND_CONN_WINDOW_UPDATE incr={}", incr);
             let frame = frame::WindowUpdate::new(StreamId::zero(), incr);
 
             // Ensure the codec has capacity
@@ -1140,18 +1130,13 @@ impl Recv {
         T: AsyncWrite + Unpin,
         B: Buf,
     {
-        let _q_empty = self.pending_window_updates.is_empty();
-        tracing::warn!(target: "phen_h2", "PHEN_H2_SSWU_ENTER queue_empty_before={}", _q_empty);
-        let mut _sent_count = 0u32;
         loop {
             // Ensure the codec has capacity
             match dst.poll_ready(cx) {
                 Poll::Pending => {
-                    tracing::warn!(target: "phen_h2", "PHEN_H2_SSWU_CODEC_PENDING queue_remaining_nonempty={} sent_this_call={}", if self.pending_window_updates.is_empty() { 0u32 } else { 1u32 }, _sent_count);
                     return Poll::Pending;
                 }
                 Poll::Ready(Err(e)) => {
-                    tracing::warn!(target: "phen_h2", "PHEN_H2_SSWU_CODEC_ERR sent_this_call={}", _sent_count);
                     return Poll::Ready(Err(e));
                 }
                 Poll::Ready(Ok(())) => {}
@@ -1161,11 +1146,9 @@ impl Recv {
             let stream = match self.pending_window_updates.pop(store) {
                 Some(stream) => stream,
                 None => {
-                    tracing::warn!(target: "phen_h2", "PHEN_H2_SSWU_DRAINED sent_this_call={}", _sent_count);
                     return Poll::Ready(Ok(()));
                 }
             };
-            _sent_count += 1;
 
             counts.transition(stream, |_, stream| {
                 tracing::trace!("pending_window_updates -- pop; stream={:?}", stream.id);
@@ -1183,7 +1166,6 @@ impl Recv {
 
                 // TODO: de-dup
                 if let Some(incr) = stream.recv_flow.unclaimed_capacity() {
-                    tracing::warn!(target: "phen_h2", "PHEN_H2_SEND_WINDOW_UPDATE stream={:?} incr={}", stream.id, incr);
                     let frame = frame::WindowUpdate::new(stream.id, incr);
                     dst.buffer(frame.into())
                         .expect("invalid WINDOW_UPDATE frame");
@@ -1207,9 +1189,8 @@ impl Recv {
         cx: &Context,
         stream: &mut Stream,
     ) -> Poll<Option<Result<Bytes, proto::Error>>> {
-        tracing::warn!(target: "phen_h2", "PHEN_H2_POLL_DATA_ENTER stream={:?}", stream.id);
         match stream.pending_recv.pop_front(&mut self.buffer) {
-            Some(Event::Data(payload)) => { tracing::warn!(target: "phen_h2", "PHEN_H2_POLL_DATA_GOT stream={:?} len={}", stream.id, payload.len()); Poll::Ready(Some(Ok(payload))) },
+            Some(Event::Data(payload)) => Poll::Ready(Some(Ok(payload))),
             Some(event) => {
                 // Frame is trailer
                 stream.pending_recv.push_front(&mut self.buffer, event);
@@ -1254,11 +1235,9 @@ impl Recv {
         stream: &mut Stream,
     ) -> Poll<Option<Result<T, proto::Error>>> {
         if stream.state.ensure_recv_open()? {
-            tracing::warn!(target: "phen_h2", "PHEN_H2_PARK stream={:?} state={:?} pending_recv_empty=true", stream.id, stream.state);
             stream.recv_task = Some(cx.waker().clone());
             Poll::Pending
         } else {
-            tracing::warn!(target: "phen_h2", "PHEN_H2_PARK_CLOSED stream={:?}", stream.id);
             Poll::Ready(None)
         }
     }

--- a/vendor/h2/src/proto/streams/stream.rs
+++ b/vendor/h2/src/proto/streams/stream.rs
@@ -372,10 +372,7 @@ impl Stream {
 
     pub fn notify_recv(&mut self) {
         if let Some(task) = self.recv_task.take() {
-            tracing::warn!(target: "phen_h2", "PHEN_H2_WAKE stream={:?} waker_was_stored=true", self.id);
             task.wake();
-        } else {
-            tracing::warn!(target: "phen_h2", "PHEN_H2_WAKE_MISS stream={:?} no_waker_stored data_may_be_buffered", self.id);
         }
     }
 


### PR DESCRIPTION
  - IbSocket::send returned Ok(0) when send_bufs.try_pop was None and the caller treated it as success, while the slot return path depended on a peer ACK that was never reached. The pool drained monotonically and
  inter node traffic wedged at high concurrency.
  - Push the slot back to send_bufs directly from the SEND work completion handler so every signalled WR replenishes credit independent of any ACK protocol. Force signal=1 on every post_send so the accounting is
  per WR.
  - Bump SEND_BUF_CNT from 32 to 64 within the HCA ICM ceiling for burst headroom on 120 runtimes per node.
  - Carries misc fixes: peer lid plumbed through PeerEndpoint / routing / RPC so AH cache uses the peer LID instead of the local one, Rc<IbDevice> held by MR owning structs to keep the PD alive past ibv_dereg_mr on
  drop, bindgen blocklist for mlx5dv_context_attr to build against newer ibverbs headers, and vendor/h2 + discovery cleanup.