### PR TITLE
(#124) [v0.7] docs: add initial Mintlify configuration 

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "mint",
+  "name": "OpenLake",
+  "description": "Distributed object storage for GPU workloads",
+  "colors": {
+    "primary": "#2563EB",
+    "light": "#3B82F6",
+    "dark": "#1D4ED8"
+  },
+  "navigation": {
+    "anchors": [
+      {
+        "anchor": "GitHub",
+        "icon": "github",
+        "href": "https://github.com/openlake-project/openlake"
+      },
+      {
+        "anchor": "OpenLake Website",
+        "icon": "globe",
+        "href": "https://theopenlake.com"
+      }
+    ]
+  },
+  "navbar": {
+    "links": [
+      {
+        "label": "GitHub",
+        "href": "https://github.com/openlake-project/openlake"
+      }
+    ],
+    "primary": {
+      "type": "button",
+      "label": "OpenLake Website",
+      "href": "https://theopenlake.com"
+    }
+  },
+  "footer": {
+    "socials": {
+      "github": "https://github.com/openlake-project/openlake",
+      "discord": "https://discord.gg/TNXqVSnP6x"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds the initial Mintlify configuration for the OpenLake documentation.

## Changes

- Add `docs/docs.json`
- Configure Mintlify project metadata
- Configure project theme colors
- Add GitHub and OpenLake website links
- Configure footer links for GitHub and Discord
- Prepare the repository for future Mintlify integration

## Validation

- Ran `mint validate`
- Ran `mint broken-links`

## Notes

This PR only introduces the initial Mintlify configuration. The GitHub App and documentation URL will be wired up separately in a follow-up change.