### PR TITLE
(#178) [v0.6] feat(s3): support CopyObject metadata replacement

### DIFF
--- a/crates/openlake_server/src/s3/handlers/objects.rs
+++ b/crates/openlake_server/src/s3/handlers/objects.rs
@@ -655,7 +655,7 @@ fn copy_object(
 
         let (src_info, mut src_stream) = engine.get(&src_bucket, &src_key).await?;
         // TODO(v0.6): Support replacement of additional x-amz-meta-* headers.
-// Currently, CopyObject metadata replacement only propagates Content-Type.
+        // Currently, CopyObject metadata replacement only propagates Content-Type.
         let content_type = if replace_metadata {
             headers
                 .get(CONTENT_TYPE)

--- a/crates/openlake_server/src/s3/handlers/objects.rs
+++ b/crates/openlake_server/src/s3/handlers/objects.rs
@@ -654,6 +654,7 @@ fn copy_object(
         let engine = state.engine().clone();
 
         let (src_info, mut src_stream) = engine.get(&src_bucket, &src_key).await?;
+        // Todo: Support other x-amz-meta-* in future. Copy with replace only supports content type today.
         let content_type = if replace_metadata {
             headers
                 .get(CONTENT_TYPE)

--- a/crates/openlake_server/src/s3/handlers/objects.rs
+++ b/crates/openlake_server/src/s3/handlers/objects.rs
@@ -654,7 +654,8 @@ fn copy_object(
         let engine = state.engine().clone();
 
         let (src_info, mut src_stream) = engine.get(&src_bucket, &src_key).await?;
-        // Todo: Support other x-amz-meta-* in future. Copy with replace only supports content type today.
+        // TODO(v0.6): Support replacement of additional x-amz-meta-* headers.
+// Currently, CopyObject metadata replacement only propagates Content-Type.
         let content_type = if replace_metadata {
             headers
                 .get(CONTENT_TYPE)

--- a/crates/openlake_server/src/s3/handlers/objects.rs
+++ b/crates/openlake_server/src/s3/handlers/objects.rs
@@ -637,15 +637,10 @@ fn copy_object(
 ) -> SendWrapper<impl std::future::Future<Output = Result<Response, AppError>>> {
     SendWrapper::new(async move {
         let (src_bucket, src_key) = parse_copy_source(&copy_source)?;
-        if headers
+        let replace_metadata = headers
             .get("x-amz-metadata-directive")
-            .and_then(|v| v.to_str().ok())
-            .is_some_and(|v| !v.eq_ignore_ascii_case("COPY"))
-        {
-            return Err(AppError::NotImplemented(
-                "CopyObject metadata replacement is not supported",
-            ));
-        }
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value.eq_ignore_ascii_case("REPLACE"));
 
         if headers
             .get("x-amz-tagging-directive")
@@ -659,7 +654,14 @@ fn copy_object(
         let engine = state.engine().clone();
 
         let (src_info, mut src_stream) = engine.get(&src_bucket, &src_key).await?;
-        let content_type = src_info.content_type.clone();
+        let content_type = if replace_metadata {
+            headers
+                .get(CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_owned)
+        } else {
+            src_info.content_type.clone()
+        };
 
         let dst_info = engine
             .put(


### PR DESCRIPTION
## Summary

This PR adds support for `x-amz-metadata-directive: REPLACE` in S3 `CopyObject` requests.

Spark's Hadoop S3A connector uses `CopyObject` with metadata replacement during its output commit workflow. OpenLake previously returned `501 NotImplemented`, which blocked Spark writes.

## Changes

- Detect `x-amz-metadata-directive: REPLACE`
- Use the request `Content-Type` for the destination object
- Preserve the source object's content type when the directive is absent or set to `COPY`
- Keep tagging replacement unsupported

## Testing

Verified locally with Spark 3.5.5 and Hadoop S3A:

- Successfully wrote a DataFrame to `s3a://test-bucket/users`
- Successfully read the Parquet data back
- Confirmed the expected rows were returned
- `cargo test -p openlake_server` passed
- Release build passed


## Related Issue

Related to #178