### PR TITLE
(#194) [v0.6] Add RdmaAttach/SlabMeta handshake + Reset wire types

### DIFF
--- a/crates/openlake_io/src/rdma/wire.rs
+++ b/crates/openlake_io/src/rdma/wire.rs
@@ -2,7 +2,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::rpc::{DiskIdx, Request, Response};
 
-pub const ENVELOPE_MAGIC: u32 = 0x52444D31;
+pub const ENVELOPE_MAGIC: u32 = 0x52444D33; // "RDM3": 54-byte KeyHash
+
+pub use crate::kv::KeyHash;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct RdmaRemoteBuf {
@@ -11,10 +13,10 @@ pub struct RdmaRemoteBuf {
     pub rkey: u32,
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CommitEntry {
     pub slot_idx: u32,
-    pub key_hash: u64,
+    pub key_hash: Vec<u8>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -42,12 +44,14 @@ pub enum RdmaRequest {
         entries: Vec<CommitEntry>,
     },
     BatchLookup {
-        key_hashes: Vec<u64>,
+        key_hashes: Vec<Vec<u8>>,
     },
     BatchRelease {
         slot_idxs: Vec<u32>,
     },
     Generic(Request),
+    /// Unbind every slot and return the whole slab to the free list.
+    Reset,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -59,6 +63,7 @@ pub enum RdmaResponse {
     BatchLookedUp { slots: Vec<Option<u32>> },
     BatchReleased,
     Generic(Response),
+    ResetDone,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/crates/openlake_io/src/rpc.rs
+++ b/crates/openlake_io/src/rpc.rs
@@ -223,7 +223,31 @@ pub enum Request {
     /// `(runtime_id, dct_num, gid, dc_key)`. Until every runtime on
     /// this node has published, `complete = false` and peers retry.
     GetRdmaEndpoints,
+
+    /// One-time client handshake with a kv node: the caller presents its
+    /// RDMA endpoints so this node can address replies to it, and the
+    /// response carries this node's endpoints (including slab metadata).
+    /// `client_node_id` must be >= `CLIENT_NODE_ID_BASE`; `epoch`
+    /// increases across client restarts so a re-attach replaces the
+    /// caller's own stale entry.
+    RdmaAttach {
+        client_node_id: u16,
+        epoch: u64,
+        endpoints: Vec<LocalRdmaEndpoint>,
+    },
 }
+
+/// Node ids below this belong to `cfg.nodes`; attaching clients must
+/// identify from `[CLIENT_NODE_ID_BASE, 4095]` so they can never shadow a
+/// cluster member. The upper bound is not cosmetic: a peer id is carried in
+/// the 12-bit node field of the credit-ack immediate (see `wr::ImmData`), so
+/// an id above 4095 would be truncated and its acks would credit the wrong
+/// peer, stalling replies once the send-credit budget is reached.
+pub const CLIENT_NODE_ID_BASE: u16 = 2_048;
+
+/// Inclusive upper bound for a client id: the credit-ack immediate carries the
+/// node id in 12 bits, so ids never exceed `0xFFF`.
+pub const CLIENT_NODE_ID_MAX: u16 = 0xFFF;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Response {
@@ -246,6 +270,8 @@ pub enum Response {
     LockRefreshed,
     LockNotFound,
     RdmaEndpoints(RdmaEndpointsReply),
+    RdmaAttached(RdmaEndpointsReply),
+    RdmaAttachDenied(String),
     Err(WireError),
 }
 


### PR DESCRIPTION
 - Extends rpc.rs (RdmaAttach + SlabMeta + client-id range)
 - Adds support for rdma/wire.rs (Reset) for the KV control plane.