### PR TITLE
(#198) [v0.6] Add KvEngine + RDMA KvBackend (openlake_storage)

### DIFF
--- a/crates/openlake_storage/src/kv_backend.rs
+++ b/crates/openlake_storage/src/kv_backend.rs
@@ -1,0 +1,74 @@
+#![cfg(all(feature = "rdma", target_os = "linux"))]
+
+//! In-memory client registry for a kv node.
+//!
+//! Clients attach over the tcp rpc plane, presenting the RDMA endpoints
+//! this node needs to address replies back to them. Entries live only
+//! as long as the process: they describe peers of *this* running node
+//! and mean nothing after a restart. Single-runtime, so a `RefCell` is
+//! enough — no lock.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use openlake_io::rdma::PeerEndpoint;
+use openlake_io::rpc::LocalRdmaEndpoint;
+
+pub struct KvBackend {
+    /// `(client_node_id, runtime_id) -> (endpoint, epoch)`.
+    peers: RefCell<HashMap<(u16, u16), (PeerEndpoint, u64)>>,
+    /// Admission cap: the receive pool is provisioned for exactly this many
+    /// bursting peers, so excess attaches are denied here, not RNR'd later.
+    cap: usize,
+}
+
+impl KvBackend {
+    pub fn new(cap: usize) -> Self {
+        Self {
+            peers: RefCell::new(HashMap::new()),
+            cap,
+        }
+    }
+
+    /// Register a client endpoint. Accepts the first entry for a slot, a
+    /// re-registration by the same client (same gid), or a newer epoch —
+    /// so a restarted client replaces its own entry and cannot displace
+    /// another's.
+    pub fn attach(&self, id: u16, ep: &LocalRdmaEndpoint, epoch: u64) -> Result<(), String> {
+        let mut peers = self.peers.borrow_mut();
+        let key = (id, ep.runtime_id);
+        match peers.get(&key) {
+            Some((held, e)) if held.gid != ep.gid && *e >= epoch => {
+                Err(format!("client id {id} held by another endpoint"))
+            }
+            None if peers.len() >= self.cap => Err(format!("at capacity ({} clients)", self.cap)),
+            _ => {
+                peers.insert(key, (to_peer(id, ep), epoch));
+                Ok(())
+            }
+        }
+    }
+
+    /// Look up a registered client's endpoint, for reply addressing.
+    pub fn peer_at(&self, node_id: u16, runtime_id: u16) -> Option<PeerEndpoint> {
+        self.peers
+            .borrow()
+            .get(&(node_id, runtime_id))
+            .map(|(ep, _)| ep.clone())
+    }
+
+    pub fn len(&self) -> usize {
+        self.peers.borrow().len()
+    }
+}
+
+fn to_peer(node_id: u16, ep: &LocalRdmaEndpoint) -> PeerEndpoint {
+    PeerEndpoint {
+        node_id,
+        gid: ep.gid,
+        dct_num: ep.dct_num,
+        dc_key: ep.dc_key,
+        lid: ep.lid,
+        kv_slab: ep.kv_slab,
+    }
+}

--- a/crates/openlake_storage/src/kv_engine.rs
+++ b/crates/openlake_storage/src/kv_engine.rs
@@ -1,42 +1,91 @@
-#![cfg(all(feature = "rdma", target_os = "linux"))]
-
 use std::rc::Rc;
 
-use openlake_io::rdma::wire::{RdmaRequest, RdmaResponse};
-use openlake_io::rpc::{Response, WireError};
-use openlake_io::KvSlab;
+use openlake_io::kv::{self, KvRequest, KvResponse, KvSlab};
 
+/// Owns the kv slab (any backing) and drives it for both transports.
+/// The rdma transport also keeps a client registry (endpoints to address
+/// one-sided replies); the tcp transport needs none of that.
 pub struct KvEngine {
-    slab: Option<Rc<KvSlab>>,
+    slab: Rc<dyn KvSlab>,
+    #[cfg(all(feature = "rdma", target_os = "linux"))]
+    backend: crate::kv_backend::KvBackend,
+    #[cfg(all(feature = "rdma", target_os = "linux"))]
+    on_attach: std::cell::RefCell<Option<Box<dyn Fn(u16, u16)>>>,
 }
 
 impl KvEngine {
-    pub fn new(slab: Option<Rc<KvSlab>>) -> Self {
-        Self { slab }
+    #[cfg_attr(not(all(feature = "rdma", target_os = "linux")), allow(unused_variables))]
+    pub fn new(slab: Rc<dyn KvSlab>, max_clients: usize) -> Self {
+        Self {
+            slab,
+            #[cfg(all(feature = "rdma", target_os = "linux"))]
+            backend: crate::kv_backend::KvBackend::new(max_clients),
+            #[cfg(all(feature = "rdma", target_os = "linux"))]
+            on_attach: std::cell::RefCell::new(None),
+        }
     }
 
-    pub fn handle(&self, req: RdmaRequest) -> RdmaResponse {
-        use RdmaRequest::*;
-        match (req, &self.slab) {
-            (BatchReserve { count }, Some(s)) => RdmaResponse::BatchReserved {
-                slots: s.reserve(count),
+    /// TCP data plane: the server holds the payload (put/get carry the
+    /// bytes). Reserves→writes→commits / looks up→reads on the slab.
+    pub fn serve_tcp(&self, req: KvRequest) -> KvResponse {
+        kv::serve_tcp(&*self.slab, req)
+    }
+
+    #[cfg(all(feature = "rdma", target_os = "linux"))]
+    pub fn set_on_attach(&self, f: impl Fn(u16, u16) + 'static) {
+        *self.on_attach.borrow_mut() = Some(Box::new(f));
+    }
+
+    #[cfg(all(feature = "rdma", target_os = "linux"))]
+    pub fn attach(
+        &self,
+        client: u16,
+        eps: &[openlake_io::rpc::LocalRdmaEndpoint],
+        epoch: u64,
+    ) -> Result<(), String> {
+        eps.iter().try_for_each(|ep| {
+            self.backend.attach(client, ep, epoch)?;
+            if let Some(f) = &*self.on_attach.borrow() {
+                f(client, ep.runtime_id);
+            }
+            Ok(())
+        })
+    }
+
+    #[cfg(all(feature = "rdma", target_os = "linux"))]
+    pub fn peer_at(&self, node_id: u16, runtime_id: u16) -> Option<openlake_io::rdma::PeerEndpoint> {
+        self.backend.peer_at(node_id, runtime_id)
+    }
+
+    /// RDMA slot plane: index only. The client moves payload one-sided.
+    #[cfg(all(feature = "rdma", target_os = "linux"))]
+    pub fn handle(
+        &self,
+        req: openlake_io::rdma::wire::RdmaRequest,
+    ) -> openlake_io::rdma::wire::RdmaResponse {
+        use openlake_io::rdma::wire::{RdmaRequest::*, RdmaResponse};
+        match req {
+            BatchReserve { count } => RdmaResponse::BatchReserved {
+                slots: self.slab.reserve(count),
             },
-            (BatchCommit { entries }, Some(s)) => {
-                s.commit(&entries);
+            BatchCommit { entries } => {
+                let e: Vec<(u32, Vec<u8>)> =
+                    entries.into_iter().map(|c| (c.slot_idx, c.key_hash)).collect();
+                self.slab.commit(&e);
                 RdmaResponse::BatchCommitted
             }
-            (BatchLookup { key_hashes }, Some(s)) => RdmaResponse::BatchLookedUp {
-                slots: s.lookup(&key_hashes),
+            BatchLookup { key_hashes } => RdmaResponse::BatchLookedUp {
+                slots: self.slab.lookup(&key_hashes),
             },
-            (BatchRelease { slot_idxs }, Some(s)) => {
-                s.release(&slot_idxs);
+            BatchRelease { slot_idxs } => {
+                self.slab.release(&slot_idxs);
                 RdmaResponse::BatchReleased
             }
-            (
-                BatchReserve { .. } | BatchCommit { .. } | BatchLookup { .. } | BatchRelease { .. },
-                None,
-            ) => RdmaResponse::Generic(Response::Err(WireError::Other("kv_slab disabled".into()))),
-            (req, _) => unreachable!("kv engine routed a foreign request: {req:?}"),
+            Reset => {
+                self.slab.reset();
+                RdmaResponse::ResetDone
+            }
+            req => unreachable!("kv engine routed a foreign request: {req:?}"),
         }
     }
 }

--- a/crates/openlake_storage/src/lib.rs
+++ b/crates/openlake_storage/src/lib.rs
@@ -9,6 +9,7 @@ pub mod engine;
 pub mod error;
 pub mod format;
 #[cfg(all(feature = "rdma", target_os = "linux"))]
+pub mod kv_backend;
 pub mod kv_engine;
 pub mod managed;
 pub mod object;
@@ -18,7 +19,6 @@ pub use dsync::{DsyncClient, LockGuard};
 pub use engine::{ByteRange, Engine, DEFAULT_EC_PER_SHARD_BYTES, DEFAULT_INLINE_THRESHOLD};
 pub use error::{StorageError, StorageResult};
 pub use format::{bootstrap_format, FormatError};
-#[cfg(all(feature = "rdma", target_os = "linux"))]
 pub use kv_engine::KvEngine;
 pub use managed::{Managed, Stats};
 pub use object::{CompletePart, MultipartInit, ObjectInfo, StorageClass};


### PR DESCRIPTION
- Adds kv_backend.rs (RDMA client registry) ensuring worker can talk to server
- Finalizes kv_engine.rs (serve_tcp + RDMA handle over the KvSlab) and exports KvEngine.