### PR TITLE
(#49) [v0.2] Add disk info admin endpoint

### DIFF
--- a/crates/openlake_server/src/s3/app.rs
+++ b/crates/openlake_server/src/s3/app.rs
@@ -26,6 +26,7 @@ use crate::s3::state::AppState;
 pub fn build_router(state: AppState, cfg: Arc<Config>) -> Router {
     let admin_cfg = cfg.clone();
     let ping_cfg = cfg.clone();
+    let disk_cfg = cfg.clone();
     let bucket_routes = put(buckets::put_bucket)
         .delete(buckets::delete_bucket)
         .head(buckets::head_bucket)
@@ -48,6 +49,13 @@ pub fn build_router(state: AppState, cfg: Arc<Config>) -> Router {
                 async move { serve_admin_ping(cfg).await }
             }),
         )
+         .route(
+    "/openlake/admin/v1/disk",
+    get(move || {
+        let cfg = disk_cfg.clone();
+        async move { serve_admin_disk(cfg).await }
+    }),
+)
         .route("/{bucket}", bucket_routes.clone())
         .route("/{bucket}/", bucket_routes)
         .route(
@@ -90,6 +98,18 @@ struct Ping {
 
 async fn serve_admin_ping(cfg: Arc<Config>) -> axum::Json<Ping> {
     axum::Json(Ping {
+        status: "ok",
+        node_id: cfg.self_id,
+    })
+}
+#[derive(serde::Serialize)]
+struct DiskInfo {
+    status: &'static str,
+    node_id: u16,
+}
+
+async fn serve_admin_disk(cfg: Arc<Config>) -> axum::Json<DiskInfo> {
+    axum::Json(DiskInfo {
         status: "ok",
         node_id: cfg.self_id,
     })

--- a/crates/openlake_server/src/s3/app.rs
+++ b/crates/openlake_server/src/s3/app.rs
@@ -49,13 +49,13 @@ pub fn build_router(state: AppState, cfg: Arc<Config>) -> Router {
                 async move { serve_admin_ping(cfg).await }
             }),
         )
-         .route(
-    "/openlake/admin/v1/disk",
-    get(move || {
-        let cfg = disk_cfg.clone();
-        async move { serve_admin_disk(cfg).await }
-    }),
-)
+        .route(
+            "/openlake/admin/v1/disk",
+            get(move || {
+                let cfg = disk_cfg.clone();
+                async move { serve_admin_disk(cfg).await }
+            }),
+        )
         .route("/{bucket}", bucket_routes.clone())
         .route("/{bucket}/", bucket_routes)
         .route(

--- a/crates/openlake_server/src/s3/app.rs
+++ b/crates/openlake_server/src/s3/app.rs
@@ -9,13 +9,13 @@ use std::convert::Infallible;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use axum::extract::connect_info::Connected;
+use axum::debug_handler;
 use axum::routing::{get, put};
 use axum::Router;
 use compio::net::TcpListener;
 use compio::tls::TlsAcceptor;
 use std::net::SocketAddr;
-
+use axum::extract::{connect_info::Connected, State};
 use crate::config::Config;
 use crate::s3::error::{not_found, AppError};
 use crate::s3::handlers::{buckets, objects};
@@ -23,10 +23,15 @@ use crate::s3::listener::TlsTcpListener;
 use crate::s3::middleware::sigv4::sigv4;
 use crate::s3::state::AppState;
 
-pub fn build_router(state: AppState, cfg: Arc<Config>) -> Router {
+pub fn build_router(
+    state: AppState,
+    cfg: Arc<Config>,
+    disk_info: Vec<openlake_io::DiskInfo>,
+) -> Router {
     let admin_cfg = cfg.clone();
     let ping_cfg = cfg.clone();
-    let disk_cfg = cfg.clone();
+    let disk_state = state.clone();
+    
     let bucket_routes = put(buckets::put_bucket)
         .delete(buckets::delete_bucket)
         .head(buckets::head_bucket)
@@ -51,9 +56,11 @@ pub fn build_router(state: AppState, cfg: Arc<Config>) -> Router {
         )
         .route(
             "/openlake/admin/v1/disk",
-            get(move || {
-                let cfg = disk_cfg.clone();
-                async move { serve_admin_disk(cfg).await }
+            get({
+                let disk_info = disk_info.clone();
+                move || async move {
+                    axum::Json(disk_info)
+                }
             }),
         )
         .route("/{bucket}", bucket_routes.clone())
@@ -90,6 +97,8 @@ async fn serve_admin_config(cfg: Arc<Config>) -> axum::Json<Config> {
 /// Liveness response for `GET /openlake/admin/v1/ping`. Served on the S3
 /// listener (behind SigV4) so cluster tooling can check a node without
 /// touching the inter-node RPC plane.
+
+
 #[derive(serde::Serialize)]
 struct Ping {
     status: &'static str,
@@ -102,17 +111,13 @@ async fn serve_admin_ping(cfg: Arc<Config>) -> axum::Json<Ping> {
         node_id: cfg.self_id,
     })
 }
-#[derive(serde::Serialize)]
-struct DiskInfo {
-    status: &'static str,
-    node_id: u16,
-}
 
-async fn serve_admin_disk(cfg: Arc<Config>) -> axum::Json<DiskInfo> {
-    axum::Json(DiskInfo {
-        status: "ok",
-        node_id: cfg.self_id,
-    })
+#[debug_handler]
+async fn serve_admin_disk(
+    State(state): State<AppState>,
+) -> Result<axum::Json<Vec<openlake_io::DiskInfo>>, AppError>  {
+    let disks = state.engine().disk_info().await?;
+    Ok(axum::Json(disks))
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -136,7 +141,8 @@ pub async fn serve(
     tls: Option<Rc<TlsAcceptor>>,
     cfg: Arc<Config>,
 ) -> Result<(), Infallible> {
-    let app = build_router(state, cfg);
+    let disk_info = state.engine().disk_info().await?;
+    let app = build_router(state, cfg, disk_info);
 
     match tls {
         None => {

--- a/crates/openlake_storage/src/engine.rs
+++ b/crates/openlake_storage/src/engine.rs
@@ -19,9 +19,9 @@ use async_trait::async_trait;
 use futures_util::future::join_all;
 use openlake_io::stream::ByteSink;
 use openlake_io::{
-    BucketMeta, ByteStream, DeleteOptions, ErasureInfo, FileInfo, IoError, ObjectPartInfo,
-    PooledBuffer, RenameDataResp, StorageBackend, UpdateMetadataOpts, VersioningStatus,
-    MULTIPART_VOL, STAGING_VOL, SYSTEM_BUCKET,
+    BucketMeta, ByteStream, DeleteOptions, DiskInfo, ErasureInfo, FileInfo, IoError,
+    ObjectPartInfo, PooledBuffer, RenameDataResp, StorageBackend, UpdateMetadataOpts,
+    VersioningStatus, MULTIPART_VOL, STAGING_VOL, SYSTEM_BUCKET,
 };
 use uuid::Uuid;
 
@@ -328,7 +328,18 @@ impl Engine {
             Err(StorageError::BucketNotFound(bucket.to_owned()))
         }
     }
+    pub async fn disk_info(&self) -> StorageResult<Vec<DiskInfo>> {
+    let backends = self.all_backends()?;
 
+    let mut disk_infos = Vec::new();
+
+    for backend in backends {
+        let info = backend.disk_info().await?;
+        disk_infos.push(info);
+    }
+
+    Ok(disk_infos)
+}
     pub async fn delete_bucket(&self, bucket: &str, force: bool) -> StorageResult<()> {
         validate_bucket_name(bucket)?;
         let _lock = self


### PR DESCRIPTION
Summary
Added a new admin endpoint for disk information.

Changes
- Added `/openlake/admin/v1/disk` route
- Added `serve_admin_disk` handler
- Added basic JSON response with node id and status

Notes
This PR adds the endpoint foundation. Actual disk statistics can be wired using the existing `openlake_io::StorageBackend::disk_info()` flow in a follow-up PR.