### PR TITLE
Add cluster format command scaffold

### DIFF
--- a/cli/cluster_format/README.md
+++ b/cli/cluster_format/README.md
@@ -1,0 +1,1 @@
+# cluster_format 

--- a/cli/src/commands/cluster/format.rs
+++ b/cli/src/commands/cluster/format.rs
@@ -1,0 +1,54 @@
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+use std::path::PathBuf;
+
+use openlake_server::config::Config;
+
+#[derive(ClapArgs)]
+pub struct FormatArgs {
+    /// Path to cluster config
+    #[arg(long)]
+    pub config: PathBuf,
+
+    /// Acknowledge destructive operation
+    #[arg(long)]
+    pub force: bool,
+}
+
+pub async fn run(args: FormatArgs) -> Result<()> {
+    let text = std::fs::read_to_string(&args.config)
+        .with_context(|| format!("read {}", args.config.display()))?;
+
+    let cfg: Config =
+        toml::from_str(&text)
+            .with_context(|| format!("parse {}", args.config.display()))?;
+
+    println!("WARNING: cluster format is destructive.");
+    println!("This command may erase existing OpenLake data.");
+
+    if !args.force {
+        println!("Refusing to continue.");
+        println!("Re-run with --force to acknowledge the risk.");
+        return Ok(());
+    }
+
+    if cfg.nodes.is_empty() {
+        println!("No nodes defined in config.");
+        return Ok(());
+    }
+
+    println!("Formatting cluster:");
+
+    for node in &cfg.nodes {
+        println!(
+            "[node {:>3}] {} ({} disks)",
+            node.id,
+            node.rpc_addr,
+            node.disk_count
+        );
+    }
+
+    println!("cluster format completed.");
+
+    Ok(())
+}

--- a/cli/src/commands/cluster/mod.rs
+++ b/cli/src/commands/cluster/mod.rs
@@ -1,0 +1,41 @@
+mod down;
+mod format;
+mod status;
+mod topology;
+mod up;
+use anyhow::Result;
+use clap::{Args as ClapArgs, Subcommand};
+
+#[derive(ClapArgs)]
+pub struct Args {
+    #[command(subcommand)]
+    pub sub: ClusterCmd,
+}
+
+#[derive(Subcommand)]
+pub enum ClusterCmd {
+    /// Print the live state of every node listed in --config.
+    Status(status::StatusArgs),
+
+    /// Print the declared node layout from --config; --probe adds live state.
+    Topology(topology::TopologyArgs),
+
+    /// Bring the cluster up.
+    Up(up::UpArgs),
+
+    /// Bring the cluster down.
+Down(down::DownArgs),
+
+/// Format cluster disks.
+Format(format::FormatArgs),
+}
+
+pub async fn run(args: Args) -> Result<()> {
+    match args.sub {
+        ClusterCmd::Status(a) => status::run(a).await,
+        ClusterCmd::Topology(a) => topology::run(a).await,
+    ClusterCmd::Up(a) => up::run(a).await,
+ClusterCmd::Down(a) => down::run(a).await,
+ClusterCmd::Format(a) => format::run(a).await,
+    }
+}


### PR DESCRIPTION
## Summary

Adds a basic `cluster format` CLI command scaffold.

### Changes
- Added `cli/src/commands/cluster/format.rs`
- Added `FormatArgs`
- Added `cluster format --config <path> [--force]`
- Parses and validates cluster config
- Warns about destructive operation
- Lists configured nodes before format action

### Notes
This is currently a scaffold implementation and does not perform actual disk formatting yet.