### PR TITLE
(#53) [v0.3] Add support for version CLI command

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod bench;
 pub mod cluster;
 pub mod disk;
+pub mod version;
 use anyhow::Result;
 use clap::Subcommand;
 
@@ -13,6 +14,8 @@ pub enum Cmd {
 
     /// Fabric microbench.
     Bench(bench::Args),
+    
+    Version(version::VersionArgs),
 }
 
 pub async fn dispatch(cmd: Cmd) -> Result<()> {
@@ -20,5 +23,7 @@ pub async fn dispatch(cmd: Cmd) -> Result<()> {
         Cmd::Cluster(a) => cluster::run(a).await,
         Cmd::Disk(a) => disk::run(a).await,
         Cmd::Bench(a) => bench::run(a).await,
+        Cmd::Version(a)  => version::run(a).await,
+
     }
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -14,7 +14,7 @@ pub enum Cmd {
 
     /// Fabric microbench.
     Bench(bench::Args),
-    
+
     Version(version::VersionArgs),
 }
 
@@ -23,7 +23,6 @@ pub async fn dispatch(cmd: Cmd) -> Result<()> {
         Cmd::Cluster(a) => cluster::run(a).await,
         Cmd::Disk(a) => disk::run(a).await,
         Cmd::Bench(a) => bench::run(a).await,
-        Cmd::Version(a)  => version::run(a).await,
-
+        Cmd::Version(a) => version::run(a).await,
     }
 }

--- a/cli/src/commands/version/mod.rs
+++ b/cli/src/commands/version/mod.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 #[derive(Parser)]
 pub struct VersionArgs {}
 
-pub async fn run(_args:  VersionArgs) -> Result<()> {
+pub async fn run(_args: VersionArgs) -> Result<()> {
     println!("OpenLake CLI Version 0.1.0");
     Ok(())
 }

--- a/cli/src/commands/version/mod.rs
+++ b/cli/src/commands/version/mod.rs
@@ -5,6 +5,6 @@ use clap::Parser;
 pub struct VersionArgs {}
 
 pub async fn run(_args: VersionArgs) -> Result<()> {
-    println!("OpenLake CLI Version 0.1.0");
+    println!("OpenLake CLI Version {}", env!("CARGO_PKG_VERSION"));
     Ok(())
 }

--- a/cli/src/commands/version/mod.rs
+++ b/cli/src/commands/version/mod.rs
@@ -1,0 +1,10 @@
+use anyhow::Result;
+use clap::Parser;
+
+#[derive(Parser)]
+pub struct VersionArgs {}
+
+pub async fn run(_args:  VersionArgs) -> Result<()> {
+    println!("OpenLake CLI Version 0.1.0");
+    Ok(())
+}


### PR DESCRIPTION
Summary
- Added a new version CLI command
- Prints OpenLake CLI version information
- Integrated command into the CLI command registry

Testing
cargo run -- version