### PR TITLE
(#152) [v0.4] Migrate from blake3 to md5 for etag validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,6 +2248,7 @@ dependencies = [
  "compio",
  "futures-util",
  "hex",
+ "md-5",
  "openlake_io",
  "reed-solomon-simd",
  "regex",

--- a/crates/openlake_server/src/s3/handlers/objects.rs
+++ b/crates/openlake_server/src/s3/handlers/objects.rs
@@ -669,16 +669,8 @@ fn is_hex_sha256(s: &str) -> bool {
 fn extract_blake3_claim(headers: &HeaderMap) -> Result<Option<String>, AppError> {
     let mut blake3: Option<String> = None;
     for (name, value) in headers.iter() {
-        let n = name.as_str();
-        if !n.starts_with("x-amz-checksum-") {
+        if name.as_str() != "x-amz-checksum-blake3" {
             continue;
-        }
-        if n != "x-amz-checksum-blake3" {
-            return Err(AppError::BadRequest(
-                "only x-amz-checksum-blake3 is supported; other checksum \
-                 algorithms (sha256/sha1/crc32/crc32c/crc64nvme/md5/sha512/\
-                 xxhash*) are rejected — use blake3",
-            ));
         }
         let hex = value
             .to_str()

--- a/crates/openlake_storage/Cargo.toml
+++ b/crates/openlake_storage/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace      = true
 [dependencies]
 openlake_io = { path = "../openlake_io" }
 
+md-5         = "0.10"
 compio       = { workspace = true }
 futures-util = { workspace = true }
 bytes        = { workspace = true }

--- a/crates/openlake_storage/src/engine.rs
+++ b/crates/openlake_storage/src/engine.rs
@@ -23,6 +23,7 @@ use openlake_io::{
     PooledBuffer, RenameDataResp, StorageBackend, UpdateMetadataOpts, VersioningStatus,
     MULTIPART_VOL, STAGING_VOL, SYSTEM_BUCKET,
 };
+use md5::Digest as _;
 use uuid::Uuid;
 
 use crate::cluster::{ClusterConfig, DiskAddr, NodeId};
@@ -661,7 +662,7 @@ impl Engine {
             etag_concat.extend_from_slice(&raw);
         }
 
-        let assembled_etag = format!("{}-{}", blake3::hash(&etag_concat).to_hex(), parts.len());
+        let assembled_etag = format!("{}-{}", hex::encode(md5::Md5::digest(&etag_concat)), parts.len());
         let mod_time_ms = now_ms();
 
         let parts_for_fi: Vec<ObjectPartInfo> = part_infos.iter().cloned().collect();
@@ -2342,7 +2343,7 @@ async fn drain_inline_payload(
     payload_len: usize,
 ) -> openlake_io::IoResult<(Vec<bytes::Bytes>, String)> {
     let mut frames: Vec<bytes::Bytes> = Vec::new();
-    let mut hasher = blake3::Hasher::new();
+    let mut hasher = md5::Md5::new();
     let mut total = 0usize;
     while total < payload_len {
         let chunk = src.read().await?;
@@ -2362,7 +2363,7 @@ async fn drain_inline_payload(
         total += frame.len();
         frames.push(frame);
     }
-    Ok((frames, hasher.finalize().to_hex().to_string()))
+    Ok((frames, hex::encode(hasher.finalize())))
 }
 
 /// Cluster-wide nominal EC contract recorded on every persisted
@@ -2556,7 +2557,7 @@ async fn encode_and_write_stripes(
 ) -> openlake_io::IoResult<(String, Vec<Box<dyn ByteSink>>)> {
     let mut slots: Vec<Option<Box<dyn ByteSink>>> = sinks.into_iter().map(Some).collect();
     let n = slots.len();
-    let mut etag_hasher = blake3::Hasher::new();
+    let mut etag_hasher = md5::Md5::new();
     let mut consumed: u64 = 0;
     let mut carry: bytes::Bytes = bytes::Bytes::new();
 
@@ -2632,7 +2633,7 @@ async fn encode_and_write_stripes(
         .into_iter()
         .map(|s| s.expect("every sink slot must hold a sink at end of stripe loop"))
         .collect();
-    Ok((etag_hasher.finalize().to_hex().to_string(), sinks))
+    Ok((hex::encode(etag_hasher.finalize()), sinks))
 }
 
 /// Drive every sink's `finish` in parallel — flush + read the


### PR DESCRIPTION
 - Blake3 is more performant however not all clients expect this and expect the md5 validation
 - Migrate from blake3 to md5 for checksum validation
