### PR TITLE
(#159) [v0.5] feat(s3): add basic CopyObject support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2218,6 +2218,7 @@ dependencies = [
  "nix",
  "openlake_io",
  "openlake_storage",
+ "percent-encoding",
  "quick-xml",
  "rcgen",
  "rustls",

--- a/crates/openlake_server/Cargo.toml
+++ b/crates/openlake_server/Cargo.toml
@@ -61,6 +61,7 @@ md-5               = "0.10"
 # rustls-pemfile is the cert/key loader.
 rustls             = { workspace = true }
 rustls-pemfile     = { workspace = true }
+percent-encoding = "2.3.2"
 
 [dev-dependencies]
 rcgen              = { workspace = true }

--- a/crates/openlake_server/src/s3/handlers/objects.rs
+++ b/crates/openlake_server/src/s3/handlers/objects.rs
@@ -543,6 +543,9 @@ pub async fn put_object(
     headers: HeaderMap,
     body: Body,
 ) -> Result<Response, AppError> {
+    if let Some(copy_source) = headers.get("x-amz-copy-source").cloned() {
+        return copy_object(state, bucket, key, copy_source).await;
+    }
     match (query.part_number, query.upload_id.as_deref()) {
         (Some(n), Some(uid)) => {
             return upload_part_handler(state, bucket, key, uid.to_owned(), n, headers, body).await
@@ -596,6 +599,65 @@ pub async fn put_object(
         }
     }
     Ok((StatusCode::OK, headers).into_response())
+}
+fn rfc3339_from_ms(ms: u64) -> String {
+    use time::format_description::well_known::Rfc3339;
+    use time::OffsetDateTime;
+    OffsetDateTime::from_unix_timestamp_nanos((ms as i128) * 1_000_000)
+        .ok()
+        .and_then(|dt| dt.format(&Rfc3339).ok())
+        .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_owned())
+}
+
+fn parse_copy_source(value: &HeaderValue) -> Result<(String, String), AppError> {
+    let raw = value
+        .to_str()
+        .map_err(|_| AppError::Malformed("x-amz-copy-source must be ASCII"))?;
+
+    let raw = raw.trim_start_matches('/');
+    let decoded = raw.to_owned();
+
+    let (bucket, key) = decoded
+        .split_once('/')
+        .ok_or(AppError::Malformed("x-amz-copy-source must be /bucket/key"))?;
+
+    if bucket.is_empty() || key.is_empty() {
+        return Err(AppError::Malformed("x-amz-copy-source must be /bucket/key"));
+    }
+
+    Ok((bucket.to_owned(), key.to_owned()))
+}
+
+fn copy_object(
+    state: AppState,
+    dst_bucket: String,
+    dst_key: String,
+    copy_source: HeaderValue,
+) -> SendWrapper<impl std::future::Future<Output = Result<Response, AppError>>> {
+    SendWrapper::new(async move {
+        let (src_bucket, src_key) = parse_copy_source(&copy_source)?;
+        let engine = state.engine().clone();
+
+        let (src_info, mut src_stream) = engine.get(&src_bucket, &src_key).await?;
+        let content_type = src_info.content_type.clone();
+
+        let dst_info = engine
+            .put(
+                &dst_bucket,
+                &dst_key,
+                src_info.size,
+                src_stream.as_mut(),
+                content_type,
+            )
+            .await?;
+
+        let body = crate::s3::xml::CopyObjectResult::new(
+            rfc3339_from_ms(dst_info.modified_ms),
+            format!("\"{}\"", dst_info.etag),
+        );
+
+        Ok(crate::s3::xml::Xml(body).into_response())
+    })
 }
 
 async fn upload_part_handler(

--- a/crates/openlake_server/src/s3/handlers/objects.rs
+++ b/crates/openlake_server/src/s3/handlers/objects.rs
@@ -544,7 +544,7 @@ pub async fn put_object(
     body: Body,
 ) -> Result<Response, AppError> {
     if let Some(copy_source) = headers.get("x-amz-copy-source").cloned() {
-        return copy_object(state, bucket, key, copy_source).await;
+        return copy_object(state, bucket, key, copy_source, headers).await;
     }
     match (query.part_number, query.upload_id.as_deref()) {
         (Some(n), Some(uid)) => {
@@ -615,7 +615,15 @@ fn parse_copy_source(value: &HeaderValue) -> Result<(String, String), AppError> 
         .map_err(|_| AppError::Malformed("x-amz-copy-source must be ASCII"))?;
 
     let raw = raw.trim_start_matches('/');
-    let decoded = raw.to_owned();
+    let decoded = percent_encoding::percent_decode_str(raw)
+        .decode_utf8()
+        .map_err(|_| AppError::Malformed("x-amz-copy-source must be valid UTF-8"))?;
+
+    if decoded.contains("?versionId=") {
+        return Err(AppError::NotImplemented(
+            "CopyObject with versionId is not supported",
+        ));
+    }
 
     let (bucket, key) = decoded
         .split_once('/')
@@ -633,9 +641,29 @@ fn copy_object(
     dst_bucket: String,
     dst_key: String,
     copy_source: HeaderValue,
+    headers: HeaderMap,
 ) -> SendWrapper<impl std::future::Future<Output = Result<Response, AppError>>> {
     SendWrapper::new(async move {
         let (src_bucket, src_key) = parse_copy_source(&copy_source)?;
+        if headers
+            .get("x-amz-metadata-directive")
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| !v.eq_ignore_ascii_case("COPY"))
+        {
+            return Err(AppError::NotImplemented(
+                "CopyObject metadata replacement is not supported",
+            ));
+        }
+
+        if headers
+            .get("x-amz-tagging-directive")
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| !v.eq_ignore_ascii_case("COPY"))
+        {
+            return Err(AppError::NotImplemented(
+                "CopyObject tagging replacement is not supported",
+            ));
+        }
         let engine = state.engine().clone();
 
         let (src_info, mut src_stream) = engine.get(&src_bucket, &src_key).await?;
@@ -930,4 +958,41 @@ fn http_date_rfc1123(ms: u64) -> String {
     let dt = OffsetDateTime::from_unix_timestamp(secs).unwrap_or(OffsetDateTime::UNIX_EPOCH);
     dt.format(&FMT)
         .unwrap_or_else(|_| "Thu, 01 Jan 1970 00:00:00 GMT".into())
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    #[test]
+    fn parse_copy_source_accepts_bucket_and_key() {
+        let header = HeaderValue::from_static("/bucket/path/to/object.parquet");
+        let (bucket, key) = parse_copy_source(&header).unwrap();
+
+        assert_eq!(bucket, "bucket");
+        assert_eq!(key, "path/to/object.parquet");
+    }
+
+    #[test]
+    fn parse_copy_source_decodes_percent_encoded_key() {
+        let header = HeaderValue::from_static("/bucket/path%20with%20spaces/file.parquet");
+        let (bucket, key) = parse_copy_source(&header).unwrap();
+
+        assert_eq!(bucket, "bucket");
+        assert_eq!(key, "path with spaces/file.parquet");
+    }
+
+    #[test]
+    fn parse_copy_source_rejects_missing_key() {
+        let header = HeaderValue::from_static("/bucket");
+
+        assert!(parse_copy_source(&header).is_err());
+    }
+
+    #[test]
+    fn parse_copy_source_rejects_version_id() {
+        let header = HeaderValue::from_static("/bucket/path/file.parquet?versionId=abc123");
+
+        assert!(parse_copy_source(&header).is_err());
+    }
 }

--- a/crates/openlake_server/src/s3/xml.rs
+++ b/crates/openlake_server/src/s3/xml.rs
@@ -224,3 +224,24 @@ impl CompleteMultipartUploadResult {
         }
     }
 }
+/// `<CopyObjectResult>` response returned by S3 CopyObject.
+#[derive(Serialize)]
+#[serde(rename = "CopyObjectResult")]
+pub struct CopyObjectResult {
+    #[serde(rename = "@xmlns")]
+    pub xmlns: &'static str,
+    #[serde(rename = "LastModified")]
+    pub last_modified: String,
+    #[serde(rename = "ETag")]
+    pub etag: String,
+}
+
+impl CopyObjectResult {
+    pub fn new(last_modified: String, etag: String) -> Self {
+        Self {
+            xmlns: S3_NS,
+            last_modified,
+            etag,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds basic S3 `CopyObject` support to OpenLake.

While validating the Spark + OpenLake integration, Spark writes failed during the output commit stage because the Hadoop S3A connector performs object renames using the S3 `CopyObject` API followed by `DeleteObject`.

This implementation handles `PUT` requests containing the `x-amz-copy-source` header by:

* parsing the source bucket and object key
* reading the source object through the storage engine
* writing the object to the destination key
* returning a standard `CopyObjectResult` XML response

## Testing

Verified locally using Spark 3.5.5 and Hadoop S3A:

* Successfully wrote a Spark DataFrame to `s3a://test-bucket/users`
* Verified the generated `_SUCCESS` marker and Parquet files
* Successfully read the Parquet data back from OpenLake using Spark

This implementation was developed while validating the Spark documentation workflow and has been separated into its own PR for independent review.
