### PR TITLE
(#122) [v0.3] Feature: Add support for ping node 

### DIFF
--- a/cli/src/commands/cluster/mod.rs
+++ b/cli/src/commands/cluster/mod.rs
@@ -1,6 +1,7 @@
-mod status;
-mod topology;
-mod up;
+pub mod up;
+pub mod status;
+pub mod topology;
+pub mod ping;
 
 use anyhow::Result;
 use clap::{Args as ClapArgs, Subcommand};
@@ -15,12 +16,15 @@ pub struct Args {
 pub enum ClusterCmd {
     /// Print the live state of every node listed in --config.
     Status(status::StatusArgs),
-
-    /// Print the declared node layout from --config; --probe adds live state.
+    
+    /// Print the declared node layout from --config.
     Topology(topology::TopologyArgs),
-
+    
     /// Bring the cluster up.
     Up(up::UpArgs),
+
+    /// Ping a specific node.
+    Ping(ping::PingArgs),
 }
 
 pub async fn run(args: Args) -> Result<()> {
@@ -28,5 +32,6 @@ pub async fn run(args: Args) -> Result<()> {
         ClusterCmd::Status(a) => status::run(a).await,
         ClusterCmd::Topology(a) => topology::run(a).await,
         ClusterCmd::Up(a) => up::run(a).await,
+        ClusterCmd::Ping(a) => ping::run(a).await,
     }
 }

--- a/cli/src/commands/cluster/ping.rs
+++ b/cli/src/commands/cluster/ping.rs
@@ -1,0 +1,62 @@
+use anyhow::{Context, Result};
+use clap::Args;
+use std::time::Duration;
+use compio::net::TcpStream;
+use openlake_server::config::Config;
+
+#[derive(Args)]
+pub struct PingArgs {
+    /// Path to the OpenLake node TOML config.
+    #[arg(long)]
+    pub config: std::path::PathBuf,
+
+    /// The specific node ID to ping (numerical)
+    pub node: String,
+
+    /// Per-node probe timeout in seconds.
+    #[arg(long, default_value_t = 2)]
+    pub probe_timeout_secs: u64,
+}
+
+pub async fn run(args: PingArgs) -> Result<()> {
+    // 1. Parse the node string argument into a u16 number
+    let target_node_id = args.node.parse::<u16>()
+        .with_context(|| format!("Invalid node ID '{}'. Node ID must be a number.", args.node))?;
+
+    // 2. Read and parse the configuration file
+    let text = std::fs::read_to_string(&args.config)
+        .with_context(|| format!("failed to read {}", args.config.display()))?;
+        
+    let cfg: Config = toml::from_str(&text)
+        .with_context(|| format!("failed to parse {}", args.config.display()))?;
+
+    // 3. Find the requested node in the config
+    let target_node = cfg.nodes.iter().find(|n| n.id == target_node_id);
+
+    match target_node {
+        Some(node) => {
+            println!("Pinging node '{}' at {}...", node.id, node.rpc_addr);
+            
+            let probe_timeout = Duration::from_secs(args.probe_timeout_secs);
+            
+            // 4. Attempt to connect to the node's rpc_addr with a compio timeout
+            let connection_attempt = TcpStream::connect(&node.rpc_addr);
+            let is_alive = matches!(
+                compio::time::timeout(probe_timeout, connection_attempt).await,
+                Ok(Ok(_))
+            );
+
+            // 5. Output the result cleanly
+            if is_alive {
+                println!("Node '{}' is UP and responding!", node.id);
+            } else {
+                println!("Node '{}' is DOWN or unreachable (Timeout).", node.id);
+            }
+        }
+        None => {
+            println!("Error: Node '{}' not found in config.", target_node_id);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Description
Added a `ping` command functionality under the cluster subcommand to allow users to verify cluster node connectivity.

## Related Issue
Closes #122