### PR TITLE
(#206) [v0.6] style: fix rustfmt failures on main

### DIFF
--- a/crates/openlake_io/src/kv.rs
+++ b/crates/openlake_io/src/kv.rs
@@ -204,11 +204,7 @@ unsafe impl Send for HostSlab {}
 unsafe impl Sync for HostSlab {}
 
 impl HostSlab {
-    pub fn new(
-        slot_bytes: u32,
-        slot_count: u32,
-        reserve_ttl: Duration,
-    ) -> std::io::Result<Self> {
+    pub fn new(slot_bytes: u32, slot_count: u32, reserve_ttl: Duration) -> std::io::Result<Self> {
         let name = format!(
             "/openlake_kv_{}_{}",
             std::process::id(),

--- a/crates/openlake_server/src/rdma_server.rs
+++ b/crates/openlake_server/src/rdma_server.rs
@@ -83,8 +83,10 @@ async fn handle(
             let sender = match node
                 .peer_at(from_node_id, from_runtime_id)
                 .cloned()
-                .or_else(|| kv.as_ref().and_then(|e| e.peer_at(from_node_id, from_runtime_id)))
-            {
+                .or_else(|| {
+                    kv.as_ref()
+                        .and_then(|e| e.peer_at(from_node_id, from_runtime_id))
+                }) {
                 Some(p) => p,
                 None => {
                     tracing::warn!("rdma_server: unknown sender (node={from_node_id}, runtime={from_runtime_id})");

--- a/crates/openlake_storage/src/kv_engine.rs
+++ b/crates/openlake_storage/src/kv_engine.rs
@@ -107,15 +107,19 @@ impl KvEngine {
         if slot_bytes > 0 && self.slab.borrow().is_none() {
             let dev = self.dev.clone().expect("rdma engine built with a device");
             let slot_count = (self.capacity_bytes / slot_bytes as u64).max(1) as usize;
-            let slab = openlake_io::RdmaSlab::new(dev, slot_bytes as usize, slot_count, self.reserve_ttl)
-                .map_err(|e| format!("rdma slab create: {e}"))?;
+            let slab =
+                openlake_io::RdmaSlab::new(dev, slot_bytes as usize, slot_count, self.reserve_ttl)
+                    .map_err(|e| format!("rdma slab create: {e}"))?;
             let meta = openlake_io::rpc::SlabMeta {
                 slab_base: slab.slab_base(),
                 rkey: slab.rkey(),
                 slot_bytes: slab.slot_bytes(),
             };
             *self.slab.borrow_mut() = Some(Rc::new(slab));
-            let registry = self.registry.as_ref().expect("rdma engine built with a registry");
+            let registry = self
+                .registry
+                .as_ref()
+                .expect("rdma engine built with a registry");
             for ep in registry.lock().unwrap().endpoints.iter_mut() {
                 ep.kv_slab = Some(meta);
             }


### PR DESCRIPTION
## Summary

Fixes the current `cargo fmt --all -- --check` failure on the latest `main`.

## Changes

Applies rustfmt-only changes to:

- `crates/openlake_io/src/kv.rs`
- `crates/openlake_server/src/rdma_server.rs`
- `crates/openlake_storage/src/kv_engine.rs`

## Verification

```bash
cargo fmt --all -- --check