### PR TITLE
(#120) [v0.3] Implement cluster down CLI command

### DIFF
--- a/cli/src/commands/cluster/down.rs
+++ b/cli/src/commands/cluster/down.rs
@@ -1,0 +1,23 @@
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+use std::process::Command;
+
+#[derive(ClapArgs)]
+pub struct DownArgs {}
+
+pub async fn run(_: DownArgs) -> Result<()> {
+    println!("bringing OpenLake cluster down");
+
+    let status = Command::new("pkill")
+        .arg("openlaked")
+        .status()
+        .context("failed to stop openlaked")?;
+
+    if status.success() {
+        println!("OpenLake cluster stopped successfully");
+    } else {
+        println!("No running openlaked process found");
+    }
+
+    Ok(())
+}

--- a/cli/src/commands/cluster/down.rs
+++ b/cli/src/commands/cluster/down.rs
@@ -1,12 +1,36 @@
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
+use std::io::{self, Write};
 use std::process::Command;
 
 #[derive(ClapArgs)]
-pub struct DownArgs {}
+pub struct DownArgs {
+    /// Skip confirmation prompt.
+    #[arg(long)]
+    pub allow: bool,
+}
 
-pub async fn run(_: DownArgs) -> Result<()> {
-    println!("bringing OpenLake cluster down");
+pub async fn run(args: DownArgs) -> Result<()> {
+    println!("Bringing OpenLake cluster down");
+
+    println!(
+        "Warning: this command only stops local openlaked processes and does not affect remote multi-node clusters."
+    );
+
+    if !args.allow {
+        print!("Are you sure you want to stop the cluster? (Y/n): ");
+        io::stdout().flush()?;
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+
+        let input = input.trim().to_lowercase();
+
+        if input == "n" || input == "no" {
+            println!("Cluster shutdown aborted.");
+            return Ok(());
+        }
+    }
 
     let status = Command::new("pkill")
         .arg("openlaked")

--- a/cli/src/commands/cluster/mod.rs
+++ b/cli/src/commands/cluster/mod.rs
@@ -1,3 +1,4 @@
+mod down;
 mod status;
 mod topology;
 mod up;
@@ -21,6 +22,9 @@ pub enum ClusterCmd {
 
     /// Bring the cluster up.
     Up(up::UpArgs),
+
+    /// Bring the cluster down.
+    Down(down::DownArgs),
 }
 
 pub async fn run(args: Args) -> Result<()> {
@@ -28,5 +32,6 @@ pub async fn run(args: Args) -> Result<()> {
         ClusterCmd::Status(a) => status::run(a).await,
         ClusterCmd::Topology(a) => topology::run(a).await,
         ClusterCmd::Up(a) => up::run(a).await,
+        ClusterCmd::Down(a) => down::run(a).await,
     }
 }


### PR DESCRIPTION
## Summary

Adds a new `cluster down` CLI command as the counterpart to the existing `cluster up` command.

The command stops running `openlaked` processes using `pkill openlaked`.

## Changes

* Added `cli/src/commands/cluster/down.rs`
* Registered the `down` subcommand in `cli/src/commands/cluster/mod.rs`

## Testing

* `cargo build`
* `cargo run --bin openlake -- cluster down --help`
* `cargo run --bin openlake -- cluster down`
