### PR TITLE
(#238) [v0.8] KVE: Short circuit inference scheduler for small requests

### DIFF
--- a/external/connectors/vllm/openlake_adapter.py
+++ b/external/connectors/vllm/openlake_adapter.py
@@ -39,6 +39,7 @@ _FLCH_RETURNS_LENGTH = str(
 
 KEY_BYTES = 16
 SLOT_HEADER_BYTES = 54
+DEFAULT_MIN_EXTERNAL_LOOKUP_TOKENS = 1000
 
 _HASH_SEED_HELP = (
     "OpenLake external KV offloading requires PYTHONHASHSEED to be set for "
@@ -1042,6 +1043,21 @@ class OpenLakeScheduler:
         nodes = extra.get("openlake_nodes")
         if not nodes:
             raise ValueError("kv_connector_extra_config.openlake_nodes required")
+        try:
+            self._min_external_lookup_tokens = int(
+                extra.get(
+                    "openlake_min_external_lookup_tokens",
+                    DEFAULT_MIN_EXTERNAL_LOOKUP_TOKENS,
+                )
+            )
+        except (TypeError, ValueError) as err:
+            raise ValueError(
+                "openlake_min_external_lookup_tokens must be a non-negative integer"
+            ) from err
+        if self._min_external_lookup_tokens < 0:
+            raise ValueError(
+                "openlake_min_external_lookup_tokens must be a non-negative integer"
+            )
         self._client = openlake_client.Client(
             device=extra.get("openlake_device", "mlx5_ib0"),
             client_id=int(extra.get("openlake_client_id", 2048)),
@@ -1130,6 +1146,8 @@ class OpenLakeScheduler:
     def get_num_new_matched_tokens(
         self, request, num_computed_tokens: int
     ) -> tuple[int | None, bool]:
+        if request.num_prompt_tokens < self._min_external_lookup_tokens:
+            return 0, False
         token_len = request.num_tokens // self._sched_bs * self._sched_bs
         if token_len < self._sched_bs:
             return 0, False

--- a/external/connectors/vllm/openlake_adapter.py
+++ b/external/connectors/vllm/openlake_adapter.py
@@ -39,7 +39,6 @@ _FLCH_RETURNS_LENGTH = str(
 
 KEY_BYTES = 16
 SLOT_HEADER_BYTES = 54
-DEFAULT_MIN_EXTERNAL_LOOKUP_TOKENS = 1000
 
 _HASH_SEED_HELP = (
     "OpenLake external KV offloading requires PYTHONHASHSEED to be set for "
@@ -1043,21 +1042,9 @@ class OpenLakeScheduler:
         nodes = extra.get("openlake_nodes")
         if not nodes:
             raise ValueError("kv_connector_extra_config.openlake_nodes required")
-        try:
-            self._min_external_lookup_tokens = int(
-                extra.get(
-                    "openlake_min_external_lookup_tokens",
-                    DEFAULT_MIN_EXTERNAL_LOOKUP_TOKENS,
-                )
-            )
-        except (TypeError, ValueError) as err:
-            raise ValueError(
-                "openlake_min_external_lookup_tokens must be a non-negative integer"
-            ) from err
-        if self._min_external_lookup_tokens < 0:
-            raise ValueError(
-                "openlake_min_external_lookup_tokens must be a non-negative integer"
-            )
+        self._min_external_lookup_tokens = extra.get(
+            "openlake_min_external_lookup_tokens", 1000
+        )
         self._client = openlake_client.Client(
             device=extra.get("openlake_device", "mlx5_ib0"),
             client_id=int(extra.get("openlake_client_id", 2048)),


### PR DESCRIPTION
 - For requests with 100s of input tokens, the cache round trip is expensive.
 - Ensure we can directly return outputs for get_num_new_matched_tokens to avoid lookup on low network environments.