### PR TITLE
(#142) [v0.4] Add KV cache offload capability over rdma

### DIFF
--- a/crates/openlake_io/src/rdma/bootstrap.rs
+++ b/crates/openlake_io/src/rdma/bootstrap.rs
@@ -28,6 +28,7 @@ impl ClusterRoutingTable {
                 dct_num: ep.dct_num,
                 dc_key: ep.dc_key,
                 lid: ep.lid,
+                kv_slab: ep.kv_slab,
             },
         );
     }

--- a/crates/openlake_io/src/rdma/buffers.rs
+++ b/crates/openlake_io/src/rdma/buffers.rs
@@ -109,6 +109,9 @@ impl Buffers {
     pub fn lkey(&self) -> u32 {
         self.mem.lkey()
     }
+    pub fn rkey(&self) -> u32 {
+        self.mem.rkey()
+    }
     pub fn buf_size(&self) -> usize {
         self.buf_size
     }

--- a/crates/openlake_io/src/rdma/mod.rs
+++ b/crates/openlake_io/src/rdma/mod.rs
@@ -18,7 +18,7 @@ pub mod wr;
 
 pub use ah_cache::AhCache;
 pub use bootstrap::{ClusterRoutingTable, LocalEndpoint};
-pub use buffers::BUF_SIZE;
+pub use buffers::{Buffers, BUF_SIZE};
 pub use device::IbDevice;
 pub use node::{PeerEndpoint, PendingResponse, RdmaConfig, RdmaNode, RdmaQos, RdmaSetup};
 pub use rdma_buf::{RdmaBuf, RdmaBufPool};

--- a/crates/openlake_io/src/rdma/node.rs
+++ b/crates/openlake_io/src/rdma/node.rs
@@ -31,6 +31,7 @@ pub struct PeerEndpoint {
     pub dct_num: u32,
     pub dc_key: u64,
     pub lid: u16,
+    pub kv_slab: Option<crate::rpc::SlabMeta>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
@@ -111,6 +112,7 @@ impl RdmaNode {
             gid: self_gid,
             dc_key: cfg.dc_key,
             lid: setup.dev.port_attr.lid,
+            kv_slab: None,
         };
         Ok((setup, endpoint))
     }

--- a/crates/openlake_io/src/rdma/wire.rs
+++ b/crates/openlake_io/src/rdma/wire.rs
@@ -11,6 +11,12 @@ pub struct RdmaRemoteBuf {
     pub rkey: u32,
 }
 
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct CommitEntry {
+    pub slot_idx: u32,
+    pub key_hash: u64,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub enum RdmaRequest {
     ReadFileChunk {
@@ -29,6 +35,18 @@ pub enum RdmaRequest {
         length: u32,
         source: RdmaRemoteBuf,
     },
+    BatchReserve {
+        count: u32,
+    },
+    BatchCommit {
+        entries: Vec<CommitEntry>,
+    },
+    BatchLookup {
+        key_hashes: Vec<u64>,
+    },
+    BatchRelease {
+        slot_idxs: Vec<u32>,
+    },
     Generic(Request),
 }
 
@@ -36,6 +54,10 @@ pub enum RdmaRequest {
 pub enum RdmaResponse {
     ChunkReady { bytes_written: u32 },
     ChunkWritten { bytes_written: u32 },
+    BatchReserved { slots: Vec<u32> },
+    BatchCommitted,
+    BatchLookedUp { slots: Vec<Option<u32>> },
+    BatchReleased,
     Generic(Response),
 }
 

--- a/crates/openlake_io/src/rpc.rs
+++ b/crates/openlake_io/src/rpc.rs
@@ -249,6 +249,13 @@ pub enum Response {
     Err(WireError),
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SlabMeta {
+    pub slab_base: u64,
+    pub rkey: u32,
+    pub slot_bytes: u32,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LocalRdmaEndpoint {
     pub runtime_id: u16,
@@ -256,6 +263,8 @@ pub struct LocalRdmaEndpoint {
     pub gid: [u8; 16],
     pub dc_key: u64,
     pub lid: u16,
+    #[serde(default)]
+    pub kv_slab: Option<SlabMeta>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/openlake_server/src/config.rs
+++ b/crates/openlake_server/src/config.rs
@@ -139,6 +139,14 @@ pub struct Config {
     pub transport: TransportMode, // h2 (default) | rdma
     #[serde(default)]
     pub rdma: Option<RdmaToml>, // required when transport = rdma
+    #[serde(default)]
+    pub kv_slab: Option<KvSlabToml>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct KvSlabToml {
+    pub slot_bytes: usize,
+    pub slot_count: usize,
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]

--- a/crates/openlake_server/src/kv_slab.rs
+++ b/crates/openlake_server/src/kv_slab.rs
@@ -1,0 +1,214 @@
+#![cfg(all(feature = "rdma", target_os = "linux"))]
+
+use std::cell::RefCell;
+use std::collections::{HashMap, VecDeque};
+use std::rc::Rc;
+
+use openlake_io::rdma::wire::CommitEntry;
+use openlake_io::rdma::{Buffers, IbDevice};
+
+pub struct SlotPool {
+    free: VecDeque<u32>,
+    by_hash: HashMap<u64, u32>,
+    by_slot: HashMap<u32, u64>,
+    fifo: VecDeque<u64>,
+}
+
+impl SlotPool {
+    pub fn new(slot_count: u32) -> Self {
+        Self {
+            free: (0..slot_count).collect(),
+            by_hash: HashMap::with_capacity(slot_count as usize),
+            by_slot: HashMap::with_capacity(slot_count as usize),
+            fifo: VecDeque::with_capacity(slot_count as usize),
+        }
+    }
+
+    pub fn reserve(&mut self, count: u32) -> Vec<u32> {
+        let mut out = Vec::with_capacity(count as usize);
+        for _ in 0..count {
+            let slot = match self.free.pop_front() {
+                Some(s) => s,
+                None => match self.evict_one() {
+                    Some(s) => s,
+                    None => break,
+                },
+            };
+            out.push(slot);
+        }
+        out
+    }
+
+    pub fn commit(&mut self, slot_idx: u32, key_hash: u64) {
+        if let Some(prev_hash) = self.by_slot.insert(slot_idx, key_hash) {
+            self.by_hash.remove(&prev_hash);
+        }
+        if let Some(prev_slot) = self.by_hash.insert(key_hash, slot_idx) {
+            if prev_slot != slot_idx {
+                self.by_slot.remove(&prev_slot);
+                self.free.push_back(prev_slot);
+            }
+        }
+        self.fifo.push_back(key_hash);
+    }
+
+    pub fn lookup(&self, key_hash: u64) -> Option<u32> {
+        self.by_hash.get(&key_hash).copied()
+    }
+
+    pub fn release(&mut self, slot_idx: u32) {
+        if let Some(hash) = self.by_slot.remove(&slot_idx) {
+            self.by_hash.remove(&hash);
+        }
+        self.free.push_back(slot_idx);
+    }
+
+    #[cfg(test)]
+    pub fn occupancy(&self) -> usize {
+        self.by_hash.len()
+    }
+
+    fn evict_one(&mut self) -> Option<u32> {
+        loop {
+            let candidate = self.fifo.pop_front()?;
+            if let Some(slot) = self.by_hash.remove(&candidate) {
+                self.by_slot.remove(&slot);
+                return Some(slot);
+            }
+        }
+    }
+}
+
+pub struct KvSlab {
+    buffers: Buffers,
+    slots: RefCell<SlotPool>,
+}
+
+impl KvSlab {
+    pub fn new(dev: Rc<IbDevice>, slot_bytes: usize, slot_count: usize) -> std::io::Result<Self> {
+        let buffers = Buffers::new(dev, slot_count, slot_bytes)?;
+        Ok(Self {
+            buffers,
+            slots: RefCell::new(SlotPool::new(slot_count as u32)),
+        })
+    }
+
+    pub fn slab_base(&self) -> u64 {
+        self.buffers.slot_addr(0)
+    }
+    pub fn rkey(&self) -> u32 {
+        self.buffers.rkey()
+    }
+    pub fn slot_bytes(&self) -> u32 {
+        self.buffers.buf_size() as u32
+    }
+
+    pub fn reserve(&self, count: u32) -> Vec<u32> {
+        self.slots.borrow_mut().reserve(count)
+    }
+
+    pub fn commit(&self, entries: &[CommitEntry]) {
+        let mut slots = self.slots.borrow_mut();
+        for e in entries {
+            slots.commit(e.slot_idx, e.key_hash);
+        }
+    }
+
+    pub fn lookup(&self, key_hashes: &[u64]) -> Vec<Option<u32>> {
+        let slots = self.slots.borrow();
+        key_hashes.iter().map(|&k| slots.lookup(k)).collect()
+    }
+
+    pub fn release(&self, slot_idxs: &[u32]) {
+        let mut slots = self.slots.borrow_mut();
+        for &slot in slot_idxs {
+            slots.release(slot);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SlotPool;
+
+    #[test]
+    fn reserve_yields_distinct_slots_until_capacity() {
+        let mut pool = SlotPool::new(4);
+        let first = pool.reserve(3);
+        assert_eq!(first, vec![0, 1, 2]);
+        let second = pool.reserve(2);
+        assert_eq!(second, vec![3]);
+    }
+
+    #[test]
+    fn commit_then_lookup_round_trips() {
+        let mut pool = SlotPool::new(8);
+        let slots = pool.reserve(3);
+        pool.commit(slots[0], 0xAA);
+        pool.commit(slots[1], 0xCC);
+        pool.commit(slots[2], 0xEE);
+        assert_eq!(pool.lookup(0xAA), Some(slots[0]));
+        assert_eq!(pool.lookup(0xCC), Some(slots[1]));
+        assert_eq!(pool.lookup(0xEE), Some(slots[2]));
+        assert_eq!(pool.lookup(0xDE), None);
+    }
+
+    #[test]
+    fn release_returns_slot_to_free_list() {
+        let mut pool = SlotPool::new(2);
+        let slots = pool.reserve(2);
+        pool.commit(slots[0], 1);
+        pool.commit(slots[1], 2);
+        pool.release(slots[0]);
+        assert_eq!(pool.lookup(1), None);
+        let reborrowed = pool.reserve(1);
+        assert_eq!(reborrowed, vec![slots[0]]);
+    }
+
+    #[test]
+    fn eviction_kicks_in_when_full() {
+        let mut pool = SlotPool::new(2);
+        let s0 = pool.reserve(1)[0];
+        pool.commit(s0, 1);
+        let s1 = pool.reserve(1)[0];
+        pool.commit(s1, 2);
+        assert_eq!(pool.occupancy(), 2);
+        let s2 = pool.reserve(1);
+        assert_eq!(s2, vec![s0]);
+        assert_eq!(pool.lookup(1), None);
+        assert_eq!(pool.lookup(2), Some(s1));
+        pool.commit(s2[0], 3);
+        assert_eq!(pool.lookup(3), Some(s2[0]));
+    }
+
+    #[test]
+    fn commit_same_hash_to_different_slot_evicts_old_slot() {
+        let mut pool = SlotPool::new(4);
+        let slots = pool.reserve(2);
+        pool.commit(slots[0], 7);
+        assert_eq!(pool.lookup(7), Some(slots[0]));
+        pool.commit(slots[1], 7);
+        assert_eq!(pool.lookup(7), Some(slots[1]));
+        assert_eq!(pool.occupancy(), 1);
+        let drained = pool.reserve(3);
+        assert!(drained.contains(&slots[0]));
+        assert_eq!(drained.len(), 3);
+    }
+
+    #[test]
+    fn eviction_skips_stale_fifo_entries() {
+        let mut pool = SlotPool::new(2);
+        let s0 = pool.reserve(1)[0];
+        pool.commit(s0, 1);
+        let s1 = pool.reserve(1)[0];
+        pool.commit(s1, 2);
+        pool.release(s0);
+        let s2 = pool.reserve(1)[0];
+        assert_eq!(s2, s0);
+        pool.commit(s2, 3);
+        let next = pool.reserve(1);
+        assert_eq!(next, vec![s1]);
+        assert_eq!(pool.lookup(2), None);
+        assert_eq!(pool.lookup(3), Some(s2));
+    }
+}

--- a/crates/openlake_server/src/main.rs
+++ b/crates/openlake_server/src/main.rs
@@ -32,6 +32,8 @@
 mod auth;
 mod config;
 mod in_memory_store;
+#[cfg(all(feature = "rdma", target_os = "linux"))]
+mod kv_slab;
 mod lock_server;
 #[cfg(all(feature = "rdma", target_os = "linux"))]
 mod rdma_server;
@@ -399,27 +401,47 @@ async fn run_runtime(
     }
 
     #[cfg(all(feature = "rdma", target_os = "linux"))]
-    let rdma_pending: Option<(openlake_io::rdma::RdmaSetup, openlake_io::rdma::RdmaConfig)> =
-        match cfg.transport {
-            config::TransportMode::Rdma => {
-                let rdma_cfg = build_rdma_config(
-                    cfg.rdma.as_ref().expect("rdma transport requires [rdma]"),
-                    runtime_id as u16,
-                    cfg.nodes.len() as u16,
-                );
-                let (setup, my_endpoint) = openlake_io::rdma::RdmaNode::start_local(&rdma_cfg)
-                    .context("rdma start_local")?;
-                {
-                    let mut reg = endpoint_registry.lock().unwrap();
-                    reg.endpoints.push(my_endpoint);
-                    if reg.endpoints.len() >= num_runtimes {
-                        reg.complete = true;
-                    }
-                }
-                Some((setup, rdma_cfg))
+    let rdma_pending: Option<(
+        openlake_io::rdma::RdmaSetup,
+        openlake_io::rdma::RdmaConfig,
+        Option<Rc<kv_slab::KvSlab>>,
+    )> = match cfg.transport {
+        config::TransportMode::Rdma => {
+            let rdma_cfg = build_rdma_config(
+                cfg.rdma.as_ref().expect("rdma transport requires [rdma]"),
+                runtime_id as u16,
+                cfg.nodes.len() as u16,
+            );
+            let (setup, mut my_endpoint) =
+                openlake_io::rdma::RdmaNode::start_local(&rdma_cfg).context("rdma start_local")?;
+            let kv_slab = cfg
+                .kv_slab
+                .map(|s| -> anyhow::Result<Rc<kv_slab::KvSlab>> {
+                    Ok(Rc::new(kv_slab::KvSlab::new(
+                        setup.dev.clone(),
+                        s.slot_bytes,
+                        s.slot_count,
+                    )?))
+                })
+                .transpose()?;
+            if let Some(ref slab) = kv_slab {
+                my_endpoint.kv_slab = Some(openlake_io::rpc::SlabMeta {
+                    slab_base: slab.slab_base(),
+                    rkey: slab.rkey(),
+                    slot_bytes: slab.slot_bytes(),
+                });
             }
-            config::TransportMode::H2 => None,
-        };
+            {
+                let mut reg = endpoint_registry.lock().unwrap();
+                reg.endpoints.push(my_endpoint);
+                if reg.endpoints.len() >= num_runtimes {
+                    reg.complete = true;
+                }
+            }
+            Some((setup, rdma_cfg, kv_slab))
+        }
+        config::TransportMode::H2 => None,
+    };
 
     let auth_state = Rc::new(auth::AuthState::new(cfg.region.clone(), &cfg.credentials));
 
@@ -462,8 +484,11 @@ async fn run_runtime(
     });
 
     #[cfg(all(feature = "rdma", target_os = "linux"))]
+    let mut rdma_kv_slab: Option<Rc<kv_slab::KvSlab>> = None;
+    #[cfg(all(feature = "rdma", target_os = "linux"))]
     let rdma_node: Option<Rc<openlake_io::rdma::RdmaNode>> =
-        if let Some((setup, rdma_cfg)) = rdma_pending {
+        if let Some((setup, rdma_cfg, kv_slab)) = rdma_pending {
+            rdma_kv_slab = kv_slab;
             let mut routing = openlake_io::rdma::ClusterRoutingTable::new(cfg.self_id);
             loop {
                 let reg = endpoint_registry.lock().unwrap();
@@ -559,8 +584,10 @@ async fn run_runtime(
             let local_disks = Rc::new(local_fs_disks.clone());
             let locks = lock_server.clone();
             let endpoints = endpoint_registry.clone();
+            let kv_slab = rdma_kv_slab.clone();
             Some(compio::runtime::spawn(async move {
-                if let Err(e) = rdma_server::serve(node, disks, local_disks, locks, endpoints).await
+                if let Err(e) =
+                    rdma_server::serve(node, disks, local_disks, locks, endpoints, kv_slab).await
                 {
                     tracing::error!(runtime_id, "rdma serve error: {e:#}");
                 }

--- a/crates/openlake_server/src/rdma_server.rs
+++ b/crates/openlake_server/src/rdma_server.rs
@@ -11,6 +11,7 @@ use openlake_io::rpc::{decode, encode, Response, WireError};
 use openlake_io::stream::ByteStream;
 use openlake_io::{LocalFsBackend, StorageBackend};
 
+use crate::kv_slab::KvSlab;
 use crate::lock_server::LockServer;
 use crate::rpc_server::{disk_at, dispatch};
 
@@ -20,6 +21,7 @@ pub async fn serve(
     local_disks: Rc<Vec<Rc<LocalFsBackend>>>,
     locks: Arc<LockServer>,
     endpoints: Arc<std::sync::Mutex<openlake_io::rpc::RdmaEndpointsReply>>,
+    kv_slab: Option<Rc<KvSlab>>,
 ) -> anyhow::Result<()> {
     let mut rx = node
         .pump
@@ -39,8 +41,9 @@ pub async fn serve(
             let ld = local_disks.clone();
             let l = locks.clone();
             let ep = endpoints.clone();
+            let slab = kv_slab.clone();
             compio::runtime::spawn(async move {
-                handle(&n, &d, &ld, &l, &ep, &bytes).await;
+                handle(&n, &d, &ld, &l, &ep, slab.as_ref(), &bytes).await;
             })
             .detach();
         }
@@ -56,6 +59,7 @@ async fn handle(
     local_disks: &Rc<Vec<Rc<LocalFsBackend>>>,
     locks: &Arc<LockServer>,
     endpoints: &Arc<std::sync::Mutex<openlake_io::rpc::RdmaEndpointsReply>>,
+    kv_slab: Option<&Rc<KvSlab>>,
     bytes: &[u8],
 ) {
     let env: Envelope = match decode(bytes) {
@@ -147,6 +151,40 @@ async fn handle(
                     )
                     .await
                 }
+                RdmaRequest::BatchReserve { count } => match kv_slab {
+                    Some(s) => RdmaResponse::BatchReserved {
+                        slots: s.reserve(count),
+                    },
+                    None => RdmaResponse::Generic(Response::Err(WireError::Other(
+                        "kv_slab disabled".into(),
+                    ))),
+                },
+                RdmaRequest::BatchCommit { entries } => match kv_slab {
+                    Some(s) => {
+                        s.commit(&entries);
+                        RdmaResponse::BatchCommitted
+                    }
+                    None => RdmaResponse::Generic(Response::Err(WireError::Other(
+                        "kv_slab disabled".into(),
+                    ))),
+                },
+                RdmaRequest::BatchLookup { key_hashes } => match kv_slab {
+                    Some(s) => RdmaResponse::BatchLookedUp {
+                        slots: s.lookup(&key_hashes),
+                    },
+                    None => RdmaResponse::Generic(Response::Err(WireError::Other(
+                        "kv_slab disabled".into(),
+                    ))),
+                },
+                RdmaRequest::BatchRelease { slot_idxs } => match kv_slab {
+                    Some(s) => {
+                        s.release(&slot_idxs);
+                        RdmaResponse::BatchReleased
+                    }
+                    None => RdmaResponse::Generic(Response::Err(WireError::Other(
+                        "kv_slab disabled".into(),
+                    ))),
+                },
                 RdmaRequest::Generic(req) => {
                     RdmaResponse::Generic(dispatch(disks, locks, endpoints, req).await)
                 }

--- a/crates/openlake_server/src/s3/app.rs
+++ b/crates/openlake_server/src/s3/app.rs
@@ -10,6 +10,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use axum::extract::connect_info::Connected;
+use axum::extract::DefaultBodyLimit;
 use axum::routing::{get, put};
 use axum::Router;
 use compio::net::TcpListener;
@@ -64,6 +65,7 @@ pub fn build_router(state: AppState, cfg: Arc<Config>) -> Router {
             "/openlake/cache/{*key}",
             get(in_memory_store::get).put(in_memory_store::put),
         )
+        .layer(DefaultBodyLimit::disable())
         .with_state(state)
 }
 


### PR DESCRIPTION
 - Add KV cache offload support for inference usecases
 - Openlake can be configured as an external endpoint to request for new slabs and commit writes in bulk