### PR TITLE
(#149) [v0.4] Fix object delete nested objects for shared prefix

### DIFF
--- a/crates/openlake_io/src/local_fs.rs
+++ b/crates/openlake_io/src/local_fs.rs
@@ -350,6 +350,44 @@ impl LocalFsBackend {
         crate::purge::try_enqueue(slot);
         Ok(())
     }
+
+    async fn delete_object_scoped(&self, volume: &str, path: &str) -> IoResult<()> {
+        self.require_vol(volume).await?;
+        let object_dir = self.file_path(volume, path);
+        let meta = object_dir.join(META_FILENAME);
+        let raw = match compio::fs::read(&meta).await {
+            Ok(b) => bytes::Bytes::from(b),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Err(IoError::FileNotFound {
+                    volume: volume.to_owned(),
+                    path: path.to_owned(),
+                });
+            }
+            Err(e) => return Err(IoError::Io(e)),
+        };
+        if let Ok(records) = xl_meta::decode_all(raw) {
+            for rec in &records {
+                if !rec.data_dir.is_empty() {
+                    let _ = self.move_to_trash(&object_dir.join(&rec.data_dir)).await;
+                }
+            }
+        }
+        compio::fs::remove_file(&meta).await.map_err(IoError::Io)?;
+        let _ = compio::fs::remove_file(&object_dir.join(META_BACKUP_FILENAME)).await;
+
+        let vol_root = self.vol_path(volume);
+        let mut cur = object_dir;
+        while cur.starts_with(&vol_root) && cur != vol_root {
+            if compio::fs::remove_dir(&cur).await.is_err() {
+                break;
+            }
+            match cur.parent() {
+                Some(p) => cur = p.to_path_buf(),
+                None => break,
+            }
+        }
+        Ok(())
+    }
 }
 
 fn map_open_err(e: std::io::Error, volume: &str, path: &str) -> IoError {
@@ -819,12 +857,12 @@ impl StorageBackend for LocalFsBackend {
         &self,
         volume: &str,
         paths: &[&str],
-        recursive: bool,
+        _recursive: bool,
     ) -> IoResult<Vec<IoResult<()>>> {
         self.require_vol(volume).await?;
         let futs = paths.iter().map(|p| {
             let path = (*p).to_owned();
-            async move { self.delete(volume, &path, recursive).await }
+            async move { self.delete_object_scoped(volume, &path).await }
         });
         let results = futures_util::future::join_all(futs).await;
         Ok(results)
@@ -953,7 +991,7 @@ impl StorageBackend for LocalFsBackend {
         opts: &DeleteOptions,
     ) -> IoResult<()> {
         if !opts.undo_write {
-            return self.delete(volume, path, true).await;
+            return self.delete_object_scoped(volume, path).await;
         }
 
         let object_dir = self.file_path(volume, path);

--- a/crates/openlake_storage/src/engine.rs
+++ b/crates/openlake_storage/src/engine.rs
@@ -1150,7 +1150,16 @@ impl Engine {
             let b = b.clone();
             let bucket = bucket.to_owned();
             let key = key.to_owned();
-            async move { b.delete(&bucket, &key, true).await }
+            async move {
+                b.delete_version(
+                    &bucket,
+                    &key,
+                    &FileInfo::default(),
+                    false,
+                    &DeleteOptions::default(),
+                )
+                .await
+            }
         }))
         .await;
 
@@ -2912,6 +2921,37 @@ mod tests {
         e.delete("buk", "k").await.unwrap();
         assert!(matches!(
             e.get("buk", "k").await,
+            Err(StorageError::ObjectNotFound { .. })
+        ));
+    }
+
+    #[compio::test]
+    async fn delete_marker_key_preserves_nested_object() {
+        let (_dirs, e) = eng(3, 3).await;
+        put_bytes(&e, "buk", "p/", Vec::new(), None).await;
+        put_bytes(&e, "buk", "p/obj", b"body".to_vec(), None).await;
+
+        e.delete("buk", "p/").await.unwrap();
+
+        let (info, _) = e.get("buk", "p/obj").await.expect("nested object survives marker delete");
+        assert_eq!(info.size, 4);
+        assert!(matches!(
+            e.get("buk", "p/").await,
+            Err(StorageError::ObjectNotFound { .. })
+        ));
+    }
+
+    #[compio::test]
+    async fn delete_nested_object_preserves_marker() {
+        let (_dirs, e) = eng(3, 3).await;
+        put_bytes(&e, "buk", "p/", Vec::new(), None).await;
+        put_bytes(&e, "buk", "p/obj", b"body".to_vec(), None).await;
+
+        e.delete("buk", "p/obj").await.unwrap();
+
+        assert!(e.get("buk", "p/").await.is_ok());
+        assert!(matches!(
+            e.get("buk", "p/obj").await,
             Err(StorageError::ObjectNotFound { .. })
         ));
     }


### PR DESCRIPTION
 - Openlake does a recursive delete on local disk for batched deletes
 - Local folders having an xl meta within can be objects and should not be deleted
 - Ensure this does not happen by prechecking the xl presence before issuing a delete
