### PR TITLE
(#173) [v0.6] Add support for ListBuckets

### DIFF
--- a/crates/openlake_server/src/s3/app.rs
+++ b/crates/openlake_server/src/s3/app.rs
@@ -18,7 +18,7 @@ use compio::tls::TlsAcceptor;
 use std::net::SocketAddr;
 
 use crate::config::Config;
-use crate::s3::error::{not_found, AppError};
+use crate::s3::error::not_found;
 use crate::s3::handlers::{buckets, in_memory_store, objects};
 use crate::s3::listener::TlsTcpListener;
 use crate::s3::middleware::sigv4::sigv4;
@@ -34,7 +34,7 @@ pub fn build_router(state: AppState, cfg: Arc<Config>) -> Router {
         .post(objects::delete_objects);
 
     Router::new()
-        .route("/", get(list_buckets_unimplemented))
+        .route("/", get(buckets::list_buckets))
         .route(
             "/openlake/admin/v1/config",
             get(move || {
@@ -72,10 +72,6 @@ pub fn build_router(state: AppState, cfg: Arc<Config>) -> Router {
         .layer(axum::middleware::from_fn(crate::s3::metrics::meter))
         .layer(DefaultBodyLimit::disable())
         .with_state(state)
-}
-
-async fn list_buckets_unimplemented() -> Result<axum::http::Response<axum::body::Body>, AppError> {
-    Err(AppError::NotImplemented("ListBuckets is not implemented"))
 }
 
 async fn serve_admin_config(cfg: Arc<Config>) -> axum::Json<Config> {

--- a/crates/openlake_server/src/s3/handlers/buckets.rs
+++ b/crates/openlake_server/src/s3/handlers/buckets.rs
@@ -20,8 +20,9 @@ use serde::Deserialize;
 use crate::s3::error::AppError;
 use crate::s3::state::AppState;
 use crate::s3::xml::{
-    CommonPrefix, ListBucketObject, ListBucketResult, ListBucketResultV1, LocationConstraint,
-    Owner, VersioningConfiguration, Xml, S3_NS,
+    BucketEntry, BucketsList, CommonPrefix, ListAllMyBucketsResult, ListBucketObject,
+    ListBucketResult, ListBucketResultV1, LocationConstraint, Owner, VersioningConfiguration, Xml,
+    S3_NS,
 };
 
 /// Bucket-scoped sub-resources S3 defines that openlake does not yet
@@ -473,6 +474,25 @@ fn storage_class_label(sc: &openlake_storage::StorageClass) -> &'static str {
     match sc {
         Inline | Single => "STANDARD",
     }
+}
+
+/// `GET /` — ListBuckets. Returns every bucket the cluster holds with
+/// its creation time.
+pub async fn list_buckets(State(state): State<AppState>) -> Result<Response, AppError> {
+    let engine = state.engine().clone();
+    let listed = SendWrapper::new(async move { engine.list_buckets().await }).await?;
+    let bucket = listed
+        .into_iter()
+        .map(|(name, created_ms)| BucketEntry {
+            name,
+            creation_date: rfc3339_from_ms(created_ms),
+        })
+        .collect();
+    let body = ListAllMyBucketsResult {
+        xmlns: S3_NS,
+        buckets: BucketsList { bucket },
+    };
+    Ok(Xml(body).into_response())
 }
 
 fn rfc3339_from_ms(ms: u64) -> String {

--- a/crates/openlake_server/src/s3/xml.rs
+++ b/crates/openlake_server/src/s3/xml.rs
@@ -170,6 +170,32 @@ pub struct Owner {
     pub display_name: String,
 }
 
+/// `<ListAllMyBucketsResult xmlns="...">` — body of `GET /`
+/// (ListBuckets).
+#[derive(Serialize)]
+#[serde(rename = "ListAllMyBucketsResult")]
+pub struct ListAllMyBucketsResult {
+    #[serde(rename = "@xmlns")]
+    pub xmlns: &'static str,
+    #[serde(rename = "Buckets")]
+    pub buckets: BucketsList,
+}
+
+#[derive(Serialize)]
+pub struct BucketsList {
+    #[serde(rename = "Bucket", default)]
+    pub bucket: Vec<BucketEntry>,
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Bucket")]
+pub struct BucketEntry {
+    #[serde(rename = "Name")]
+    pub name: String,
+    #[serde(rename = "CreationDate")]
+    pub creation_date: String,
+}
+
 #[derive(Serialize)]
 #[serde(rename = "ListBucketResult")]
 pub struct ListBucketResultV1 {

--- a/crates/openlake_storage/src/engine.rs
+++ b/crates/openlake_storage/src/engine.rs
@@ -257,6 +257,45 @@ impl Engine {
         BucketMeta::decode(&buf).map_err(StorageError::Io)
     }
 
+    /// `GET /` — ListBuckets.
+    pub async fn list_buckets(&self) -> StorageResult<Vec<(String, u64)>> {
+        let backends = self.all_backends()?;
+        let read_quorum = self.cluster.read_quorum();
+
+        let mut counts: std::collections::BTreeMap<String, usize> =
+            std::collections::BTreeMap::new();
+        let mut answered = 0usize;
+        let mut last_err: Option<IoError> = None;
+        for r in join_all(backends.iter().map(|b| b.list_vols())).await {
+            match r {
+                Ok(vols) => {
+                    answered += 1;
+                    for v in vols {
+                        *counts.entry(v.name).or_default() += 1;
+                    }
+                }
+                Err(e) => last_err = Some(e),
+            }
+        }
+        if answered < read_quorum {
+            return Err(StorageError::from(last_err.unwrap_or_else(|| {
+                IoError::InvalidArgument("no disks responded to list_vols".into())
+            })));
+        }
+
+        let names: Vec<String> = counts
+            .into_iter()
+            .filter(|(_, seen)| *seen >= read_quorum)
+            .map(|(name, _)| name)
+            .collect();
+        let metas = join_all(names.iter().map(|n| self.get_bucket_meta(n))).await;
+        Ok(names
+            .into_iter()
+            .zip(metas)
+            .map(|(name, meta)| (name, meta.map(|m| m.created_ms).unwrap_or(0)))
+            .collect())
+    }
+
     pub async fn create_bucket(&self, bucket: &str, meta: BucketMeta) -> StorageResult<()> {
         validate_bucket_name(bucket)?;
         let _lock = self
@@ -3493,6 +3532,47 @@ mod tests {
         ] {
             validate_bucket_name(ok).unwrap();
         }
+    }
+
+    #[compio::test]
+    async fn list_buckets_returns_all_created() {
+        let (_dirs, e) = eng(3, 3).await;
+        // eng() already created "buk"; add two more.
+        e.create_bucket("alpha", BucketMeta::new(1000, false))
+            .await
+            .unwrap();
+        e.create_bucket("zeta", BucketMeta::new(2000, false))
+            .await
+            .unwrap();
+        let listed = e.list_buckets().await.unwrap();
+        let names: Vec<&str> = listed.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "buk", "zeta"]); // union, sorted, no system vols
+        let created: std::collections::HashMap<&str, u64> =
+            listed.iter().map(|(n, c)| (n.as_str(), *c)).collect();
+        assert_eq!(created["alpha"], 1000);
+        assert_eq!(created["zeta"], 2000);
+    }
+
+    #[compio::test]
+    async fn list_buckets_empty_when_none() {
+        let cluster = local_cluster(3, 3);
+        let dirs: Vec<TempDir> = (0..3).map(|_| TempDir::new().unwrap()).collect();
+        let mut backends: HashMap<DiskAddr, Rc<dyn StorageBackend>> = HashMap::new();
+        for (i, d) in dirs.iter().enumerate() {
+            backends.insert(
+                DiskAddr {
+                    node_id: i as NodeId,
+                    disk_idx: 0,
+                },
+                Rc::new(LocalFsBackend::new(d.path()).unwrap()),
+            );
+        }
+        let num_sets = cluster.num_sets().max(1);
+        let dsync_by_set: Vec<Rc<crate::dsync::DsyncClient>> = (0..num_sets)
+            .map(|_| Rc::new(crate::dsync::DsyncClient::no_op()))
+            .collect();
+        let e = Engine::new(cluster, backends, dsync_by_set, 0);
+        assert!(e.list_buckets().await.unwrap().is_empty());
     }
 
     #[compio::test]


### PR DESCRIPTION
 - List bucket is required by NFS clients and file explorers for cluster navigation.
 - Add support for the same.
 - Aggregates results from all backends and returns majority consensus metadata.
