### PR TITLE
(#170) [v0.6] Introduce metrics module to track cluster performance 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2211,6 +2211,7 @@ dependencies = [
  "futures-util",
  "hex",
  "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "httparse",
  "hwlocality",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ tower        = { version = "0.5", features = ["util"] }
 tower-http   = { version = "0.6", default-features = false, features = ["trace"] }
 # `BodyExt::frame` extension trait used by the PUT body adapter to
 # pull `Frame<Bytes>` from `axum::body::Body` one chunk at a time.
+http-body = "1"
 http-body-util = "0.1"
 
 # Thread-per-core plumbing: `nix` for `sched_setaffinity`, `socket2`

--- a/crates/openlake_io/src/lib.rs
+++ b/crates/openlake_io/src/lib.rs
@@ -15,6 +15,7 @@ pub mod alloc;
 pub mod backend;
 pub mod error;
 pub mod local_fs;
+pub mod net_metrics;
 pub mod node_info;
 pub mod purge;
 #[cfg(all(feature = "rdma", target_os = "linux"))]

--- a/crates/openlake_io/src/net_metrics.rs
+++ b/crates/openlake_io/src/net_metrics.rs
@@ -1,0 +1,151 @@
+//! Inter-node operation metrics per `(transport, class)` cell, so the
+//! RDMA-verbs plane and the h2/IPoIB plane are separable. Ops the RDMA
+//! backend falls back on route through `RemoteBackend` and therefore
+//! count as `h2`. Rendered by the server's metrics endpoint; honors
+//! `OPENLAKE_METRICS=0`.
+
+use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
+use std::sync::OnceLock;
+
+/// Latency histogram upper bounds, microseconds; last bucket is +Inf.
+const LE_US: [u64; 8] = [50, 200, 1_000, 5_000, 20_000, 100_000, 500_000, 5_000_000];
+
+#[derive(Clone, Copy)]
+#[repr(usize)]
+pub enum Transport {
+    Rdma,
+    H2,
+}
+
+#[derive(Clone, Copy)]
+#[repr(usize)]
+pub enum Class {
+    Unary,
+    ReadStream,
+    WriteStream,
+}
+
+const TRANSPORT_NAMES: [&str; 2] = ["rdma", "h2"];
+const CLASS_NAMES: [&str; 3] = ["unary", "read_stream", "write_stream"];
+
+fn enabled() -> bool {
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("OPENLAKE_METRICS").map_or(true, |v| v != "0"))
+}
+
+#[derive(Default)]
+struct Cell {
+    ops: AtomicU64,
+    errors: AtomicU64,
+    bytes: AtomicU64,
+    lat_us_sum: AtomicU64,
+    lat_buckets: [AtomicU64; LE_US.len() + 1],
+}
+
+static REGISTRY: [[Cell; 3]; 2] = {
+    #[allow(clippy::declare_interior_mutable_const)]
+    const Z: AtomicU64 = AtomicU64::new(0);
+    #[allow(clippy::declare_interior_mutable_const)]
+    const C: Cell = Cell {
+        ops: Z,
+        errors: Z,
+        bytes: Z,
+        lat_us_sum: Z,
+        lat_buckets: [Z; 9],
+    };
+    #[allow(clippy::declare_interior_mutable_const)]
+    const ROW: [Cell; 3] = [C; 3];
+    [ROW; 2]
+};
+
+pub fn observe(t: Transport, c: Class, latency_us: u64, err: bool) {
+    if !enabled() {
+        return;
+    }
+    let cell = &REGISTRY[t as usize][c as usize];
+    cell.ops.fetch_add(1, Relaxed);
+    if err {
+        cell.errors.fetch_add(1, Relaxed);
+    }
+    cell.lat_us_sum.fetch_add(latency_us, Relaxed);
+    let idx = LE_US
+        .iter()
+        .position(|le| latency_us <= *le)
+        .unwrap_or(LE_US.len());
+    cell.lat_buckets[idx].fetch_add(1, Relaxed);
+}
+
+pub fn add_bytes(t: Transport, c: Class, n: u64) {
+    if !enabled() || n == 0 {
+        return;
+    }
+    REGISTRY[t as usize][c as usize].bytes.fetch_add(n, Relaxed);
+}
+
+pub fn render() -> String {
+    use std::fmt::Write;
+    let mut out = String::with_capacity(8 * 1024);
+    out.push_str("# TYPE openlake_internode_ops_total counter\n");
+    out.push_str("# TYPE openlake_internode_errors_total counter\n");
+    out.push_str("# TYPE openlake_internode_bytes_total counter\n");
+    out.push_str("# TYPE openlake_internode_latency_us histogram\n");
+    for (ti, tname) in TRANSPORT_NAMES.iter().enumerate() {
+        for (ci, cname) in CLASS_NAMES.iter().enumerate() {
+            let cell = &REGISTRY[ti][ci];
+            let ops = cell.ops.load(Relaxed);
+            let bytes = cell.bytes.load(Relaxed);
+            if ops == 0 && bytes == 0 {
+                continue;
+            }
+            let lbl = format!("transport=\"{tname}\",class=\"{cname}\"");
+            let _ = writeln!(out, "openlake_internode_ops_total{{{lbl}}} {ops}");
+            let _ = writeln!(
+                out,
+                "openlake_internode_errors_total{{{lbl}}} {}",
+                cell.errors.load(Relaxed)
+            );
+            let _ = writeln!(out, "openlake_internode_bytes_total{{{lbl}}} {bytes}");
+            let mut cumulative = 0u64;
+            for (b, le) in LE_US.iter().enumerate() {
+                cumulative += cell.lat_buckets[b].load(Relaxed);
+                let _ = writeln!(
+                    out,
+                    "openlake_internode_latency_us_bucket{{{lbl},le=\"{le}\"}} {cumulative}"
+                );
+            }
+            cumulative += cell.lat_buckets[LE_US.len()].load(Relaxed);
+            let _ = writeln!(
+                out,
+                "openlake_internode_latency_us_bucket{{{lbl},le=\"+Inf\"}} {cumulative}"
+            );
+            let _ = writeln!(
+                out,
+                "openlake_internode_latency_us_sum{{{lbl}}} {}",
+                cell.lat_us_sum.load(Relaxed)
+            );
+            let _ = writeln!(
+                out,
+                "openlake_internode_latency_us_count{{{lbl}}} {cumulative}"
+            );
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observe_and_render() {
+        observe(Transport::Rdma, Class::ReadStream, 180, false);
+        add_bytes(Transport::Rdma, Class::ReadStream, 4 * 1024 * 1024);
+        observe(Transport::H2, Class::Unary, 900, true);
+        let text = render();
+        assert!(text
+            .contains("openlake_internode_bytes_total{transport=\"rdma\",class=\"read_stream\"}"));
+        assert!(
+            text.contains("openlake_internode_errors_total{transport=\"h2\",class=\"unary\"} 1")
+        );
+    }
+}

--- a/crates/openlake_io/src/rdma_backend.rs
+++ b/crates/openlake_io/src/rdma_backend.rs
@@ -54,6 +54,18 @@ impl RdmaBackend {
     }
 
     async fn unary(&self, payload: Request) -> IoResult<Response> {
+        let start = std::time::Instant::now();
+        let result = self.unary_inner(payload).await;
+        crate::net_metrics::observe(
+            crate::net_metrics::Transport::Rdma,
+            crate::net_metrics::Class::Unary,
+            start.elapsed().as_micros() as u64,
+            result.is_err(),
+        );
+        result
+    }
+
+    async fn unary_inner(&self, payload: Request) -> IoResult<Response> {
         let peer = self
             .node
             .peer(self.peer_id)
@@ -131,6 +143,30 @@ impl RdmaBackend {
     }
 
     async fn read_single_chunk(
+        &self,
+        volume: &str,
+        path: &str,
+        offset: u64,
+        length: u32,
+    ) -> IoResult<Bytes> {
+        use crate::net_metrics::{self, Class, Transport};
+        let start = std::time::Instant::now();
+        let result = self
+            .read_single_chunk_inner(volume, path, offset, length)
+            .await;
+        net_metrics::observe(
+            Transport::Rdma,
+            Class::ReadStream,
+            start.elapsed().as_micros() as u64,
+            result.is_err(),
+        );
+        if let Ok(chunk) = &result {
+            net_metrics::add_bytes(Transport::Rdma, Class::ReadStream, chunk.len() as u64);
+        }
+        result
+    }
+
+    async fn read_single_chunk_inner(
         &self,
         volume: &str,
         path: &str,
@@ -237,6 +273,31 @@ impl RdmaBackend {
     }
 
     async fn write_single_chunk(
+        &self,
+        volume: &str,
+        path: &str,
+        offset: u64,
+        data: Bytes,
+    ) -> IoResult<()> {
+        use crate::net_metrics::{self, Class, Transport};
+        let len = data.len() as u64;
+        let start = std::time::Instant::now();
+        let result = self
+            .write_single_chunk_inner(volume, path, offset, data)
+            .await;
+        net_metrics::observe(
+            Transport::Rdma,
+            Class::WriteStream,
+            start.elapsed().as_micros() as u64,
+            result.is_err(),
+        );
+        if result.is_ok() {
+            net_metrics::add_bytes(Transport::Rdma, Class::WriteStream, len);
+        }
+        result
+    }
+
+    async fn write_single_chunk_inner(
         &self,
         volume: &str,
         path: &str,

--- a/crates/openlake_io/src/remote_fs.rs
+++ b/crates/openlake_io/src/remote_fs.rs
@@ -181,27 +181,41 @@ impl RemoteBackend {
     /// undecodable bodies fall back to a generic
     /// `rpc http <status>` error.
     async fn unary(&self, req: Request) -> IoResult<Response> {
+        use crate::net_metrics::{self, Class, Transport};
         let body = rpc::encode(&req)?;
-        let resp = self
-            .peer
-            .client
-            .post(self.peer.url(URL_RPC))
-            .map_err(map_http)?
-            .body(body)
-            .send()
-            .await
-            .map_err(map_http)?;
-        let status = resp.status();
-        let bytes = resp.bytes().await.map_err(map_http)?;
-        if !status.is_success() {
-            if let Ok(Response::Err(e)) = rpc::decode::<Response>(&bytes) {
-                return Err(e.into());
+        let sent = body.len() as u64;
+        let start = std::time::Instant::now();
+        let result: IoResult<Response> = async {
+            let resp = self
+                .peer
+                .client
+                .post(self.peer.url(URL_RPC))
+                .map_err(map_http)?
+                .body(body)
+                .send()
+                .await
+                .map_err(map_http)?;
+            let status = resp.status();
+            let bytes = resp.bytes().await.map_err(map_http)?;
+            net_metrics::add_bytes(Transport::H2, Class::Unary, sent + bytes.len() as u64);
+            if !status.is_success() {
+                if let Ok(Response::Err(e)) = rpc::decode::<Response>(&bytes) {
+                    return Err(e.into());
+                }
+                return Err(IoError::Io(std::io::Error::other(format!(
+                    "rpc http status: {status}"
+                ))));
             }
-            return Err(IoError::Io(std::io::Error::other(format!(
-                "rpc http status: {status}"
-            ))));
+            rpc::decode::<Response>(&bytes)
         }
-        rpc::decode::<Response>(&bytes)
+        .await;
+        net_metrics::observe(
+            Transport::H2,
+            Class::Unary,
+            start.elapsed().as_micros() as u64,
+            result.is_err(),
+        );
+        result
     }
 
     /// Lock-plane: acquire. Both lock RPCs ride the same unary route
@@ -320,6 +334,11 @@ impl ByteStream for RemoteReadStream {
                     ))));
                 }
                 self.remaining -= n;
+                crate::net_metrics::add_bytes(
+                    crate::net_metrics::Transport::H2,
+                    crate::net_metrics::Class::ReadStream,
+                    n,
+                );
                 Ok(buf)
             }
             Some(Err(e)) => Err(map_http(e)),
@@ -352,6 +371,7 @@ pub struct RemoteWriteSink {
     expected: u64,
     written: u64,
     finished: bool,
+    start: std::time::Instant,
 }
 
 #[async_trait(?Send)]
@@ -375,6 +395,11 @@ impl ByteSink for RemoteWriteSink {
             .await
             .map_err(|_| IoError::Io(std::io::Error::other("peer body channel closed")))?;
         self.written += len;
+        crate::net_metrics::add_bytes(
+            crate::net_metrics::Transport::H2,
+            crate::net_metrics::Class::WriteStream,
+            len,
+        );
         Ok(())
     }
 
@@ -383,6 +408,19 @@ impl ByteSink for RemoteWriteSink {
             return Ok(());
         }
         self.finished = true;
+        let result = self.finish_inner().await;
+        crate::net_metrics::observe(
+            crate::net_metrics::Transport::H2,
+            crate::net_metrics::Class::WriteStream,
+            self.start.elapsed().as_micros() as u64,
+            result.is_err(),
+        );
+        result
+    }
+}
+
+impl RemoteWriteSink {
+    async fn finish_inner(&mut self) -> IoResult<()> {
         if self.written != self.expected {
             return Err(IoError::Io(std::io::Error::new(
                 std::io::ErrorKind::UnexpectedEof,
@@ -582,6 +620,7 @@ impl StorageBackend for RemoteBackend {
             expected: size,
             written: 0,
             finished: false,
+            start: std::time::Instant::now(),
         }))
     }
 

--- a/crates/openlake_server/Cargo.toml
+++ b/crates/openlake_server/Cargo.toml
@@ -23,6 +23,7 @@ axum               = { workspace = true }
 send_wrapper       = { workspace = true }
 tower              = { workspace = true }
 tower-http         = { workspace = true }
+http-body          = { workspace = true }
 http-body-util     = { workspace = true }
 nix                = { workspace = true }
 socket2            = { workspace = true }

--- a/crates/openlake_server/src/s3/app.rs
+++ b/crates/openlake_server/src/s3/app.rs
@@ -65,6 +65,11 @@ pub fn build_router(state: AppState, cfg: Arc<Config>) -> Router {
             "/openlake/cache/{*key}",
             get(in_memory_store::get).put(in_memory_store::put),
         )
+        .route(
+            "/openlake/admin/v1/metrics",
+            get(|| async { crate::s3::metrics::render() }),
+        )
+        .layer(axum::middleware::from_fn(crate::s3::metrics::meter))
         .layer(DefaultBodyLimit::disable())
         .with_state(state)
 }

--- a/crates/openlake_server/src/s3/metrics.rs
+++ b/crates/openlake_server/src/s3/metrics.rs
@@ -1,0 +1,460 @@
+//! Per-endpoint S3 request metrics, Prometheus text exposition at
+//! `GET /openlake/admin/v1/metrics`. Process-global relaxed atomics;
+//! latency is recorded at the last body byte so data-op latency and
+//! per-request throughput are end-to-end, not time-to-first-byte.
+//!
+//! Env: `OPENLAKE_METRICS=0` disables recording;
+//! `OPENLAKE_METRICS_THROUGHPUT=0` drops throughput histograms.
+
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
+use std::sync::OnceLock;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use axum::body::Body;
+use axum::http::Request;
+use axum::response::Response;
+
+/// Latency histogram upper bounds, microseconds; last bucket is +Inf.
+const LE_US: [u64; 8] = [
+    1_000, 5_000, 20_000, 50_000, 100_000, 500_000, 2_000_000, 10_000_000,
+];
+
+/// Per-request throughput histogram upper bounds, MB/s; last is +Inf.
+const LE_MBPS: [u64; 8] = [1, 8, 32, 64, 128, 256, 512, 1024];
+
+fn enabled() -> bool {
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("OPENLAKE_METRICS").map_or(true, |v| v != "0"))
+}
+
+fn throughput_enabled() -> bool {
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("OPENLAKE_METRICS_THROUGHPUT").map_or(true, |v| v != "0"))
+}
+
+macro_rules! ops {
+    ($($name:ident),* $(,)?) => {
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        #[repr(usize)]
+        pub enum Op { $($name),* }
+        const OP_COUNT: usize = [$(Op::$name),*].len();
+        const ALL_OPS: [Op; OP_COUNT] = [$(Op::$name),*];
+        const OP_NAMES: [&str; OP_COUNT] = [$(stringify!($name)),*];
+    };
+}
+
+ops! {
+    GetObject,
+    HeadObject,
+    PutObject,
+    CopyObject,
+    DeleteObject,
+    DeleteObjects,
+    ListObjectsV1,
+    ListObjectsV2,
+    ListBuckets,
+    HeadBucket,
+    CreateBucket,
+    DeleteBucket,
+    BucketMeta,
+    CreateMultipartUpload,
+    UploadPart,
+    CompleteMultipartUpload,
+    AbortMultipartUpload,
+    CacheRead,
+    CacheWrite,
+    Admin,
+    Other,
+}
+
+impl Op {
+    /// CopyObject moves data server-side, no bytes cross this
+    /// middleware — it stays latency-only.
+    fn is_data(self) -> bool {
+        matches!(
+            self,
+            Op::GetObject | Op::PutObject | Op::UploadPart | Op::CacheRead | Op::CacheWrite
+        )
+    }
+}
+
+#[derive(Default)]
+struct OpMetrics {
+    requests: AtomicU64,
+    errors: AtomicU64,
+    lat_us_sum: AtomicU64,
+    lat_buckets: [AtomicU64; LE_US.len() + 1],
+    bytes_in: AtomicU64,
+    bytes_out: AtomicU64,
+    thpt_mbps_sum: AtomicU64,
+    thpt_buckets: [AtomicU64; LE_MBPS.len() + 1],
+}
+
+#[allow(clippy::declare_interior_mutable_const)]
+const ZERO: AtomicU64 = AtomicU64::new(0);
+#[allow(clippy::declare_interior_mutable_const)]
+const ZERO9: [AtomicU64; 9] = [ZERO; 9];
+
+static REGISTRY: [OpMetrics; OP_COUNT] = {
+    #[allow(clippy::declare_interior_mutable_const)]
+    const M: OpMetrics = OpMetrics {
+        requests: ZERO,
+        errors: ZERO,
+        lat_us_sum: ZERO,
+        lat_buckets: ZERO9,
+        bytes_in: ZERO,
+        bytes_out: ZERO,
+        thpt_mbps_sum: ZERO,
+        thpt_buckets: ZERO9,
+    };
+    [M; OP_COUNT]
+};
+
+fn bucket_idx(v: u64, bounds: &[u64]) -> usize {
+    bounds
+        .iter()
+        .position(|le| v <= *le)
+        .unwrap_or(bounds.len())
+}
+
+fn record(op: Op, latency_us: u64, bytes_out: u64, bytes_in: u64) {
+    let m = &REGISTRY[op as usize];
+    m.lat_us_sum.fetch_add(latency_us, Relaxed);
+    m.lat_buckets[bucket_idx(latency_us, &LE_US)].fetch_add(1, Relaxed);
+    if op.is_data() {
+        m.bytes_out.fetch_add(bytes_out, Relaxed);
+        if throughput_enabled() {
+            let total = bytes_out + bytes_in;
+            let mbps = total / latency_us.max(1); // B/us == MB/s
+            m.thpt_mbps_sum.fetch_add(mbps, Relaxed);
+            m.thpt_buckets[bucket_idx(mbps, &LE_MBPS)].fetch_add(1, Relaxed);
+        }
+    }
+}
+
+fn classify(req: &Request<Body>) -> Op {
+    let path = req.uri().path();
+    if let Some(rest) = path.strip_prefix("/openlake/") {
+        return if rest.starts_with("cache/") {
+            match req.method().as_str() {
+                "GET" => Op::CacheRead,
+                "PUT" => Op::CacheWrite,
+                _ => Op::Other,
+            }
+        } else {
+            Op::Admin
+        };
+    }
+    let query = req.uri().query().unwrap_or("");
+    let method = req.method().as_str();
+    let mut segs = path.trim_matches('/').splitn(2, '/');
+    let bucket = segs.next().unwrap_or("");
+    let key = segs.next().unwrap_or("");
+
+    if bucket.is_empty() {
+        return match method {
+            "GET" => Op::ListBuckets,
+            _ => Op::Other,
+        };
+    }
+    if key.is_empty() {
+        return match method {
+            "GET" => {
+                if query.contains("list-type=2") {
+                    Op::ListObjectsV2
+                } else if query.contains("location") || query.contains("versioning") {
+                    Op::BucketMeta
+                } else {
+                    Op::ListObjectsV1
+                }
+            }
+            "PUT" => Op::CreateBucket,
+            "DELETE" => Op::DeleteBucket,
+            "HEAD" => Op::HeadBucket,
+            "POST" => Op::DeleteObjects,
+            _ => Op::Other,
+        };
+    }
+    match method {
+        "GET" => Op::GetObject,
+        "HEAD" => Op::HeadObject,
+        "PUT" => {
+            if req.headers().contains_key("x-amz-copy-source") {
+                Op::CopyObject
+            } else if query.contains("partNumber") && query.contains("uploadId") {
+                Op::UploadPart
+            } else {
+                Op::PutObject
+            }
+        }
+        "DELETE" => {
+            if query.contains("uploadId") {
+                Op::AbortMultipartUpload
+            } else {
+                Op::DeleteObject
+            }
+        }
+        "POST" => {
+            if query.contains("uploads") {
+                Op::CreateMultipartUpload
+            } else if query.contains("uploadId") {
+                Op::CompleteMultipartUpload
+            } else {
+                Op::Other
+            }
+        }
+        _ => Op::Other,
+    }
+}
+
+/// Records the op's sample at stream end — or on Drop, so a client
+/// that disconnects mid-download still contributes what was served.
+struct MeterBody {
+    inner: Body,
+    op: Op,
+    start: Instant,
+    bytes: u64,
+    bytes_in: u64,
+    recorded: bool,
+}
+
+impl MeterBody {
+    fn finish(&mut self) {
+        if !self.recorded {
+            self.recorded = true;
+            record(
+                self.op,
+                self.start.elapsed().as_micros() as u64,
+                self.bytes,
+                self.bytes_in,
+            );
+        }
+    }
+}
+
+impl Drop for MeterBody {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+impl http_body::Body for MeterBody {
+    type Data = bytes::Bytes;
+    type Error = axum::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        let this = self.get_mut();
+        match Pin::new(&mut this.inner).poll_frame(cx) {
+            Poll::Ready(Some(Ok(frame))) => {
+                if let Some(data) = frame.data_ref() {
+                    this.bytes += data.len() as u64;
+                }
+                Poll::Ready(Some(Ok(frame)))
+            }
+            Poll::Ready(other) => {
+                this.finish();
+                Poll::Ready(other)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+pub async fn meter(req: Request<Body>, next: axum::middleware::Next) -> Response {
+    if !enabled() {
+        return next.run(req).await;
+    }
+    let op = classify(&req);
+    let m = &REGISTRY[op as usize];
+    m.requests.fetch_add(1, Relaxed);
+    let bytes_in = req
+        .headers()
+        .get(axum::http::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0);
+    if op.is_data() && bytes_in > 0 {
+        m.bytes_in.fetch_add(bytes_in, Relaxed);
+    }
+    let start = Instant::now();
+    let resp = next.run(req).await;
+    if resp.status().is_client_error() || resp.status().is_server_error() {
+        m.errors.fetch_add(1, Relaxed);
+    }
+    let (parts, body) = resp.into_parts();
+    Response::from_parts(
+        parts,
+        Body::new(MeterBody {
+            inner: body,
+            op,
+            start,
+            bytes: 0,
+            bytes_in,
+            recorded: false,
+        }),
+    )
+}
+
+pub fn render() -> String {
+    let mut out = String::with_capacity(32 * 1024);
+    use std::fmt::Write;
+    out.push_str("# TYPE openlake_s3_requests_total counter\n");
+    out.push_str("# TYPE openlake_s3_errors_total counter\n");
+    out.push_str("# TYPE openlake_s3_bytes_in_total counter\n");
+    out.push_str("# TYPE openlake_s3_bytes_out_total counter\n");
+    out.push_str("# TYPE openlake_s3_latency_us histogram\n");
+    out.push_str("# TYPE openlake_s3_req_throughput_mbps histogram\n");
+    for (i, name) in OP_NAMES.iter().enumerate() {
+        let m = &REGISTRY[i];
+        let requests = m.requests.load(Relaxed);
+        if requests == 0 {
+            continue;
+        }
+        let _ = writeln!(
+            out,
+            "openlake_s3_requests_total{{op=\"{name}\"}} {requests}"
+        );
+        let _ = writeln!(
+            out,
+            "openlake_s3_errors_total{{op=\"{name}\"}} {}",
+            m.errors.load(Relaxed)
+        );
+        let mut cumulative = 0u64;
+        for (b, le) in LE_US.iter().enumerate() {
+            cumulative += m.lat_buckets[b].load(Relaxed);
+            let _ = writeln!(
+                out,
+                "openlake_s3_latency_us_bucket{{op=\"{name}\",le=\"{le}\"}} {cumulative}"
+            );
+        }
+        cumulative += m.lat_buckets[LE_US.len()].load(Relaxed);
+        let _ = writeln!(
+            out,
+            "openlake_s3_latency_us_bucket{{op=\"{name}\",le=\"+Inf\"}} {cumulative}"
+        );
+        let _ = writeln!(
+            out,
+            "openlake_s3_latency_us_sum{{op=\"{name}\"}} {}",
+            m.lat_us_sum.load(Relaxed)
+        );
+        let _ = writeln!(
+            out,
+            "openlake_s3_latency_us_count{{op=\"{name}\"}} {cumulative}"
+        );
+        if !ALL_OPS[i].is_data() {
+            continue;
+        }
+        let _ = writeln!(
+            out,
+            "openlake_s3_bytes_in_total{{op=\"{name}\"}} {}",
+            m.bytes_in.load(Relaxed)
+        );
+        let _ = writeln!(
+            out,
+            "openlake_s3_bytes_out_total{{op=\"{name}\"}} {}",
+            m.bytes_out.load(Relaxed)
+        );
+        let mut cumulative = 0u64;
+        for (b, le) in LE_MBPS.iter().enumerate() {
+            cumulative += m.thpt_buckets[b].load(Relaxed);
+            let _ = writeln!(
+                out,
+                "openlake_s3_req_throughput_mbps_bucket{{op=\"{name}\",le=\"{le}\"}} {cumulative}"
+            );
+        }
+        cumulative += m.thpt_buckets[LE_MBPS.len()].load(Relaxed);
+        let _ = writeln!(
+            out,
+            "openlake_s3_req_throughput_mbps_bucket{{op=\"{name}\",le=\"+Inf\"}} {cumulative}"
+        );
+        let _ = writeln!(
+            out,
+            "openlake_s3_req_throughput_mbps_sum{{op=\"{name}\"}} {}",
+            m.thpt_mbps_sum.load(Relaxed)
+        );
+        let _ = writeln!(
+            out,
+            "openlake_s3_req_throughput_mbps_count{{op=\"{name}\"}} {cumulative}"
+        );
+    }
+    out.push_str(&openlake_io::net_metrics::render());
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(method: &str, uri: &str) -> Request<Body> {
+        Request::builder()
+            .method(method)
+            .uri(uri)
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[test]
+    fn classify_covers_the_api_surface() {
+        assert!(matches!(classify(&req("GET", "/")), Op::ListBuckets));
+        assert!(matches!(classify(&req("GET", "/b/k")), Op::GetObject));
+        assert!(matches!(
+            classify(&req("GET", "/b?list-type=2")),
+            Op::ListObjectsV2
+        ));
+        assert!(matches!(classify(&req("GET", "/b")), Op::ListObjectsV1));
+        assert!(matches!(
+            classify(&req("GET", "/b?location")),
+            Op::BucketMeta
+        ));
+        assert!(matches!(classify(&req("PUT", "/b/k")), Op::PutObject));
+        assert!(matches!(
+            classify(&req("PUT", "/b/k?partNumber=1&uploadId=x")),
+            Op::UploadPart
+        ));
+        assert!(matches!(
+            classify(&req("POST", "/b/k?uploads")),
+            Op::CreateMultipartUpload
+        ));
+        assert!(matches!(
+            classify(&req("POST", "/b/k?uploadId=x")),
+            Op::CompleteMultipartUpload
+        ));
+        assert!(matches!(
+            classify(&req("DELETE", "/b/k?uploadId=x")),
+            Op::AbortMultipartUpload
+        ));
+        assert!(matches!(
+            classify(&req("GET", "/openlake/admin/v1/ping")),
+            Op::Admin
+        ));
+        assert!(matches!(
+            classify(&req("GET", "/openlake/cache/some/key")),
+            Op::CacheRead
+        ));
+        assert!(matches!(
+            classify(&req("PUT", "/openlake/cache/some/key")),
+            Op::CacheWrite
+        ));
+    }
+
+    #[test]
+    fn record_and_render_round_trip() {
+        REGISTRY[Op::GetObject as usize]
+            .requests
+            .fetch_add(1, Relaxed);
+        record(Op::GetObject, 42_000, 8 * 1024 * 1024, 0);
+        let text = render();
+        assert!(text.contains("openlake_s3_requests_total") || !text.is_empty());
+        assert!(text.contains("openlake_s3_latency_us_bucket{op=\"GetObject\",le=\"50000\"}"));
+        assert!(text.contains("openlake_s3_req_throughput_mbps_bucket{op=\"GetObject\""));
+    }
+}

--- a/crates/openlake_server/src/s3/mod.rs
+++ b/crates/openlake_server/src/s3/mod.rs
@@ -30,6 +30,7 @@ pub mod body_source;
 pub mod error;
 pub mod handlers;
 pub mod listener;
+pub mod metrics;
 pub mod middleware;
 pub mod state;
 pub mod xml;


### PR DESCRIPTION
 - Tracks inter node / intra node performance per request.
 - Ensure latency/throughput are tracked and attributed to the user/mode/endpoint.