### PR TITLE
(#192) [v0.6] Wire kv/shm modules into openlake_io (exports)

### DIFF
--- a/crates/openlake_io/Cargo.toml
+++ b/crates/openlake_io/Cargo.toml
@@ -22,8 +22,8 @@ futures-util = { workspace = true }
 send_wrapper = { workspace = true }
 # URL-safe-no-pad base64 for encoding the bincode `Request` envelope
 # into the `x-openlake-rpc` HTTP header on the streaming-write
-# route. Same encoder MinIO and rustfs use for upload-IDs and other
-# header-borne tokens, so the alphabet matches AWS conventions.
+# route. The URL-safe alphabet matches AWS conventions for
+# upload-IDs and other header-borne tokens.
 base64       = { workspace = true }
 
 bytes        = { workspace = true }

--- a/crates/openlake_io/src/lib.rs
+++ b/crates/openlake_io/src/lib.rs
@@ -14,6 +14,8 @@
 pub mod alloc;
 pub mod backend;
 pub mod error;
+pub mod kv;
+pub mod shm;
 #[cfg(all(feature = "rdma", target_os = "linux"))]
 pub mod kv_slab;
 pub mod local_fs;
@@ -35,7 +37,8 @@ pub use alloc::{MemoryPool, MemoryPoolConfig, PooledBuffer};
 pub use backend::{LockPeer, StorageBackend};
 pub use error::{IoError, IoResult};
 #[cfg(all(feature = "rdma", target_os = "linux"))]
-pub use kv_slab::KvSlab;
+pub use kv_slab::RdmaSlab;
+pub use kv::{HostSlab, KvSlab};
 pub use local_fs::{LocalFsBackend, MULTIPART_VOL, STAGING_VOL, SYSTEM_BUCKET};
 pub use purge::init_purge_worker;
 pub use remote_fs::{PeerClient, RemoteBackend};


### PR DESCRIPTION
-  Kv.rs/shm.rs aren't declared in the crate root.
 - Export them so they compile and are reachable.
 - HostSlab/KvSlab/RdmaSlab are now reachable and compile friendly, plus Cargo cleanup.