### PR TITLE
Add clusterinfo command

### DIFF
--- a/cli/src/commands/cluster/mod.rs
+++ b/cli/src/commands/cluster/mod.rs
@@ -1,3 +1,4 @@
+mod clusterinfo;
 mod down;
 mod status;
 mod topology;
@@ -14,24 +15,29 @@ pub struct Args {
 
 #[derive(Subcommand)]
 pub enum ClusterCmd {
-    /// Print the live state of every node listed in --config.
+   
+    Clusterinfo(clusterinfo::ClusterInfoArgs),
+
+
     Status(status::StatusArgs),
 
-    /// Print the declared node layout from --config; --probe adds live state.
     Topology(topology::TopologyArgs),
 
-    /// Bring the cluster up.
     Up(up::UpArgs),
 
-    /// Bring the cluster down.
     Down(down::DownArgs),
 }
 
 pub async fn run(args: Args) -> Result<()> {
     match args.sub {
+        ClusterCmd::Clusterinfo(a) => clusterinfo::run(a).await,
+
         ClusterCmd::Status(a) => status::run(a).await,
+
         ClusterCmd::Topology(a) => topology::run(a).await,
+
         ClusterCmd::Up(a) => up::run(a).await,
+
         ClusterCmd::Down(a) => down::run(a).await,
     }
 }


### PR DESCRIPTION
Implemented clusterinfo command based on status.rs.
Reads cluster configuration and displays node information.