### PR TITLE
Implement cluster topology CLI command

### DIFF
--- a/cli/src/commands/cluster/mod.rs
+++ b/cli/src/commands/cluster/mod.rs
@@ -1,4 +1,5 @@
 mod status;
+mod topology;
 
 use anyhow::Result;
 use clap::{Args as ClapArgs, Subcommand};
@@ -13,10 +14,14 @@ pub struct Args {
 pub enum ClusterCmd {
     /// Print the live state of every node listed in --config.
     Status(status::StatusArgs),
+
+    /// Print cluster topology.
+    Topology(topology::TopologyArgs),
 }
 
 pub async fn run(args: Args) -> Result<()> {
     match args.sub {
         ClusterCmd::Status(a) => status::run(a).await,
+        ClusterCmd::Topology(a) => topology::run(a).await,
     }
 }

--- a/cli/src/commands/cluster/topology.rs
+++ b/cli/src/commands/cluster/topology.rs
@@ -1,0 +1,36 @@
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+use std::path::PathBuf;
+
+use crate::config;
+
+#[derive(ClapArgs)]
+pub struct TopologyArgs {
+    /// Path to the cluster TOML config file.
+    #[arg(long)]
+    pub config: PathBuf,
+}
+
+pub async fn run(args: TopologyArgs) -> Result<()> {
+    let cfg =
+        config::load(&args.config).with_context(|| format!("load {}", args.config.display()))?;
+
+    println!("OpenLake Cluster Topology");
+    println!("=========================");
+
+    if cfg.nodes.is_empty() {
+        println!(
+            "no openlake cluster detected: {} declares zero nodes",
+            args.config.display()
+        );
+        return Ok(());
+    }
+
+    for node in &cfg.nodes {
+        println!("[node {:>3}] {}", node.id, node.rpc_addr);
+    }
+
+    println!();
+    println!("cluster contains {} node(s)", cfg.nodes.len());
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds a new `cluster topology` CLI command that:

- Loads a cluster TOML configuration file
- Prints the configured cluster topology
- Displays each node's ID and RPC address
- Handles empty cluster configurations gracefully

## Testing

- cargo build
- cargo run --bin openlake -- cluster topology --help