### PR TITLE
[v0.3] Implement cluster up run() wrapper!

### DIFF
--- a/cli/Cluster_up/README.md
+++ b/cli/Cluster_up/README.md
@@ -1,0 +1,1 @@
+# Cluster_up 

--- a/cli/Cluster_up/README.md
+++ b/cli/Cluster_up/README.md
@@ -1,1 +1,0 @@
-# Cluster_up 

--- a/cli/src/commands/cluster/up.rs
+++ b/cli/src/commands/cluster/up.rs
@@ -1,10 +1,11 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use std::path::PathBuf;
+use std::process::{Command, Stdio};
 
 #[derive(ClapArgs)]
 pub struct UpArgs {
-    /// Cluster TOML. One TOML describes exactly one cluster.
+    /// Path to the OpenLake node TOML config.
     #[arg(long)]
     pub config: PathBuf,
 }
@@ -15,7 +16,23 @@ pub async fn run(args: UpArgs) -> Result<()> {
         args.config.display()
     );
 
-    println!("cluster started successfully");
+    let mut child = Command::new("openlaked")
+        .arg("--config")
+        .arg(&args.config)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .context("failed to start openlaked process")?;
+
+    println!("openlaked process started successfully");
+
+    let status = child.wait()?;
+
+    if status.success() {
+        println!("cluster exited successfully");
+    } else {
+        println!("cluster exited with failure: {}", status);
+    }
 
     Ok(())
 }

--- a/cli/src/commands/cluster/up.rs
+++ b/cli/src/commands/cluster/up.rs
@@ -24,14 +24,14 @@ pub async fn run(args: UpArgs) -> Result<()> {
         .spawn()
         .context("failed to start openlaked process")?;
 
-    println!("openlaked process started successfully");
+    println!("Openlaked process started successfully");
 
     let status = child.wait()?;
 
     if status.success() {
-        println!("cluster exited successfully");
+        println!("Cluster exited successfully");
     } else {
-        println!("cluster exited with failure: {}", status);
+        println!("Cluster exited with failure: {}", status);
     }
 
     Ok(())


### PR DESCRIPTION
Updates up.rs so cluster up can actually spin up openlaked using the provided config while sticking to the existing OpenLake config flow instead of introducing another config format!!