### PR TITLE
(#146) [v0.4] Fix sigv4 verification for aws sdk v1 clients

### DIFF
--- a/crates/openlake_server/src/auth.rs
+++ b/crates/openlake_server/src/auth.rs
@@ -611,6 +611,7 @@ fn s3_signing_settings() -> SigningSettings {
     s.payload_checksum_kind = PayloadChecksumKind::XAmzSha256;
     s.uri_path_normalization_mode = UriPathNormalizationMode::Disabled;
     s.session_token_mode = SessionTokenMode::Include;
+    s.excluded_headers = Some(Vec::new());
     s
 }
 


### PR DESCRIPTION
 - s3 requests from aws sdk v1 clients (flink presto and hadoop s3a connectors, older boto) get 403 due to aws crate stripping out reserved headers under default settings.
 - Ensure headers are not stripped unnecessarily.
 