### PR TITLE
(#51) [v0.3] Add cluster topology liveness probe via signed S3 /ping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,6 +2108,9 @@ name = "openlake_cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-runtime-api",
  "axum",
  "bytes",
  "clap",
@@ -2117,6 +2120,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hdrhistogram",
+ "http 1.4.0",
  "libc",
  "openlake_io",
  "openlake_server",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,6 +33,13 @@ axum        = { workspace = true }
 bytes       = { workspace = true }
 futures     = { workspace = true }
 
+# SigV4 signing for the admin /ping liveness probe. Mirrors the server's
+# verifier so signatures the CLI produces are accepted by the S3 listener.
+http                   = { workspace = true }
+aws-sigv4              = { workspace = true }
+aws-credential-types   = { workspace = true }
+aws-smithy-runtime-api = { workspace = true }
+
 hdrhistogram = "7"
 libc         = "0.2"
 

--- a/cli/src/commands/cluster/mod.rs
+++ b/cli/src/commands/cluster/mod.rs
@@ -16,7 +16,7 @@ pub enum ClusterCmd {
     /// Print the live state of every node listed in --config.
     Status(status::StatusArgs),
 
-    /// Print the declared node layout from --config, without probing.
+    /// Print the declared node layout from --config; --probe adds live state.
     Topology(topology::TopologyArgs),
 
     /// Bring the cluster up.

--- a/cli/src/commands/cluster/topology.rs
+++ b/cli/src/commands/cluster/topology.rs
@@ -1,14 +1,20 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
+use aws_credential_types::Credentials;
+use aws_sigv4::http_request::{
+    sign, PayloadChecksumKind, PercentEncodingMode, SessionTokenMode, SignableBody,
+    SignableRequest, SigningSettings, UriPathNormalizationMode,
+};
+use aws_sigv4::sign::v4;
+use aws_smithy_runtime_api::client::identity::Identity;
 use clap::Args as ClapArgs;
-use compio::net::TcpStream;
 use futures::stream::StreamExt as _;
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
-use openlake_server::config::Config;
+use openlake_server::config::{Config, Credential};
 use openlake_storage::NodeAddr;
 
 #[derive(ClapArgs)]
@@ -48,7 +54,7 @@ pub async fn run(args: TopologyArgs) -> Result<()> {
         let secs = args
             .probe_timeout_secs
             .unwrap_or(DEFAULT_PROBE_TIMEOUT_SECS);
-        Some(probe(&cfg.nodes, Duration::from_secs(secs)).await)
+        Some(probe(&cfg, Duration::from_secs(secs)).await)
     } else {
         None
     };
@@ -62,26 +68,127 @@ pub async fn run(args: TopologyArgs) -> Result<()> {
     Ok(())
 }
 
-/// Connect to every node's RPC listener, mapping `rpc_addr -> reachable`.
+/// Path of the liveness route on the S3 listener (behind SigV4).
+const PING_PATH: &str = "/openlake/admin/v1/ping";
+
+/// Probe every node's liveness over the S3 plane, mapping `rpc_addr -> up`.
 ///
-/// A node counts as up when the TCP connect succeeds within `timeout`; any
-/// timeout or connection error counts as down. Probes run concurrently with a
-/// bounded fan-out of `MAX_CONCURRENT_PROBES`, so a large cluster stays close
-/// to one `timeout` of wall time without opening every socket at once.
-async fn probe(nodes: &[NodeAddr], timeout: Duration) -> BTreeMap<SocketAddr, bool> {
-    futures::stream::iter(nodes.iter().map(|n| {
-        let addr = n.rpc_addr;
+/// Liveness is checked against the S3 listener's `/ping` admin route, never
+/// the inter-node RPC plane: each node's S3 endpoint is derived from its
+/// `rpc_addr` IP plus the cluster-wide S3 port (`s3_port`, defaulting to this
+/// node's own `s3_addr` port). Requests are SigV4-signed with the first
+/// configured credential so the server's verifier accepts them. A node is up
+/// when `/ping` answers 2xx within `timeout`. Probes run concurrently with a
+/// bounded fan-out of `MAX_CONCURRENT_PROBES`. Results are keyed by `rpc_addr`
+/// to match how the layout table identifies nodes.
+async fn probe(cfg: &Config, timeout: Duration) -> BTreeMap<SocketAddr, bool> {
+    let s3_port = cfg.s3_port.unwrap_or_else(|| cfg.s3_addr.port());
+    let scheme = if cfg.s3_tls.is_some() {
+        "https"
+    } else {
+        "http"
+    };
+    let cred = cfg.credentials.first();
+    let client = cyper::Client::new();
+
+    futures::stream::iter(cfg.nodes.iter().map(|n| {
+        let endpoint = SocketAddr::new(n.rpc_addr.ip(), s3_port);
+        let client = client.clone();
+        let region = cfg.region.as_str();
         async move {
-            let ok = matches!(
-                compio::time::timeout(timeout, TcpStream::connect(addr)).await,
-                Ok(Ok(_))
-            );
-            (addr, ok)
+            let up = match cred {
+                Some(c) => ping_node(&client, scheme, endpoint, c, region, timeout).await,
+                None => false,
+            };
+            (n.rpc_addr, up)
         }
     }))
     .buffer_unordered(MAX_CONCURRENT_PROBES)
     .collect()
     .await
+}
+
+/// GET the signed `/ping` route on one node's S3 endpoint; `true` on 2xx.
+async fn ping_node(
+    client: &cyper::Client,
+    scheme: &str,
+    endpoint: SocketAddr,
+    cred: &Credential,
+    region: &str,
+    timeout: Duration,
+) -> bool {
+    let host = endpoint.to_string();
+    let url = format!("{scheme}://{host}{PING_PATH}");
+
+    let signed = match sign_ping(&url, &host, cred, region) {
+        Ok(headers) => headers,
+        Err(_) => return false,
+    };
+
+    let request = match client.get(&url) {
+        Ok(builder) => builder.headers(signed),
+        Err(_) => return false,
+    };
+
+    matches!(
+        compio::time::timeout(timeout, request.send()).await,
+        Ok(Ok(resp)) if resp.status().is_success()
+    )
+}
+
+/// SigV4-sign a GET of `url` and return the headers to attach to the request.
+///
+/// Mirrors the server's verifier: service `s3`, S3-specific signing settings,
+/// and an unsigned payload. The `host` header is signed but dropped from the
+/// returned set so the HTTP client supplies its own (avoiding a duplicate).
+fn sign_ping(url: &str, host: &str, cred: &Credential, region: &str) -> Result<http::HeaderMap> {
+    let identity: Identity = Credentials::new(
+        &cred.access_key,
+        &cred.secret_key,
+        None,
+        None,
+        "openlake-cli",
+    )
+    .into();
+
+    let mut settings = SigningSettings::default();
+    settings.percent_encoding_mode = PercentEncodingMode::Single;
+    settings.payload_checksum_kind = PayloadChecksumKind::XAmzSha256;
+    settings.uri_path_normalization_mode = UriPathNormalizationMode::Disabled;
+    settings.session_token_mode = SessionTokenMode::Include;
+
+    let params = v4::SigningParams::builder()
+        .identity(&identity)
+        .region(region)
+        .name("s3")
+        .time(SystemTime::now())
+        .settings(settings)
+        .build()
+        .map_err(|e| anyhow!("build signing params: {e}"))?;
+
+    let signable = SignableRequest::new(
+        "GET",
+        url,
+        std::iter::once(("host", host)),
+        SignableBody::UnsignedPayload,
+    )
+    .map_err(|e| anyhow!("build signable request: {e}"))?;
+
+    let (instructions, _signature) = sign(signable, &params.into())
+        .map_err(|e| anyhow!("sign request: {e}"))?
+        .into_parts();
+
+    let mut request = http::Request::builder()
+        .method("GET")
+        .uri(url)
+        .header(http::header::HOST, host)
+        .body(())
+        .map_err(|e| anyhow!("build request: {e}"))?;
+    instructions.apply_to_request_http1x(&mut request);
+
+    let mut headers = request.headers().clone();
+    headers.remove(http::header::HOST);
+    Ok(headers)
 }
 
 /// Render the declared cluster layout, sorted by node id.
@@ -239,6 +346,32 @@ mod tests {
         let (report, _) = render(&[node(0, "127.0.0.1:9000", 1)], None);
         assert!(!report.contains("state"));
         assert!(!report.contains("alive"));
+    }
+
+    #[test]
+    fn sign_ping_produces_sigv4_headers() {
+        let cred = Credential {
+            access_key: "AKIDEXAMPLE".into(),
+            secret_key: "secret".into(),
+        };
+        let headers = sign_ping(
+            "http://10.0.0.1:9000/openlake/admin/v1/ping",
+            "10.0.0.1:9000",
+            &cred,
+            "us-east-1",
+        )
+        .unwrap();
+
+        let auth = headers
+            .get(http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default();
+        assert!(auth.starts_with("AWS4-HMAC-SHA256"), "got: {auth}");
+        assert!(auth.contains("/us-east-1/s3/aws4_request"));
+        assert!(headers.contains_key("x-amz-date"));
+        assert!(headers.contains_key("x-amz-content-sha256"));
+        // host is signed but left to the HTTP client, not returned here.
+        assert!(!headers.contains_key(http::header::HOST));
     }
 
     #[test]

--- a/cli/src/commands/cluster/topology.rs
+++ b/cli/src/commands/cluster/topology.rs
@@ -1,7 +1,12 @@
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
+use compio::net::TcpStream;
+use futures::stream::StreamExt as _;
+use std::collections::BTreeMap;
 use std::fmt::Write as _;
+use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use openlake_server::config::Config;
 use openlake_storage::NodeAddr;
@@ -11,7 +16,22 @@ pub struct TopologyArgs {
     /// openlake.toml. The same file openlaked reads.
     #[arg(long)]
     pub config: PathBuf,
+
+    /// Probe each node's RPC listener and annotate the layout with live state.
+    #[arg(long)]
+    pub probe: bool,
+
+    /// Per node probe timeout in seconds. Requires --probe. [default: 2]
+    #[arg(long, requires = "probe")]
+    pub probe_timeout_secs: Option<u64>,
 }
+
+/// Default per node probe timeout, used when --probe-timeout-secs is omitted.
+const DEFAULT_PROBE_TIMEOUT_SECS: u64 = 2;
+
+/// Cap on probes in flight at once, so a large cluster cannot open an
+/// unbounded number of sockets simultaneously.
+const MAX_CONCURRENT_PROBES: usize = 64;
 
 pub async fn run(args: TopologyArgs) -> Result<()> {
     let text = std::fs::read_to_string(&args.config)
@@ -22,7 +42,18 @@ pub async fn run(args: TopologyArgs) -> Result<()> {
     println!("openlake cluster topology: {}", args.config.display());
     println!();
 
-    let (report, warnings) = render(&cfg.nodes);
+    // Probing is opt-in: by default `topology` reports the declared layout
+    // without touching the network. With --probe it also reports liveness.
+    let liveness = if args.probe {
+        let secs = args
+            .probe_timeout_secs
+            .unwrap_or(DEFAULT_PROBE_TIMEOUT_SECS);
+        Some(probe(&cfg.nodes, Duration::from_secs(secs)).await)
+    } else {
+        None
+    };
+
+    let (report, warnings) = render(&cfg.nodes, liveness.as_ref());
     print!("{report}");
 
     for w in warnings {
@@ -31,7 +62,37 @@ pub async fn run(args: TopologyArgs) -> Result<()> {
     Ok(())
 }
 
-fn render(nodes: &[NodeAddr]) -> (String, Vec<String>) {
+/// Connect to every node's RPC listener, mapping `rpc_addr -> reachable`.
+///
+/// A node counts as up when the TCP connect succeeds within `timeout`; any
+/// timeout or connection error counts as down. Probes run concurrently with a
+/// bounded fan-out of `MAX_CONCURRENT_PROBES`, so a large cluster stays close
+/// to one `timeout` of wall time without opening every socket at once.
+async fn probe(nodes: &[NodeAddr], timeout: Duration) -> BTreeMap<SocketAddr, bool> {
+    futures::stream::iter(nodes.iter().map(|n| {
+        let addr = n.rpc_addr;
+        async move {
+            let ok = matches!(
+                compio::time::timeout(timeout, TcpStream::connect(addr)).await,
+                Ok(Ok(_))
+            );
+            (addr, ok)
+        }
+    }))
+    .buffer_unordered(MAX_CONCURRENT_PROBES)
+    .collect()
+    .await
+}
+
+/// Render the declared cluster layout, sorted by node id.
+///
+/// When `liveness` is `Some`, a `state` column and an alive count are added
+/// from the probe results keyed by `rpc_addr`; when `None`, the layout is
+/// reported exactly as declared, without any network state.
+fn render(
+    nodes: &[NodeAddr],
+    liveness: Option<&BTreeMap<SocketAddr, bool>>,
+) -> (String, Vec<String>) {
     if nodes.is_empty() {
         return (
             "config declares zero nodes, nothing to lay out.\n".to_string(),
@@ -43,14 +104,35 @@ fn render(nodes: &[NodeAddr]) -> (String, Vec<String>) {
     sorted.sort_unstable_by_key(|n| n.id);
 
     let mut out = String::new();
-    out.push_str("  node    disks    rpc address\n");
-    out.push_str("  ----    -----    -----------\n");
+    if liveness.is_some() {
+        out.push_str("  node    disks    state    rpc address\n");
+        out.push_str("  ----    -----    -----    -----------\n");
+    } else {
+        out.push_str("  node    disks    rpc address\n");
+        out.push_str("  ----    -----    -----------\n");
+    }
     for n in &sorted {
-        let _ = writeln!(
-            out,
-            "  {:>4}    {:>5}    {}",
-            n.id, n.disk_count, n.rpc_addr
-        );
+        match liveness {
+            Some(map) => {
+                let state = match map.get(&n.rpc_addr) {
+                    Some(true) => "up",
+                    Some(false) => "DOWN",
+                    None => "?",
+                };
+                let _ = writeln!(
+                    out,
+                    "  {:>4}    {:>5}    {:<5}    {}",
+                    n.id, n.disk_count, state, n.rpc_addr
+                );
+            }
+            None => {
+                let _ = writeln!(
+                    out,
+                    "  {:>4}    {:>5}    {}",
+                    n.id, n.disk_count, n.rpc_addr
+                );
+            }
+        }
     }
     out.push('\n');
 
@@ -64,6 +146,20 @@ fn render(nodes: &[NodeAddr]) -> (String, Vec<String>) {
         total_disks,
         if total_disks == 1 { "" } else { "s" },
     );
+
+    if let Some(map) = liveness {
+        let alive = sorted
+            .iter()
+            .filter(|n| map.get(&n.rpc_addr) == Some(&true))
+            .count();
+        let _ = writeln!(
+            out,
+            "{} / {} node{} alive.",
+            alive,
+            count,
+            if count == 1 { "" } else { "s" }
+        );
+    }
 
     let mut dup_ids: Vec<u16> = sorted
         .windows(2)
@@ -82,7 +178,6 @@ fn render(nodes: &[NodeAddr]) -> (String, Vec<String>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::SocketAddr;
 
     fn node(id: u16, addr: &str, disk_count: u16) -> NodeAddr {
         NodeAddr {
@@ -94,7 +189,7 @@ mod tests {
 
     #[test]
     fn empty_config_reports_no_nodes() {
-        let (report, warnings) = render(&[]);
+        let (report, warnings) = render(&[], None);
         assert!(report.contains("zero nodes"));
         assert!(warnings.is_empty());
     }
@@ -106,7 +201,7 @@ mod tests {
             node(0, "127.0.0.1:9000", 1),
             node(1, "127.0.0.1:9001", 1),
         ];
-        let (report, warnings) = render(&nodes);
+        let (report, warnings) = render(&nodes, None);
         let p0 = report.find("127.0.0.1:9000").unwrap();
         let p1 = report.find("127.0.0.1:9001").unwrap();
         let p2 = report.find("127.0.0.1:9002").unwrap();
@@ -117,7 +212,7 @@ mod tests {
 
     #[test]
     fn single_node_uses_singular() {
-        let (report, _) = render(&[node(0, "127.0.0.1:9000", 1)]);
+        let (report, _) = render(&[node(0, "127.0.0.1:9000", 1)], None);
         assert!(report.contains("1 node configured"));
         assert!(report.contains("1 disk total"));
     }
@@ -125,14 +220,38 @@ mod tests {
     #[test]
     fn duplicate_ids_are_flagged() {
         let nodes = vec![node(0, "127.0.0.1:9000", 1), node(0, "10.0.0.1:9000", 2)];
-        let (_, warnings) = render(&nodes);
+        let (_, warnings) = render(&nodes, None);
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].contains("node id 0 declared more than once."));
     }
 
     #[test]
     fn disk_count_appears_in_render() {
-        let (report, _) = render(&[node(0, "127.0.0.1:9000", 4), node(1, "127.0.0.1:9001", 4)]);
+        let (report, _) = render(
+            &[node(0, "127.0.0.1:9000", 4), node(1, "127.0.0.1:9001", 4)],
+            None,
+        );
         assert!(report.contains("8 disks total"));
+    }
+
+    #[test]
+    fn default_layout_has_no_state_column() {
+        let (report, _) = render(&[node(0, "127.0.0.1:9000", 1)], None);
+        assert!(!report.contains("state"));
+        assert!(!report.contains("alive"));
+    }
+
+    #[test]
+    fn probed_layout_shows_state_and_alive_count() {
+        let nodes = vec![node(0, "127.0.0.1:9000", 1), node(1, "127.0.0.1:9001", 1)];
+        let liveness = BTreeMap::from([
+            ("127.0.0.1:9000".parse::<SocketAddr>().unwrap(), true),
+            ("127.0.0.1:9001".parse::<SocketAddr>().unwrap(), false),
+        ]);
+        let (report, _) = render(&nodes, Some(&liveness));
+        assert!(report.contains("state"));
+        assert!(report.contains("up"));
+        assert!(report.contains("DOWN"));
+        assert!(report.contains("1 / 2 nodes alive."));
     }
 }

--- a/crates/openlake_server/src/config.rs
+++ b/crates/openlake_server/src/config.rs
@@ -75,6 +75,13 @@ pub struct Config {
     #[serde(deserialize_with = "deserialize_data_dirs")]
     pub data_dirs: Vec<PathBuf>,
     pub s3_addr: SocketAddr,
+    /// Shared S3 listener port across every node in the cluster. Cluster
+    /// tooling (e.g. the CLI liveness probe) derives a node's S3 endpoint
+    /// from its `rpc_addr` IP plus this port, since the `nodes` table only
+    /// carries each peer's RPC address. Optional: defaults to this node's
+    /// own `s3_addr` port, which is the common all-nodes-same-port case.
+    #[serde(default)]
+    pub s3_port: Option<u16>,
     pub rpc_addr: SocketAddr,
     /// Disks per erasure set. `total_disks() % set_drive_count` must
     /// be 0, where `total_disks() = sum(node.disk_count)` across all

--- a/crates/openlake_server/src/s3/app.rs
+++ b/crates/openlake_server/src/s3/app.rs
@@ -25,6 +25,7 @@ use crate::s3::state::AppState;
 
 pub fn build_router(state: AppState, cfg: Arc<Config>) -> Router {
     let admin_cfg = cfg.clone();
+    let ping_cfg = cfg.clone();
     let bucket_routes = put(buckets::put_bucket)
         .delete(buckets::delete_bucket)
         .head(buckets::head_bucket)
@@ -38,6 +39,13 @@ pub fn build_router(state: AppState, cfg: Arc<Config>) -> Router {
             get(move || {
                 let cfg = admin_cfg.clone();
                 async move { serve_admin_config(cfg).await }
+            }),
+        )
+        .route(
+            "/openlake/admin/v1/ping",
+            get(move || {
+                let cfg = ping_cfg.clone();
+                async move { serve_admin_ping(cfg).await }
             }),
         )
         .route("/{bucket}", bucket_routes.clone())
@@ -69,6 +77,22 @@ async fn serve_admin_config(cfg: Arc<Config>) -> axum::Json<Config> {
         cr.secret_key = "***".into();
     }
     axum::Json(c)
+}
+
+/// Liveness response for `GET /openlake/admin/v1/ping`. Served on the S3
+/// listener (behind SigV4) so cluster tooling can check a node without
+/// touching the inter-node RPC plane.
+#[derive(serde::Serialize)]
+struct Ping {
+    status: &'static str,
+    node_id: u16,
+}
+
+async fn serve_admin_ping(cfg: Arc<Config>) -> axum::Json<Ping> {
+    axum::Json(Ping {
+        status: "ok",
+        node_id: cfg.self_id,
+    })
 }
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
Follow-up to #87, where @ArnavBalyan asked for a dynamic cluster-liveness check on `cluster topology`.

`cluster topology` keeps its default contract, print the declared node layout without touching the network.

The new `--probe` flag opts into a liveness pass:

* Probes each node over the S3 plane via `GET /openlake/admin/v1/ping`
* SigV4-signs requests using the configured credentials
* Supports a `--probe-timeout-secs` knob
* Uses bounded concurrency (64 probes in flight)
* Adds a `state` column
* Adds an alive count to the report

A new authenticated admin route, `GET /openlake/admin/v1/ping`, is exposed on the S3 listener and returns `{status, node_id}`. Nodes are considered `up` when the probe receives a 2xx response.

To locate each node's S3 endpoint, the CLI derives it from the node's `rpc_addr` IP and a cluster-wide `s3_port` configuration. If `s3_port` is not configured, the local node's `s3_addr` port is used.

## Example

```sh
$ openlake cluster topology --config node0.toml --probe

openlake cluster topology: node0.toml

  node    disks    state    rpc address
  ----    -----    -----    -----------
     0        4    up       127.0.0.1:7000
     1        2    DOWN     127.0.0.1:7001

2 nodes configured, 6 disks total.
1 / 2 nodes alive.
```

Without --probe, output is unchanged (no state column, no network I/O).

## Changes

### crates/openlake_server/src/s3/app.rs

* Added authenticated GET /openlake/admin/v1/ping route on the S3 listener, returning {status, node_id}

### crates/openlake_server/src/config.rs

* Added optional cluster-wide s3_port

### cli/src/commands/cluster/topology.rs

* --probe / --probe-timeout-secs flags
* SigV4-signed /ping probing; endpoint derived from rpc_addr IP + s3_port (defaults to the local s3_addr port)
* Bounded-concurrency probe execution (64 in flight)
* Liveness-aware render() that stays pure (takes probe results as an optional map)
* Additional unit tests

### cli/Cargo.toml + Cargo.lock

* Added aws-sigv4, aws-credential-types, aws-smithy-runtime-api, http deps for client-side SigV4 signing

## Testing

* 8 unit tests pass (including SigV4 header generation)

* End-to-end against a local single-node openlaked

  * Signed probe returns up
  * Killed daemon reports DOWN
  * Unsigned request returns 403

* cargo test -p openlake_cli

* cargo clippy clean

* Workspace cargo fmt --check clean