### PR TITLE
Implement cluster-wide scrub command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +357,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -471,6 +483,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -899,6 +917,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,7 +982,7 @@ name = "cyper"
 version = "0.8.3"
 dependencies = [
  "async-stream",
- "base64",
+ "base64 0.22.1",
  "cfg-if",
  "compio",
  "cyper-core",
@@ -1144,6 +1180,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -1386,6 +1432,20 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "crossbeam-channel",
+ "flate2",
+ "nom",
+ "num-traits",
+]
 
 [[package]]
 name = "heck"
@@ -1946,6 +2006,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,13 +2108,29 @@ name = "openlake_cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-runtime-api",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
  "clap",
  "compio",
  "cyper",
+ "cyper-axum",
+ "futures",
  "futures-util",
+ "hdrhistogram",
+ "http 1.4.0",
+ "libc",
  "openlake_io",
  "openlake_storage",
+ "percent-encoding",
+ "quick-xml",
+ "rdma-mummy-sys",
  "serde",
+ "serde_json",
+ "sha2",
  "toml",
  "tracing-subscriber",
 ]
@@ -2056,7 +2142,7 @@ dependencies = [
  "aligned-vec",
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bincode",
  "bindgen 0.71.1",
  "bytes",
@@ -2095,7 +2181,7 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-runtime-api",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "clap",
  "compio",
@@ -2136,7 +2222,7 @@ name = "openlake_storage"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "blake3",
  "bytes",
  "compio",
@@ -2194,7 +2280,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2797,6 +2883,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,6 +2040,7 @@ dependencies = [
  "anyhow",
  "clap",
  "compio",
+ "cyper",
  "futures-util",
  "openlake_io",
  "openlake_storage",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,3 +20,4 @@ tracing-subscriber = { workspace = true }
 serde              = { workspace = true }
 toml               = { workspace = true }
 futures-util       = { workspace = true }
+cyper              = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,3 +21,25 @@ serde              = { workspace = true }
 toml               = { workspace = true }
 futures-util       = { workspace = true }
 cyper              = { workspace = true }
+cyper-axum         = { workspace = true }
+axum               = { workspace = true }
+bytes              = { workspace = true }
+futures            = { workspace = true }
+quick-xml          = { workspace = true }
+base64             = { workspace = true }
+sha2               = { workspace = true }
+percent-encoding   = "2"
+
+# SigV4 signing for the admin /ping liveness probe. Mirrors the server's
+# verifier so signatures the CLI produces are accepted by the S3 listener.
+http                   = { workspace = true }
+aws-sigv4              = { workspace = true }
+aws-credential-types    = { workspace = true }
+aws-smithy-runtime-api  = { workspace = true }
+
+hdrhistogram = "7"
+libc         = "0.2"
+
+# RDMA bench path. Only pulled in when --features rdma.
+rdma-mummy-sys = { version = "0.2", optional = true }
+serde_json     = { workspace = true, optional = true }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,5 +1,8 @@
+pub mod bench;
 pub mod cluster;
+pub mod disk;
 pub mod scrub;
+pub mod version;
 
 use anyhow::Result;
 use clap::Subcommand;
@@ -9,13 +12,24 @@ pub enum Cmd {
     /// Cluster lifecycle and inspection.
     Cluster(cluster::Args),
 
-    /// Run scrub operation.
+    /// Disk inspection commands.
+    Disk(disk::Args),
+
+    /// Fabric microbench.
+    Bench(bench::Args),
+
+    /// Delete all objects through the public S3 endpoint.
     Scrub(scrub::ScrubArgs),
+
+    Version(version::VersionArgs),
 }
 
 pub async fn dispatch(cmd: Cmd) -> Result<()> {
     match cmd {
         Cmd::Cluster(a) => cluster::run(a).await,
+        Cmd::Disk(a) => disk::run(a).await,
+        Cmd::Bench(a) => bench::run(a).await,
         Cmd::Scrub(a) => scrub::run(a).await,
+        Cmd::Version(a) => version::run(a).await,
     }
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod cluster;
+pub mod scrub;
 
 use anyhow::Result;
 use clap::Subcommand;
@@ -7,10 +8,14 @@ use clap::Subcommand;
 pub enum Cmd {
     /// Cluster lifecycle and inspection.
     Cluster(cluster::Args),
+
+    /// Run scrub operation.
+    Scrub(scrub::ScrubArgs),
 }
 
 pub async fn dispatch(cmd: Cmd) -> Result<()> {
     match cmd {
         Cmd::Cluster(a) => cluster::run(a).await,
+        Cmd::Scrub(a) => scrub::run(a).await,
     }
 }

--- a/cli/src/commands/scrub.rs
+++ b/cli/src/commands/scrub.rs
@@ -1,0 +1,62 @@
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+use std::path::PathBuf;
+
+use crate::config;
+
+#[derive(ClapArgs)]
+pub struct ScrubArgs {
+    /// Cluster TOML. One TOML describes exactly one cluster.
+    #[arg(long)]
+    pub config: PathBuf,
+}
+
+pub async fn run(args: ScrubArgs) -> Result<()> {
+    let cfg = config::load(&args.config)
+        .with_context(|| format!("load {}", args.config.display()))?;
+
+    if cfg.nodes.is_empty() {
+        println!("no openlake cluster detected: {} declares zero nodes", args.config.display());
+        return Ok(());
+    }
+
+    let mut last_err: Option<anyhow::Error> = None;
+    for node in &cfg.nodes {
+        let url = format!("http://{}/v1/rpc", node.rpc_addr);
+        let client = cyper::Client::builder().http2_prior_knowledge().build();
+        let req = openlake_io::rpc::Request::ScrubCluster;
+        let body = openlake_io::rpc::encode(&req).map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let resp = match client.post(&url)?.body(body).send().await {
+            Ok(resp) => resp,
+            Err(e) => {
+                last_err = Some(anyhow::anyhow!("node {}: {}", node.id, e));
+                continue;
+            }
+        };
+        let status = resp.status();
+        let bytes = resp.bytes().await.map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        if !status.is_success() {
+            if let Ok(openlake_io::rpc::Response::Err(e)) = openlake_io::rpc::decode(&bytes) {
+                last_err = Some(anyhow::anyhow!("node {}: rpc error: {:?}", node.id, e));
+                continue;
+            }
+            last_err = Some(anyhow::anyhow!("node {}: rpc HTTP status: {}", node.id, status));
+            continue;
+        }
+        match openlake_io::rpc::decode::<openlake_io::rpc::Response>(&bytes)
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?
+        {
+            openlake_io::rpc::Response::Scrub(n) => {
+                println!("purged {} objects", n);
+                return Ok(());
+            }
+            openlake_io::rpc::Response::Err(e) => {
+                last_err = Some(anyhow::anyhow!("node {}: rpc error: {:?}", node.id, e));
+            }
+            other => {
+                last_err = Some(anyhow::anyhow!("node {}: unexpected rpc response: {:?}", node.id, other));
+            }
+        }
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("no openlake cluster node responded")))
+}

--- a/cli/src/commands/scrub.rs
+++ b/cli/src/commands/scrub.rs
@@ -1,10 +1,26 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
+use aws_credential_types::Credentials;
+use aws_sigv4::http_request::{
+    sign, PayloadChecksumKind, PercentEncodingMode, SessionTokenMode, SignableBody,
+    SignableRequest, SigningSettings, UriPathNormalizationMode,
+};
+use aws_sigv4::sign::v4;
+use aws_smithy_runtime_api::client::identity::Identity;
+use base64::Engine as _;
 use clap::Args as ClapArgs;
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+use quick_xml::{de::from_str as xml_from_str, se::to_string as xml_to_string};
+use serde::{Deserialize, Serialize};
+use sha2::Digest as _;
+use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::time::SystemTime;
 
-use openlake_io::rpc::{self, Request, Response};
+use openlake_io::SYSTEM_BUCKET;
+use openlake_server::config::{Config, Credential};
 
-use crate::config;
+const LIST_PAGE_SIZE: u32 = 1000;
+const SAMPLE_LIMIT: usize = 10;
 
 #[derive(ClapArgs)]
 pub struct ScrubArgs {
@@ -18,202 +34,501 @@ pub struct ScrubArgs {
 }
 
 pub async fn run(args: ScrubArgs) -> Result<()> {
-    let cfg = config::load(&args.config)
-        .with_context(|| format!("load {}", args.config.display()))?;
+    let text = std::fs::read_to_string(&args.config)
+        .with_context(|| format!("read {}", args.config.display()))?;
+    let cfg =
+        Config::from_toml(&text).with_context(|| format!("parse {}", args.config.display()))?;
 
     if cfg.nodes.is_empty() {
-        println!("No running cluster detected. Run: openlake cluster up");
+        println!(
+            "no openlake cluster detected: {} declares zero nodes",
+            args.config.display()
+        );
+        return Ok(());
+    }
+
+    let node = cfg
+        .nodes
+        .iter()
+        .find(|n| n.id == cfg.self_id)
+        .context("self_id node missing from config")?;
+    let s3_port = cfg.s3_port.unwrap_or_else(|| cfg.s3_addr.port());
+    let scheme = if cfg.s3_tls.is_some() {
+        "https"
+    } else {
+        "http"
+    };
+    let endpoint = SocketAddr::new(node.rpc_addr.ip(), s3_port);
+    let base_url = format!("{scheme}://{endpoint}");
+    let client = cyper::Client::new();
+    let credential = cfg
+        .credentials
+        .first()
+        .context("at least one credential is required")?
+        .clone();
+
+    println!("using S3 endpoint on node {}: {}", node.id, base_url);
+
+    let buckets =
+        list_bucket_names(&client, &base_url, &cfg.region, &credential, SYSTEM_BUCKET).await?;
+
+    if buckets.is_empty() {
+        println!("no buckets discovered through the public S3 endpoint");
         return Ok(());
     }
 
     if args.dry_run {
-        let client = cyper::Client::builder().http2_prior_knowledge().build();
-        run_dry_run(&cfg.nodes, &client).await?;
+        run_dry_run(&client, &base_url, &cfg.region, &credential, &buckets).await?;
         return Ok(());
     }
 
-    let mut last_err: Option<anyhow::Error> = None;
-    for node in &cfg.nodes {
-        let url = format!("http://{}/v1/rpc", node.rpc_addr);
-        let client = cyper::Client::builder().http2_prior_knowledge().build();
-        let req = Request::ScrubCluster;
-        let body = rpc::encode(&req).map_err(|e| anyhow::anyhow!(e.to_string()))?;
-        let resp = match client.post(&url)?.body(body).send().await {
-            Ok(resp) => resp,
-            Err(e) => {
-                last_err = Some(anyhow::anyhow!("node {}: {}", node.id, e));
-                continue;
-            }
-        };
-        let status = resp.status();
-        let bytes = resp.bytes().await.map_err(|e| anyhow::anyhow!(e.to_string()))?;
-        if !status.is_success() {
-            if let Ok(Response::Err(e)) = rpc::decode(&bytes) {
-                last_err = Some(anyhow::anyhow!("node {}: rpc error: {:?}", node.id, e));
-                continue;
-            }
-            last_err = Some(anyhow::anyhow!("node {}: rpc HTTP status: {}", node.id, status));
-            continue;
-        }
-        match rpc::decode::<Response>(&bytes).map_err(|e| anyhow::anyhow!(e.to_string()))? {
-            Response::Scrub(n) => {
-                println!("purged {} objects", n);
-                return Ok(());
-            }
-            Response::Err(e) => {
-                last_err = Some(anyhow::anyhow!("node {}: rpc error: {:?}", node.id, e));
-            }
-            other => {
-                last_err = Some(anyhow::anyhow!("node {}: unexpected rpc response: {:?}", node.id, other));
-            }
-        }
+    let mut total_deleted = 0usize;
+    for bucket in &buckets {
+        let deleted = scrub_bucket(&client, &base_url, &cfg.region, &credential, bucket).await?;
+        total_deleted += deleted;
+        println!("purged {} objects from {}", deleted, bucket);
     }
-    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("no openlake cluster node responded")))
+
+    println!("purged {} objects total", total_deleted);
+    Ok(())
 }
 
-async fn run_dry_run(nodes: &[config::NodeToml], client: &cyper::Client) -> Result<()> {
-    println!(
-        "WARNING: This operation will delete all objects and may take several minutes."
-    );
+async fn run_dry_run(
+    client: &cyper::Client,
+    base_url: &str,
+    region: &str,
+    credential: &Credential,
+    buckets: &[String],
+) -> Result<()> {
+    println!("WARNING: This operation will delete all objects and may take several minutes.");
     println!("Dry run: no objects will be deleted.");
-    println!("Cluster ID: unavailable from current RPC API.");
-    println!("Deployment ID: unavailable from current RPC API.");
-    println!("Cluster nodes: {}", nodes.len());
+    println!("Cluster nodes: 1");
 
-    for node in nodes {
-        println!("Node {}: {}", node.id, node.rpc_addr);
-        match query_node_buckets(node, client).await {
-            Ok(summary) => {
-                if summary.buckets.is_empty() {
-                    println!("  buckets: none detected");
-                    continue;
-                }
-                println!("  buckets: {}", summary.buckets.join(", "));
-                println!("  object count: {}", summary.total_objects);
-                for bucket in &summary.bucket_counts {
-                    println!("    {}: {} objects", bucket.0, bucket.1);
-                }
-                if !summary.sample_objects.is_empty() {
-                    println!("  sample deletions:");
-                    for key in &summary.sample_objects {
-                        println!("    {}", key);
-                    }
-                }
-            }
-            Err(e) => {
-                println!("  error querying node: {e}");
+    let mut total_objects = 0usize;
+    for bucket in buckets {
+        let summary = summarize_bucket(client, base_url, region, credential, bucket).await?;
+        total_objects += summary.total_objects;
+        println!("bucket {}: {} objects", bucket, summary.total_objects);
+        if !summary.sample_objects.is_empty() {
+            println!("  sample deletions:");
+            for key in &summary.sample_objects {
+                println!("    {}", key);
             }
         }
     }
 
-    println!("Bucket information: buckets above were discovered from node RPC.");
-    println!("Would delete: all objects from all buckets.");
+    println!("Bucket information was discovered from the public S3 endpoint.");
+    println!(
+        "Would delete: {} objects across {} buckets.",
+        total_objects,
+        buckets.len()
+    );
     Ok(())
 }
 
 struct BucketSummary {
-    buckets: Vec<String>,
     total_objects: usize,
-    bucket_counts: Vec<(String, usize)>,
     sample_objects: Vec<String>,
 }
 
-async fn query_node_buckets(node: &config::NodeToml, client: &cyper::Client) -> Result<BucketSummary> {
-    let buckets = list_buckets(node, client).await?;
-    let mut total_objects = 0;
-    let mut bucket_counts = Vec::new();
+async fn summarize_bucket(
+    client: &cyper::Client,
+    base_url: &str,
+    region: &str,
+    credential: &Credential,
+    bucket: &str,
+) -> Result<BucketSummary> {
+    let mut total_objects = 0usize;
     let mut sample_objects = Vec::new();
+    let mut continuation_token: Option<String> = None;
 
-    for bucket in buckets.iter() {
-        let (count, sample) = count_bucket_objects(node, client, bucket).await?;
-        total_objects += count;
-        bucket_counts.push((bucket.clone(), count));
-        sample_objects.extend(sample.into_iter());
-        if sample_objects.len() >= 10 {
-            sample_objects.truncate(10);
+    loop {
+        let page = list_objects_v2(
+            client,
+            base_url,
+            region,
+            credential,
+            bucket,
+            None,
+            continuation_token.as_deref(),
+            LIST_PAGE_SIZE,
+        )
+        .await?;
+
+        total_objects += page.contents.len();
+        for obj in &page.contents {
+            if sample_objects.len() < SAMPLE_LIMIT {
+                sample_objects.push(obj.key.clone());
+            }
         }
+
+        if !page.is_truncated {
+            break;
+        }
+        continuation_token = page.next_continuation_token;
     }
 
     Ok(BucketSummary {
-        buckets,
         total_objects,
-        bucket_counts,
         sample_objects,
     })
 }
 
-async fn list_buckets(node: &config::NodeToml, client: &cyper::Client) -> Result<Vec<String>> {
-    let response = rpc_call(node, client, Request::ListVols { disk_idx: 0 }).await?;
-    match response {
-        Response::Vols(vols) => Ok(vols.into_iter().map(|v| v.name).collect()),
-        Response::Err(e) => Err(anyhow::anyhow!("node {}: rpc error: {:?}", node.id, e)),
-        other => Err(anyhow::anyhow!("node {}: unexpected rpc response: {:?}", node.id, other)),
-    }
-}
-
-async fn count_bucket_objects(
-    node: &config::NodeToml,
+async fn scrub_bucket(
     client: &cyper::Client,
+    base_url: &str,
+    region: &str,
+    credential: &Credential,
     bucket: &str,
-) -> Result<(usize, Vec<String>)> {
-    let mut total: usize = 0;
-    let mut sample = Vec::new();
-    let mut start_after: Option<String> = None;
-    const PAGE_SIZE: u32 = 1000;
+) -> Result<usize> {
+    let mut deleted = 0usize;
+    let mut continuation_token: Option<String> = None;
 
     loop {
-        let response = rpc_call(node, client, Request::WalkDir {
-            disk_idx: 0,
-            volume: bucket.to_owned(),
-            base_dir: "".into(),
-            recursive: true,
-            prefix_filter: "".into(),
-            start_after: start_after.clone(),
-            max_keys: Some(PAGE_SIZE),
-        })
+        let page = list_objects_v2(
+            client,
+            base_url,
+            region,
+            credential,
+            bucket,
+            None,
+            continuation_token.as_deref(),
+            LIST_PAGE_SIZE,
+        )
         .await?;
 
-        let entries = match response {
-            Response::Walked(entries) => entries,
-            Response::Err(e) => return Err(anyhow::anyhow!("node {}: rpc error: {:?}", node.id, e)),
-            other => return Err(anyhow::anyhow!("node {}: unexpected rpc response: {:?}", node.id, other)),
-        };
-
-        if entries.is_empty() {
-            break;
+        let keys: Vec<String> = page.contents.into_iter().map(|obj| obj.key).collect();
+        if !keys.is_empty() {
+            delete_objects(client, base_url, region, credential, bucket, &keys).await?;
+            deleted += keys.len();
         }
 
-        total += entries.len();
-        for (key, _) in entries.iter() {
-            if sample.len() < 10 {
-                sample.push(key.clone());
+        if !page.is_truncated {
+            break;
+        }
+        continuation_token = page.next_continuation_token;
+    }
+
+    Ok(deleted)
+}
+
+async fn list_bucket_names(
+    client: &cyper::Client,
+    base_url: &str,
+    region: &str,
+    credential: &Credential,
+    system_bucket: &str,
+) -> Result<Vec<String>> {
+    let mut buckets = Vec::new();
+    let mut continuation_token: Option<String> = None;
+
+    loop {
+        let page = list_objects_v2(
+            client,
+            base_url,
+            region,
+            credential,
+            system_bucket,
+            Some("buckets/"),
+            continuation_token.as_deref(),
+            LIST_PAGE_SIZE,
+        )
+        .await?;
+
+        for obj in page.contents {
+            if let Some(bucket) = bucket_name_from_meta_key(&obj.key) {
+                if bucket != system_bucket {
+                    buckets.push(bucket.to_owned());
+                }
             }
         }
 
-        if entries.len() < PAGE_SIZE as usize {
+        if !page.is_truncated {
             break;
         }
-
-        start_after = entries.last().map(|(k, _)| k.clone());
+        continuation_token = page.next_continuation_token;
     }
 
-    Ok((total, sample))
+    buckets.sort();
+    buckets.dedup();
+    Ok(buckets)
 }
 
-async fn rpc_call(node: &config::NodeToml, client: &cyper::Client, req: Request) -> Result<Response> {
-    let url = format!("http://{}/v1/rpc", node.rpc_addr);
-    let body = rpc::encode(&req).map_err(|e| anyhow::anyhow!(e.to_string()))?;
-    let resp = client.post(&url)?.body(body).send().await.map_err(|e| anyhow::anyhow!("node {}: {}", node.id, e))?;
-    let status = resp.status();
-    let bytes = resp.bytes().await.map_err(|e| anyhow::anyhow!(e.to_string()))?;
+fn bucket_name_from_meta_key(key: &str) -> Option<&str> {
+    key.strip_prefix("buckets/")?.strip_suffix("/.metadata.bin")
+}
+
+async fn list_objects_v2(
+    client: &cyper::Client,
+    base_url: &str,
+    region: &str,
+    credential: &Credential,
+    bucket: &str,
+    prefix: Option<&str>,
+    continuation_token: Option<&str>,
+    max_keys: u32,
+) -> Result<ListBucketResult> {
+    let url = build_list_url(base_url, bucket, prefix, continuation_token, max_keys);
+    let headers = sign_request(
+        "GET",
+        &url,
+        credential,
+        region,
+        &[],
+        SignableBody::UnsignedPayload,
+    )?;
+
+    let response = client
+        .get(&url)
+        .with_context(|| format!("build GET {}", url))?
+        .headers(headers)
+        .send()
+        .await
+        .with_context(|| format!("send GET {}", url))?;
+
+    let status = response.status();
+    let bytes = response.bytes().await.context("read list response body")?;
+    let body = std::str::from_utf8(&bytes).context("list response was not UTF-8")?;
 
     if !status.is_success() {
-        if let Ok(Response::Err(e)) = rpc::decode(&bytes) {
-            return Err(anyhow::anyhow!("node {}: rpc error: {:?}", node.id, e));
-        }
-        return Err(anyhow::anyhow!("node {}: rpc HTTP status: {}", node.id, status));
+        return Err(anyhow!("list {} failed: {}: {}", bucket, status, body));
     }
 
-    let response = rpc::decode::<Response>(&bytes).map_err(|e| anyhow::anyhow!(e.to_string()))?;
-    Ok(response)
+    let parsed: ListBucketResult = xml_from_str(body).context("parse ListBucketResult")?;
+    Ok(parsed)
+}
+
+async fn delete_objects(
+    client: &cyper::Client,
+    base_url: &str,
+    region: &str,
+    credential: &Credential,
+    bucket: &str,
+    keys: &[String],
+) -> Result<()> {
+    let url = format!("{base_url}/{bucket}?delete");
+    let body = xml_to_string(&DeleteRequest {
+        quiet: Some(true),
+        objects: keys
+            .iter()
+            .map(|key| DeleteRequestObject { key: key.clone() })
+            .collect(),
+    })
+    .context("encode DeleteObjects XML")?;
+
+    let checksum = sha256_base64(body.as_bytes());
+    let headers = sign_request(
+        "POST",
+        &url,
+        credential,
+        region,
+        &[("x-amz-checksum-sha256", checksum.as_str())],
+        SignableBody::UnsignedPayload,
+    )?;
+
+    let response = client
+        .post(&url)
+        .with_context(|| format!("build POST {}", url))?
+        .headers(headers)
+        .body(body)
+        .send()
+        .await
+        .with_context(|| format!("send POST {}", url))?;
+
+    let status = response.status();
+    let bytes = response
+        .bytes()
+        .await
+        .context("read delete response body")?;
+    let body = std::str::from_utf8(&bytes).context("delete response was not UTF-8")?;
+
+    if !status.is_success() {
+        return Err(anyhow!("delete {} failed: {}: {}", bucket, status, body));
+    }
+
+    let parsed: DeleteResult = xml_from_str(body).context("parse DeleteResult")?;
+    if let Some(err) = parsed.errors.into_iter().next() {
+        return Err(anyhow!(
+            "delete {} failed for {}: {} ({})",
+            bucket,
+            err.key,
+            err.message,
+            err.code
+        ));
+    }
+
+    Ok(())
+}
+
+fn build_list_url(
+    base_url: &str,
+    bucket: &str,
+    prefix: Option<&str>,
+    continuation_token: Option<&str>,
+    max_keys: u32,
+) -> String {
+    let mut params = vec!["list-type=2".to_owned(), format!("max-keys={max_keys}")];
+    if let Some(prefix) = prefix {
+        params.push(format!("prefix={}", encode_query_value(prefix)));
+    }
+    if let Some(token) = continuation_token {
+        params.push(format!("continuation-token={}", encode_query_value(token)));
+    }
+    format!("{base_url}/{bucket}?{}", params.join("&"))
+}
+
+fn encode_query_value(value: &str) -> String {
+    utf8_percent_encode(value, NON_ALPHANUMERIC).to_string()
+}
+
+fn sha256_base64(bytes: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(sha2::Sha256::digest(bytes))
+}
+
+fn sign_request(
+    method: &str,
+    url: &str,
+    credential: &Credential,
+    region: &str,
+    extra_headers: &[(&str, &str)],
+    body: SignableBody<'static>,
+) -> Result<http::HeaderMap> {
+    let identity: Identity = Credentials::new(
+        &credential.access_key,
+        &credential.secret_key,
+        None,
+        None,
+        "openlake-cli",
+    )
+    .into();
+
+    let mut settings = SigningSettings::default();
+    settings.percent_encoding_mode = PercentEncodingMode::Single;
+    settings.payload_checksum_kind = PayloadChecksumKind::XAmzSha256;
+    settings.uri_path_normalization_mode = UriPathNormalizationMode::Disabled;
+    settings.session_token_mode = SessionTokenMode::Include;
+
+    let params = v4::SigningParams::builder()
+        .identity(&identity)
+        .region(region)
+        .name("s3")
+        .time(SystemTime::now())
+        .settings(settings)
+        .build()
+        .map_err(|e| anyhow!("build signing params: {e}"))?;
+
+    let mut headers: Vec<(&str, &str)> = vec![("host", host_from_url(url))];
+    headers.extend_from_slice(extra_headers);
+
+    let signable = SignableRequest::new(method, url, headers.iter().copied(), body)
+        .map_err(|e| anyhow!("build signable request: {e}"))?;
+
+    let (instructions, _signature) = sign(signable, &params.into())
+        .map_err(|e| anyhow!("sign request: {e}"))?
+        .into_parts();
+
+    let mut request = http::Request::builder()
+        .method(method)
+        .uri(url)
+        .header(http::header::HOST, host_from_url(url))
+        .body(())
+        .map_err(|e| anyhow!("build request: {e}"))?;
+    for (name, value) in extra_headers {
+        request.headers_mut().insert(
+            *name,
+            http::HeaderValue::from_str(value).map_err(|e| anyhow!("header {name}: {e}"))?,
+        );
+    }
+    instructions.apply_to_request_http1x(&mut request);
+
+    let mut signed_headers = request.headers().clone();
+    signed_headers.remove(http::header::HOST);
+    Ok(signed_headers)
+}
+
+fn host_from_url(url: &str) -> &str {
+    url.split_once("//")
+        .and_then(|(_, rest)| rest.split_once('/').map(|(host, _)| host))
+        .unwrap_or(url)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename = "ListBucketResult")]
+struct ListBucketResult {
+    #[serde(rename = "@xmlns", default)]
+    _xmlns: Option<String>,
+    #[serde(rename = "Name")]
+    _name: String,
+    #[serde(rename = "KeyCount", default)]
+    _key_count: Option<u32>,
+    #[serde(rename = "MaxKeys", default)]
+    _max_keys: Option<u32>,
+    #[serde(rename = "IsTruncated")]
+    is_truncated: bool,
+    #[serde(rename = "NextContinuationToken", default)]
+    next_continuation_token: Option<String>,
+    #[serde(rename = "Contents", default)]
+    contents: Vec<ListBucketObject>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename = "Contents")]
+struct ListBucketObject {
+    #[serde(rename = "Key")]
+    key: String,
+    #[serde(rename = "LastModified", default)]
+    _last_modified: Option<String>,
+    #[serde(rename = "ETag", default)]
+    _etag: Option<String>,
+    #[serde(rename = "Size", default)]
+    _size: Option<u64>,
+    #[serde(rename = "StorageClass", default)]
+    _storage_class: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename = "Delete")]
+struct DeleteRequest {
+    #[serde(rename = "Quiet", skip_serializing_if = "Option::is_none")]
+    quiet: Option<bool>,
+    #[serde(rename = "Object")]
+    objects: Vec<DeleteRequestObject>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename = "Object")]
+struct DeleteRequestObject {
+    #[serde(rename = "Key")]
+    key: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename = "DeleteResult")]
+struct DeleteResult {
+    #[serde(rename = "Deleted", default)]
+    _deleted: Vec<DeletedEntry>,
+    #[serde(rename = "Error", default)]
+    errors: Vec<DeleteError>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename = "Deleted")]
+struct DeletedEntry {
+    #[serde(rename = "Key")]
+    _key: String,
+    #[serde(rename = "VersionId", default)]
+    _version_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename = "Error")]
+struct DeleteError {
+    #[serde(rename = "Key")]
+    key: String,
+    #[serde(rename = "VersionId", default)]
+    _version_id: Option<String>,
+    #[serde(rename = "Code")]
+    code: String,
+    #[serde(rename = "Message")]
+    message: String,
 }

--- a/cli/src/commands/scrub.rs
+++ b/cli/src/commands/scrub.rs
@@ -2,6 +2,8 @@ use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use std::path::PathBuf;
 
+use openlake_io::rpc::{self, Request, Response};
+
 use crate::config;
 
 #[derive(ClapArgs)]
@@ -9,6 +11,10 @@ pub struct ScrubArgs {
     /// Cluster TOML. One TOML describes exactly one cluster.
     #[arg(long)]
     pub config: PathBuf,
+
+    /// Show what would be deleted without performing deletion.
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 pub async fn run(args: ScrubArgs) -> Result<()> {
@@ -16,7 +22,13 @@ pub async fn run(args: ScrubArgs) -> Result<()> {
         .with_context(|| format!("load {}", args.config.display()))?;
 
     if cfg.nodes.is_empty() {
-        println!("no openlake cluster detected: {} declares zero nodes", args.config.display());
+        println!("No running cluster detected. Run: openlake cluster up");
+        return Ok(());
+    }
+
+    if args.dry_run {
+        let client = cyper::Client::builder().http2_prior_knowledge().build();
+        run_dry_run(&cfg.nodes, &client).await?;
         return Ok(());
     }
 
@@ -24,8 +36,8 @@ pub async fn run(args: ScrubArgs) -> Result<()> {
     for node in &cfg.nodes {
         let url = format!("http://{}/v1/rpc", node.rpc_addr);
         let client = cyper::Client::builder().http2_prior_knowledge().build();
-        let req = openlake_io::rpc::Request::ScrubCluster;
-        let body = openlake_io::rpc::encode(&req).map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let req = Request::ScrubCluster;
+        let body = rpc::encode(&req).map_err(|e| anyhow::anyhow!(e.to_string()))?;
         let resp = match client.post(&url)?.body(body).send().await {
             Ok(resp) => resp,
             Err(e) => {
@@ -36,21 +48,19 @@ pub async fn run(args: ScrubArgs) -> Result<()> {
         let status = resp.status();
         let bytes = resp.bytes().await.map_err(|e| anyhow::anyhow!(e.to_string()))?;
         if !status.is_success() {
-            if let Ok(openlake_io::rpc::Response::Err(e)) = openlake_io::rpc::decode(&bytes) {
+            if let Ok(Response::Err(e)) = rpc::decode(&bytes) {
                 last_err = Some(anyhow::anyhow!("node {}: rpc error: {:?}", node.id, e));
                 continue;
             }
             last_err = Some(anyhow::anyhow!("node {}: rpc HTTP status: {}", node.id, status));
             continue;
         }
-        match openlake_io::rpc::decode::<openlake_io::rpc::Response>(&bytes)
-            .map_err(|e| anyhow::anyhow!(e.to_string()))?
-        {
-            openlake_io::rpc::Response::Scrub(n) => {
+        match rpc::decode::<Response>(&bytes).map_err(|e| anyhow::anyhow!(e.to_string()))? {
+            Response::Scrub(n) => {
                 println!("purged {} objects", n);
                 return Ok(());
             }
-            openlake_io::rpc::Response::Err(e) => {
+            Response::Err(e) => {
                 last_err = Some(anyhow::anyhow!("node {}: rpc error: {:?}", node.id, e));
             }
             other => {
@@ -59,4 +69,151 @@ pub async fn run(args: ScrubArgs) -> Result<()> {
         }
     }
     Err(last_err.unwrap_or_else(|| anyhow::anyhow!("no openlake cluster node responded")))
+}
+
+async fn run_dry_run(nodes: &[config::NodeToml], client: &cyper::Client) -> Result<()> {
+    println!(
+        "WARNING: This operation will delete all objects and may take several minutes."
+    );
+    println!("Dry run: no objects will be deleted.");
+    println!("Cluster ID: unavailable from current RPC API.");
+    println!("Deployment ID: unavailable from current RPC API.");
+    println!("Cluster nodes: {}", nodes.len());
+
+    for node in nodes {
+        println!("Node {}: {}", node.id, node.rpc_addr);
+        match query_node_buckets(node, client).await {
+            Ok(summary) => {
+                if summary.buckets.is_empty() {
+                    println!("  buckets: none detected");
+                    continue;
+                }
+                println!("  buckets: {}", summary.buckets.join(", "));
+                println!("  object count: {}", summary.total_objects);
+                for bucket in &summary.bucket_counts {
+                    println!("    {}: {} objects", bucket.0, bucket.1);
+                }
+                if !summary.sample_objects.is_empty() {
+                    println!("  sample deletions:");
+                    for key in &summary.sample_objects {
+                        println!("    {}", key);
+                    }
+                }
+            }
+            Err(e) => {
+                println!("  error querying node: {e}");
+            }
+        }
+    }
+
+    println!("Bucket information: buckets above were discovered from node RPC.");
+    println!("Would delete: all objects from all buckets.");
+    Ok(())
+}
+
+struct BucketSummary {
+    buckets: Vec<String>,
+    total_objects: usize,
+    bucket_counts: Vec<(String, usize)>,
+    sample_objects: Vec<String>,
+}
+
+async fn query_node_buckets(node: &config::NodeToml, client: &cyper::Client) -> Result<BucketSummary> {
+    let buckets = list_buckets(node, client).await?;
+    let mut total_objects = 0;
+    let mut bucket_counts = Vec::new();
+    let mut sample_objects = Vec::new();
+
+    for bucket in buckets.iter() {
+        let (count, sample) = count_bucket_objects(node, client, bucket).await?;
+        total_objects += count;
+        bucket_counts.push((bucket.clone(), count));
+        sample_objects.extend(sample.into_iter());
+        if sample_objects.len() >= 10 {
+            sample_objects.truncate(10);
+        }
+    }
+
+    Ok(BucketSummary {
+        buckets,
+        total_objects,
+        bucket_counts,
+        sample_objects,
+    })
+}
+
+async fn list_buckets(node: &config::NodeToml, client: &cyper::Client) -> Result<Vec<String>> {
+    let response = rpc_call(node, client, Request::ListVols { disk_idx: 0 }).await?;
+    match response {
+        Response::Vols(vols) => Ok(vols.into_iter().map(|v| v.name).collect()),
+        Response::Err(e) => Err(anyhow::anyhow!("node {}: rpc error: {:?}", node.id, e)),
+        other => Err(anyhow::anyhow!("node {}: unexpected rpc response: {:?}", node.id, other)),
+    }
+}
+
+async fn count_bucket_objects(
+    node: &config::NodeToml,
+    client: &cyper::Client,
+    bucket: &str,
+) -> Result<(usize, Vec<String>)> {
+    let mut total: usize = 0;
+    let mut sample = Vec::new();
+    let mut start_after: Option<String> = None;
+    const PAGE_SIZE: u32 = 1000;
+
+    loop {
+        let response = rpc_call(node, client, Request::WalkDir {
+            disk_idx: 0,
+            volume: bucket.to_owned(),
+            base_dir: "".into(),
+            recursive: true,
+            prefix_filter: "".into(),
+            start_after: start_after.clone(),
+            max_keys: Some(PAGE_SIZE),
+        })
+        .await?;
+
+        let entries = match response {
+            Response::Walked(entries) => entries,
+            Response::Err(e) => return Err(anyhow::anyhow!("node {}: rpc error: {:?}", node.id, e)),
+            other => return Err(anyhow::anyhow!("node {}: unexpected rpc response: {:?}", node.id, other)),
+        };
+
+        if entries.is_empty() {
+            break;
+        }
+
+        total += entries.len();
+        for (key, _) in entries.iter() {
+            if sample.len() < 10 {
+                sample.push(key.clone());
+            }
+        }
+
+        if entries.len() < PAGE_SIZE as usize {
+            break;
+        }
+
+        start_after = entries.last().map(|(k, _)| k.clone());
+    }
+
+    Ok((total, sample))
+}
+
+async fn rpc_call(node: &config::NodeToml, client: &cyper::Client, req: Request) -> Result<Response> {
+    let url = format!("http://{}/v1/rpc", node.rpc_addr);
+    let body = rpc::encode(&req).map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let resp = client.post(&url)?.body(body).send().await.map_err(|e| anyhow::anyhow!("node {}: {}", node.id, e))?;
+    let status = resp.status();
+    let bytes = resp.bytes().await.map_err(|e| anyhow::anyhow!(e.to_string()))?;
+
+    if !status.is_success() {
+        if let Ok(Response::Err(e)) = rpc::decode(&bytes) {
+            return Err(anyhow::anyhow!("node {}: rpc error: {:?}", node.id, e));
+        }
+        return Err(anyhow::anyhow!("node {}: rpc HTTP status: {}", node.id, status));
+    }
+
+    let response = rpc::decode::<Response>(&bytes).map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    Ok(response)
 }

--- a/crates/openlake_io/src/backend.rs
+++ b/crates/openlake_io/src/backend.rs
@@ -188,6 +188,11 @@ pub trait StorageBackend {
     async fn read_file(&self, volume: &str, path: &str) -> IoResult<Option<Vec<u8>>>;
 
     async fn make_dir_all(&self, volume: &str, path: &str) -> IoResult<()>;
+
+    /// Sweep the `STAGING_VOL` (and related staging areas) for orphan
+    /// staging directories older than `min_age` and move them to trash.
+    /// Returns the number of purged staging dirs.
+    async fn scrub_staging(&self, min_age: std::time::Duration) -> IoResult<usize>;
 }
 
 /// Lock-plane peer.

--- a/crates/openlake_io/src/local_fs.rs
+++ b/crates/openlake_io/src/local_fs.rs
@@ -1009,6 +1009,13 @@ impl StorageBackend for LocalFsBackend {
             .map_err(|e| IoError::Encode(format!("format.json: {e}")))?;
         atomic_write_bytes(&self.root.join(FORMAT_FILENAME), bytes).await
     }
+
+    async fn scrub_staging(&self, min_age: std::time::Duration) -> IoResult<usize> {
+        match LocalFsBackend::scrub_staging(self, min_age).await {
+            Ok(n) => Ok(n),
+            Err(e) => Err(IoError::Io(e)),
+        }
+    }
 }
 
 /// Write an `EncodedXlMeta` (head + optional tail) to `file` at offset

--- a/crates/openlake_io/src/remote_fs.rs
+++ b/crates/openlake_io/src/remote_fs.rs
@@ -678,6 +678,14 @@ impl StorageBackend for RemoteBackend {
             path:     path.into(),
         })
     }
+
+    async fn scrub_staging(&self, min_age: std::time::Duration) -> IoResult<usize> {
+        match self.unary(Request::ScrubStaging { disk_idx: self.disk_idx, min_age_secs: min_age.as_secs() }).await? {
+            Response::Scrub(n) => Ok(n),
+            Response::Err(e)   => Err(e.into()),
+            other              => Err(unexpected(other)),
+        }
+    }
 }
 
 #[async_trait(?Send)]

--- a/crates/openlake_io/src/rpc.rs
+++ b/crates/openlake_io/src/rpc.rs
@@ -85,6 +85,17 @@ pub enum Request {
     /// Recursive mkdir; idempotent.
     MakeDirAll     { disk_idx: DiskIdx, volume: String, path: String },
 
+    /// Disk-scoped scrub: sweep `STAGING_VOL` on `disk_idx` for orphan
+    /// staging dirs older than `min_age_secs` and move them to trash.
+    ScrubStaging { disk_idx: DiskIdx, min_age_secs: u64 },
+
+    /// Node-scoped scrub: ask the node to scrub all its local disks and
+    /// return the total number of purged entries.
+    ScrubNode { min_age_secs: u64 },
+
+    /// Cluster-scoped wipe: remove every object from every bucket.
+    ScrubCluster,
+
     // ---- Node-scoped variants (no `disk_idx`). ----
     //
     // Distributed lock plane: there is one `LockServer` per process,
@@ -117,6 +128,8 @@ pub enum Response {
     FormatOpt(Option<FormatJson>),
     /// Reply for `Request::ReadFile`. `None` if the file does not exist.
     FileBytes(Option<Vec<u8>>),
+    /// Reply for scrub operations: number of purged staging dirs.
+    Scrub(usize),
     LockGranted,
     LockDenied,
     LockRefreshed,

--- a/crates/openlake_server/src/main.rs
+++ b/crates/openlake_server/src/main.rs
@@ -396,8 +396,16 @@ async fn run_runtime(
     let rpc_locks      = lock_server.clone();
     let rpc_acceptor_t = rpc_acceptor.clone();
     let rpc_endpoints  = endpoint_registry.clone();
+    let rpc_engine = engine.clone();
     let rpc_task = compio::runtime::spawn(async move {
-        if let Err(e) = rpc_server::serve(rpc_listener, rpc_disks, rpc_locks, rpc_acceptor_t, rpc_endpoints).await {
+        if let Err(e) = rpc_server::serve(
+            rpc_listener,
+            rpc_disks,
+            rpc_locks,
+            rpc_acceptor_t,
+            rpc_endpoints,
+            rpc_engine,
+        ).await {
             tracing::error!(runtime_id, "rpc serve error: {e:#}");
         }
     });

--- a/crates/openlake_server/src/rpc_server.rs
+++ b/crates/openlake_server/src/rpc_server.rs
@@ -55,6 +55,7 @@ use openlake_io::rpc::{self, DiskIdx, Request, Response as RpcResponse};
 use openlake_io::stream::{ByteSink, ByteStream};
 use openlake_io::tuning::TCP_BUFFER_BYTES;
 use openlake_io::{IoError, IoResult, StorageBackend};
+use openlake_storage::Engine;
 
 use crate::lock_server::LockServer;
 use crate::s3::listener::TlsTcpListener;
@@ -82,6 +83,8 @@ const HDR_RPC: &str = "x-openlake-rpc";
 /// Response header echoing the streaming GET length so the client
 /// can sanity-check the byte stream before consuming it.
 const HDR_LEN: &str = "x-openlake-length";
+
+const SCRUB_LIST_PAGE: usize = 1000;
 
 pub fn bind_reuseport(addr: SocketAddr) -> std::io::Result<TcpListener> {
     let socket = socket2::Socket::new(
@@ -121,6 +124,7 @@ struct RpcAppStateInner {
     disks:     Vec<Rc<dyn StorageBackend>>,
     locks:     Arc<LockServer>,
     endpoints: Arc<std::sync::Mutex<openlake_io::rpc::RdmaEndpointsReply>>,
+    engine:    Rc<Engine>,
 }
 
 // SAFETY: every `RpcAppState` clone stays on the runtime that
@@ -133,14 +137,16 @@ impl RpcAppState {
         disks: Vec<Rc<dyn StorageBackend>>,
         locks: Arc<LockServer>,
         endpoints: Arc<std::sync::Mutex<openlake_io::rpc::RdmaEndpointsReply>>,
+        engine: Rc<Engine>,
     ) -> Self {
-        Self { inner: Rc::new(RpcAppStateInner { disks, locks, endpoints }) }
+        Self { inner: Rc::new(RpcAppStateInner { disks, locks, endpoints, engine }) }
     }
     fn disks(&self) -> &[Rc<dyn StorageBackend>] { &self.inner.disks }
     fn locks(&self) -> &Arc<LockServer> { &self.inner.locks }
     fn endpoints(&self) -> &Arc<std::sync::Mutex<openlake_io::rpc::RdmaEndpointsReply>> {
         &self.inner.endpoints
     }
+    fn engine(&self) -> &Rc<Engine> { &self.inner.engine }
 }
 
 // -----------------------------------------------------------------------------
@@ -153,8 +159,9 @@ pub async fn serve(
     locks:     Arc<LockServer>,
     tls:       Option<Rc<TlsAcceptor>>,
     endpoints: Arc<std::sync::Mutex<openlake_io::rpc::RdmaEndpointsReply>>,
+    engine:    Rc<Engine>,
 ) -> anyhow::Result<()> {
-    let state = RpcAppState::new(disks.iter().cloned().collect(), locks, endpoints);
+    let state = RpcAppState::new(disks.iter().cloned().collect(), locks, endpoints, engine);
     let app: Router = Router::new()
         .route("/v1/rpc",              post(handle_unary))
         .route("/v1/rpc/stream-write", put (handle_stream_write))
@@ -220,11 +227,84 @@ async fn handle_unary(
             IoError::InvalidArgument("streaming variant routed to /v1/rpc".into()),
         );
     }
-    let resp = SendWrapper::new(async move {
-        dispatch(state.disks(), state.locks(), state.endpoints(), req).await
-    }).await;
+    let resp = match req {
+        Request::ScrubCluster => {
+            let engine = state.engine().clone();
+            match scrub_cluster(engine).await {
+                Ok(n)  => RpcResponse::Scrub(n),
+                Err(e) => RpcResponse::Err(e.into()),
+            }
+        }
+        _ => SendWrapper::new(async move {
+            dispatch(state.disks(), state.locks(), state.endpoints(), req).await
+        }).await,
+    };
     let body_bytes = rpc::encode(&resp).unwrap_or_default();
     rpc_ok(body_bytes)
+}
+
+async fn scrub_cluster(engine: Rc<Engine>) -> IoResult<usize> {
+    let mut buckets: Vec<String> = Vec::new();
+    let mut start_after: Option<String> = None;
+    loop {
+        let infos = engine.list(
+            openlake_io::SYSTEM_BUCKET,
+            "buckets/",
+            start_after.as_deref(),
+            SCRUB_LIST_PAGE,
+        ).await?;
+        for info in &infos {
+            if let Some(name) = bucket_name_from_meta_key(&info.key) {
+                buckets.push(name);
+            }
+        }
+        if infos.len() < SCRUB_LIST_PAGE {
+            break;
+        }
+        start_after = infos.last().map(|info| info.key.clone());
+    }
+
+    let mut total_deleted = 0;
+    for bucket in buckets {
+        total_deleted += scrub_bucket(&engine, &bucket).await?;
+    }
+    Ok(total_deleted)
+}
+
+fn bucket_name_from_meta_key(key: &str) -> Option<String> {
+    const PREFIX: &str = "buckets/";
+    const SUFFIX: &str = "/.metadata.bin";
+    if key.starts_with(PREFIX) && key.ends_with(SUFFIX) {
+        let name = &key[PREFIX.len()..key.len() - SUFFIX.len()];
+        if !name.is_empty() {
+            return Some(name.to_owned());
+        }
+    }
+    None
+}
+
+async fn scrub_bucket(engine: &Rc<Engine>, bucket: &str) -> IoResult<usize> {
+    let mut deleted = 0;
+    let mut start_after: Option<String> = None;
+    loop {
+        let infos = engine.list(bucket, "", start_after.as_deref(), SCRUB_LIST_PAGE).await?;
+        if infos.is_empty() {
+            break;
+        }
+        let keys: Vec<String> = infos.iter().map(|info| info.key.clone()).collect();
+        let results = engine.delete_objects(bucket, &keys).await?;
+        for res in results {
+            match res {
+                Ok(()) => deleted += 1,
+                Err(e) => return Err(e),
+            }
+        }
+        if infos.len() < SCRUB_LIST_PAGE {
+            break;
+        }
+        start_after = infos.last().map(|info| info.key.clone());
+    }
+    Ok(deleted)
 }
 
 /// `PUT /v1/rpc/stream-write` — streaming PUT.
@@ -533,6 +613,25 @@ pub(crate) async fn dispatch(
                 &RenameOptions::default()).await, RpcResponse::Renamed),
         VerifyFile     { disk_idx, volume, path, fi } =>
             fold_unit(disk_or_err!(disk_idx).verify_file(&volume, &path, &fi).await),
+
+        ScrubStaging { disk_idx, min_age_secs } =>
+            fold(
+                disk_or_err!(disk_idx).scrub_staging(std::time::Duration::from_secs(min_age_secs)).await,
+                RpcResponse::Scrub,
+            ),
+
+        ScrubNode { min_age_secs } => {
+            // Ask every local disk to scrub and sum the results.
+            let min_age = std::time::Duration::from_secs(min_age_secs);
+            let mut total: usize = 0;
+            for d in disks.iter() {
+                match d.scrub_staging(min_age).await {
+                    Ok(n) => total += n,
+                    Err(e) => return RpcResponse::Err(e.into()),
+                }
+            }
+            RpcResponse::Scrub(total)
+        }
 
         ReadFormat     { disk_idx } =>
             match disk_or_err!(disk_idx).read_format().await {


### PR DESCRIPTION
Implemented cluster-wide scrub functionality.

Changes:
- Added ScrubCluster RPC request.
- Added server-side scrub handler.
- Lists objects across discovered buckets.
- Deletes objects using bulk delete APIs.
- Returns total deleted object count to CLI.