### PR TITLE
release: prepare openlake-vllm 0.8.0

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -1,0 +1,321 @@
+name: release Python package
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/release-python.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/openlake_io/**"
+      - "crates/openlake_kv_client/**"
+      - "crates/openlake_server/**"
+      - "crates/openlake_storage/**"
+      - "external/connectors/vllm/**"
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-python-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: github.repository == 'openlake-project/openlake'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify release version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo_version="$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)"/\1/p' Cargo.toml | head -1)"
+          [[ "$cargo_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            release_version="${GITHUB_REF_NAME#v}"
+            test "$GITHUB_REF_NAME" = "v$release_version"
+            test "$cargo_version" = "$release_version"
+            test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = "tag"
+            git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+          fi
+          echo "version=$cargo_version" >> "$GITHUB_OUTPUT"
+
+      - name: Reject an existing package version
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_version="${GITHUB_REF_NAME#v}"
+          pypi_status="$(curl --silent --show-error --location --retry 3 \
+            --output /dev/null --write-out '%{http_code}' \
+            "https://pypi.org/pypi/openlake-vllm/$release_version/json")"
+          testpypi_status="$(curl --silent --show-error --location --retry 3 \
+            --output /dev/null --write-out '%{http_code}' \
+            "https://test.pypi.org/pypi/openlake-vllm/$release_version/json")"
+          test "$pypi_status" = "404"
+          test "$testpypi_status" = "404"
+
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        with:
+          toolchain: "1.91.1"
+          components: rustfmt, clippy
+
+      - name: Install system dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            clang cmake libhwloc-dev libudev-dev pkg-config
+
+      - name: Cargo preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo metadata --locked --no-deps --format-version 1 >/dev/null
+          cargo fmt --all -- --check
+          cargo clippy --locked --workspace --all-targets -- -D warnings
+          # The PyO3 crate is linked as a Python extension and is exercised from
+          # the built wheel below; linking it as a standalone Rust test binary
+          # is not supported by extension-module builds.
+          cargo test --locked --workspace --exclude openlake_kv_client
+
+      - name: Build the manylinux wheel
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          command: build
+          maturin-version: v1.14.1
+          rust-toolchain: "1.91.1"
+          target: x86_64-unknown-linux-gnu
+          manylinux: "2_28"
+          container: quay.io/pypa/manylinux_2_28_x86_64@sha256:f854c50adf7b7a325bc4794316f3758d387a41d61f9e2ebca0f26c7dc8f761d4
+          working-directory: crates/openlake_kv_client
+          before-script-linux: bash ./prepare-wheel.sh cpu x86_64-unknown-linux-gnu
+          args: >-
+            --release
+            --locked
+            --compatibility pypi
+            --auditwheel repair
+            --out dist
+
+      - name: Validate wheel structure and clean install
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check \
+            auditwheel==6.8.0 twine==7.0.0
+          chmod +x crates/openlake_kv_client/verify-wheel.sh
+          crates/openlake_kv_client/verify-wheel.sh \
+            "${{ steps.version.outputs.version }}" \
+            crates/openlake_kv_client/dist
+
+      - name: Record artifact digest
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release/packages
+          cp crates/openlake_kv_client/dist/*.whl release/packages/
+          (cd release/packages && sha256sum *.whl) > release/SHA256SUMS
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: openlake-vllm-${{ github.run_id }}
+          path: release/
+          if-no-files-found: error
+          retention-days: 30
+
+  smoke-supported-python:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.14"]
+    steps:
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openlake-vllm-${{ github.run_id }}
+          path: release
+
+      - name: Install and import the abi3 wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+          (cd release/packages && sha256sum --check ../SHA256SUMS)
+          python -m pip install --disable-pip-version-check \
+            --no-deps --no-index release/packages/*.whl
+          python - <<'PY'
+          import importlib.metadata
+          import openlake_client
+
+          expected = "${{ needs.build.outputs.version }}"
+          assert importlib.metadata.version("openlake-vllm") == expected
+          assert openlake_client.__version__ == expected
+          PY
+          openlaked --version | grep -Fx "openlaked ${{ needs.build.outputs.version }}"
+
+  smoke-clean-linux:
+    needs: [build, smoke-supported-python]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openlake-vllm-${{ github.run_id }}
+          path: release
+
+      - name: Exercise wheel in a pinned minimal Linux image
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --shm-size 2g \
+            --volume "$PWD:/workspace:ro" \
+            --volume "$PWD/release:/release:ro" \
+            python:3.10-slim-bookworm@sha256:6dafe336b64dbf76f7ec872d07e58b5c7de0e2ea5d4c0853a05c3b6be3278b00 \
+            bash /workspace/crates/openlake_kv_client/smoke-wheel.sh \
+              /release/packages \
+              "${{ needs.build.outputs.version }}"
+
+  approve-staging-validation:
+    needs: [build, smoke-supported-python, smoke-clean-linux]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: release-staging
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openlake-vllm-${{ github.run_id }}
+          path: release
+
+      - name: Confirm the approved staging artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          (cd release/packages && sha256sum --check ../SHA256SUMS)
+          echo "The release-staging approver confirms that this exact wheel"
+          cat release/SHA256SUMS
+          echo "passed the OpenLake local-mode CUDA/vLLM miss-store-hit test on staging."
+
+  publish-testpypi:
+    needs: approve-staging-validation
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openlake-vllm-${{ github.run_id }}
+          path: dist
+
+      - name: Final immutable-artifact check
+        shell: bash
+        run: |
+          set -euo pipefail
+          (cd dist/packages && sha256sum --check ../SHA256SUMS)
+          test "$(find dist/packages -maxdepth 1 -type f -name '*.whl' | wc -l)" -eq 1
+          version="${GITHUB_REF_NAME#v}"
+          pypi_status="$(curl --silent --show-error --location --retry 3 \
+            --output /dev/null --write-out '%{http_code}' \
+            "https://pypi.org/pypi/openlake-vllm/$version/json")"
+          testpypi_status="$(curl --silent --show-error --location --retry 3 \
+            --output /dev/null --write-out '%{http_code}' \
+            "https://test.pypi.org/pypi/openlake-vllm/$version/json")"
+          test "$pypi_status" = "404"
+          test "$testpypi_status" = "404"
+
+      - name: Publish exact wheel to TestPyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/packages/
+          verbose: true
+          attestations: true
+
+  verify-testpypi:
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openlake-vllm-${{ github.run_id }}
+          path: release
+
+      - name: Fetch the exact TestPyPI wheel and compare it byte-for-byte
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          mkdir fetched
+          for attempt in {1..12}; do
+            if python -m pip download \
+              --disable-pip-version-check \
+              --no-cache-dir \
+              --no-deps \
+              --only-binary=:all: \
+              --index-url https://test.pypi.org/simple/ \
+              --dest fetched \
+              "openlake-vllm==$version"; then
+              break
+            fi
+            test "$attempt" -lt 12
+            sleep 10
+          done
+          cmp release/packages/*.whl fetched/*.whl
+          python -m pip install --disable-pip-version-check --no-deps fetched/*.whl
+          python -c 'import openlake_client; assert openlake_client.__version__ == "'"$version"'"'
+
+  publish-pypi:
+    needs: verify-testpypi
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openlake-vllm-${{ github.run_id }}
+          path: dist
+
+      - name: Final immutable-artifact check
+        shell: bash
+        run: |
+          set -euo pipefail
+          (cd dist/packages && sha256sum --check ../SHA256SUMS)
+          test "$(find dist/packages -maxdepth 1 -type f -name '*.whl' | wc -l)" -eq 1
+          version="${GITHUB_REF_NAME#v}"
+          status="$(curl --silent --show-error --location --retry 3 \
+            --output /dev/null --write-out '%{http_code}' \
+            "https://pypi.org/pypi/openlake-vllm/$version/json")"
+          test "$status" = "404"
+
+      - name: Publish exact wheel to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: dist/packages/
+          verbose: true
+          attestations: true

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -182,18 +182,31 @@ jobs:
           name: openlake-vllm-${{ github.run_id }}
           path: release
 
-      - name: Exercise wheel in a pinned minimal Linux image
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+
+      - name: Verify dependencies in a pinned minimal Linux image
         shell: bash
         run: |
           set -euo pipefail
           docker run --rm \
-            --shm-size 2g \
             --volume "$PWD:/workspace:ro" \
             --volume "$PWD/release:/release:ro" \
             python:3.10-slim-bookworm@sha256:6dafe336b64dbf76f7ec872d07e58b5c7de0e2ea5d4c0853a05c3b6be3278b00 \
             bash /workspace/crates/openlake_kv_client/smoke-wheel.sh \
               /release/packages \
-              "${{ needs.build.outputs.version }}"
+              "${{ needs.build.outputs.version }}" \
+              dependencies-only
+
+      - name: Exercise the packaged daemon and local data plane
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash crates/openlake_kv_client/smoke-wheel.sh \
+            "$PWD/release/packages" \
+            "${{ needs.build.outputs.version }}" \
+            full
 
   approve-staging-validation:
     needs: [build, smoke-supported-python, smoke-clean-linux]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2160,7 +2160,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openlake_cli"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "aws-credential-types",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "openlake_io"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "aligned-vec",
  "anyhow",
@@ -2229,7 +2229,7 @@ dependencies = [
 
 [[package]]
 name = "openlake_kv_client"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "compio",
  "futures",
@@ -2242,7 +2242,7 @@ dependencies = [
 
 [[package]]
 name = "openlake_server"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "openlake_storage"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members  = ["crates/*", "cli"]
 resolver = "2"
 
 [workspace.package]
-version      = "0.1.0"
+version      = "0.8.0"
 edition      = "2021"
 rust-version = "1.88"
 license      = "Apache-2.0"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -52,9 +52,10 @@ No long-lived PyPI token is required by the workflow.
    ```
 
 4. The tag workflow builds one wheel, audits both ELF files, validates package
-   contents and versions, installs on CPython 3.10 and 3.14, and runs a local
-   KV put/get round trip in a pinned minimal Debian image with no build-time
-   system packages available to hide a missing runtime dependency.
+   contents and versions, and installs on CPython 3.10 and 3.14. A pinned
+   minimal Debian image checks imports and ELF dependencies with no build-time
+   packages available to hide a missing runtime library; the Linux host then
+   runs the packaged daemon and a local KV put/get round trip with `io_uring`.
 5. Download that run's `openlake-vllm-*` artifact. On the staging H100, install
    the wheel by file path and run the local-mode CUDA/vLLM miss → store → hit
    test. Verify its SHA-256 against the included `SHA256SUMS`. In the protected

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,73 @@
+# Releasing `openlake-vllm`
+
+The `openlake-vllm` wheel embeds both a native Python extension and the
+`openlaked` Linux executable. Release artifacts must therefore be built in the
+pinned manylinux environment in `.github/workflows/release-python.yml`, never
+on a developer workstation.
+
+## v0.8 scope
+
+- Distribution: `openlake-vllm`
+- Version: `0.8.0` (Git tag: `v0.8.0`)
+- Artifact: `cp310-abi3-manylinux_2_28_x86_64`
+- Supported interpreter family: regular CPython 3.10 and newer
+- Transport: non-RDMA local/H2 build
+
+The v0.8 PyPI release does not include an sdist, the RDMA/UCX build, the ExANS
+CUDA codec, or the control-plane UI. The current RDMA build skips auditwheel
+and has external UCX/verbs/mlx5 runtime requirements; release it separately
+only after its packaging and clean-host tests are defined.
+
+## One-time repository setup
+
+Before creating a release tag:
+
+1. Protect `main` and `v*` tags against direct or mutable updates.
+2. Create protected GitHub environments named `release-staging`, `testpypi`,
+   and `pypi`, and require an approval before each deployment. Enable
+   prevention of self-review after the repository has a second release
+   maintainer; at present the organization has only one member.
+3. Add Trusted Publishers on TestPyPI and PyPI with these exact values:
+
+   - Owner: `openlake-project`
+   - Repository: `openlake`
+   - Workflow: `release-python.yml`
+   - Environment: `testpypi` or `pypi`, respectively
+
+No long-lived PyPI token is required by the workflow.
+
+## Release procedure
+
+1. Merge the version and release-workflow PR only after its Linux package job
+   passes.
+2. Update local `main` with a fast-forward pull and verify that it is clean.
+3. Create and push an annotated tag:
+
+   ```bash
+   git switch main
+   git pull --ff-only origin main
+   git status --short
+   git tag -a v0.8.0 -m "OpenLake v0.8.0"
+   git push origin v0.8.0
+   ```
+
+4. The tag workflow builds one wheel, audits both ELF files, validates package
+   contents and versions, installs on CPython 3.10 and 3.14, and runs a local
+   KV put/get round trip in a pinned minimal Debian image with no build-time
+   system packages available to hide a missing runtime dependency.
+5. Download that run's `openlake-vllm-*` artifact. On the staging H100, install
+   the wheel by file path and run the local-mode CUDA/vLLM miss → store → hit
+   test. Verify its SHA-256 against the included `SHA256SUMS`. In the protected
+   environment approval record, record that SHA-256 and link the retained
+   staging test output, then approve the `release-staging` job.
+6. Approve `testpypi`. The workflow uploads the same wheel, downloads it again,
+   and compares it byte-for-byte with the candidate.
+7. Approve `pypi` only after TestPyPI verification succeeds. The production job
+   checks the digest and confirms that the version is still unused immediately
+   before upload.
+8. Verify a clean production install by exact version and confirm the published
+   attestation on PyPI.
+
+Never rebuild between validation and publication, publish from macOS, use
+`--skip-existing`, or upload a wheel manually. PyPI release files are
+immutable.

--- a/crates/openlake_kv_client/README.md
+++ b/crates/openlake_kv_client/README.md
@@ -1,0 +1,14 @@
+# OpenLake for vLLM
+
+`openlake-vllm` packages the OpenLake KV-cache client, the `openlaked` daemon,
+and the OpenLake vLLM connector for Linux.
+
+Version 0.8 provides the non-RDMA local/H2 transport as a
+`cp310-abi3-manylinux_2_28_x86_64` wheel. It supports regular CPython 3.10 and
+newer on x86-64 Linux. Install vLLM separately for the connector runtime.
+
+The RDMA/UCX build, ExANS CUDA codec, control-plane UI, source distribution,
+and aarch64 wheel are not included in this package release.
+
+Project source and documentation are available at
+[github.com/openlake-project/openlake](https://github.com/openlake-project/openlake).

--- a/crates/openlake_kv_client/build.sh
+++ b/crates/openlake_kv_client/build.sh
@@ -1,45 +1,41 @@
 #!/usr/bin/env bash
-# Build one wheel that carries all four artifacts:
+# Build one Linux wheel that carries all four artifacts:
 #   client .so (maturin compiles) + openlaked (cargo) + connector .py + configs.
-#   ./build.sh          -> openlake-vllm      (non-RDMA)
+#   ./build.sh       -> openlake-vllm      (non-RDMA)
+#   ./build.sh rdma  -> openlake-vllm-ib   (environment-specific RDMA build)
 set -euo pipefail
 cd "$(dirname "$0")"
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "OpenLake wheels embed a Linux openlaked binary; build on Linux/manylinux." >&2
+  exit 1
+fi
 
 VARIANT="${1:-cpu}"
 case "$VARIANT" in
   cpu|rdma) ;;
-  *) echo "usage: $0 [rdma]" >&2; exit 2 ;;
+  *) echo "usage: $0 [cpu|rdma]" >&2; exit 2 ;;
 esac
-PKG="python/openlake_client"
-FEAT=""
-AUDIT=""
+
+MATURIN_FEATURES=()
+MATURIN_POLICY=(--compatibility pypi --auditwheel repair)
 if [ "$VARIANT" = "rdma" ]; then
-  FEAT="--features rdma"
-  AUDIT="--auditwheel skip"
+  MATURIN_FEATURES=(--features rdma)
+  # The RDMA artifact has external UCX/verbs/mlx5 runtime requirements and is
+  # not currently claimed to be a portable manylinux wheel.
+  MATURIN_POLICY=(--auditwheel skip)
   cp pyproject.toml pyproject.toml.orig
   trap 'mv pyproject.toml.orig pyproject.toml' EXIT
   sed 's/^name = "openlake-vllm"/name = "openlake-vllm-ib"/' pyproject.toml.orig > pyproject.toml
 fi
 
-# 1. server binary — cargo compiles it
-cargo build --release -p openlake_server --bin openlaked $FEAT --features vendored-hwloc
-cp ../../target/release/openlaked "$PKG/openlaked"
+# A release directory is single-use: stale wheels must never survive a build.
+rm -rf dist ../../target/maturin
+bash ./prepare-wheel.sh "$VARIANT"
 
-# 2. connector .py
-cp ../../external/connectors/vllm/*.py "$PKG/"
-sed -i 's|vllm\.distributed\.kv_transfer\.kv_connector\.v1\.openlake_|openlake_client.openlake_|g' "$PKG"/openlake_*.py
-
-# 3. default configs
-rm -rf "$PKG/configs"
-mkdir -p "$PKG/configs"
-cp ../openlake_server/configs/kv_local.toml "$PKG/configs/"
-if [ "$VARIANT" = "rdma" ]; then
-  cp ../openlake_server/configs/kv_rdma.toml ../openlake_server/configs/kv_ucx.toml "$PKG/configs/"
-  cp ../openlake_server/configs/kv_rdma.toml "$PKG/configs/default.toml"
-else
-  cp ../openlake_server/configs/kv_local.toml "$PKG/configs/default.toml"
-fi
-
-# 4. maturin compiles the client .so and packs the wheel
-rm -rf ../../target/maturin
-maturin build --release $FEAT $AUDIT -o dist
+maturin build \
+  --release \
+  --locked \
+  "${MATURIN_FEATURES[@]}" \
+  "${MATURIN_POLICY[@]}" \
+  --out dist

--- a/crates/openlake_kv_client/prepare-wheel.sh
+++ b/crates/openlake_kv_client/prepare-wheel.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Prepare the generated files embedded in the OpenLake Python wheel.
+# Run this inside the target Linux/manylinux environment before maturin.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "OpenLake wheels embed a Linux openlaked binary; build on Linux/manylinux." >&2
+  exit 1
+fi
+
+VARIANT="${1:-cpu}"
+TARGET="${2:-}"
+case "$VARIANT" in
+  cpu|rdma) ;;
+  *) echo "usage: $0 [cpu|rdma] [rust-target]" >&2; exit 2 ;;
+esac
+
+PKG="python/openlake_client"
+
+# Never allow generated files from an earlier build or variant into a wheel.
+rm -f "$PKG/openlaked" "$PKG"/_native*.so "$PKG"/openlake_*.py
+rm -rf "$PKG/configs"
+
+FEATURES="vendored-hwloc"
+CARGO_TARGET=()
+SERVER_BIN="../../target/release/openlaked"
+if [ -n "$TARGET" ]; then
+  CARGO_TARGET=(--target "$TARGET")
+  SERVER_BIN="../../target/$TARGET/release/openlaked"
+fi
+if [ "$VARIANT" = "rdma" ]; then
+  FEATURES+=",rdma"
+fi
+
+cargo build \
+  --locked \
+  --release \
+  -p openlake_server \
+  --bin openlaked \
+  "${CARGO_TARGET[@]}" \
+  --features "$FEATURES"
+install -m 0755 "$SERVER_BIN" "$PKG/openlaked"
+
+cp ../../external/connectors/vllm/*.py "$PKG/"
+sed -i \
+  's|vllm\.distributed\.kv_transfer\.kv_connector\.v1\.openlake_|openlake_client.openlake_|g' \
+  "$PKG"/openlake_*.py
+
+mkdir -p "$PKG/configs"
+cp ../openlake_server/configs/kv_local.toml "$PKG/configs/"
+if [ "$VARIANT" = "rdma" ]; then
+  cp \
+    ../openlake_server/configs/kv_rdma.toml \
+    ../openlake_server/configs/kv_ucx.toml \
+    "$PKG/configs/"
+  cp ../openlake_server/configs/kv_rdma.toml "$PKG/configs/default.toml"
+else
+  cp ../openlake_server/configs/kv_local.toml "$PKG/configs/default.toml"
+fi

--- a/crates/openlake_kv_client/pyproject.toml
+++ b/crates/openlake_kv_client/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "maturin"
 name = "openlake-vllm"
 dynamic = ["version"]
 description = "OpenLake high performance KV cache client and server for vLLM."
+readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 

--- a/crates/openlake_kv_client/pyproject.toml
+++ b/crates/openlake_kv_client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "openlake-vllm"
-version = "0.6.1"
+dynamic = ["version"]
 description = "OpenLake high performance KV cache client and server for vLLM."
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }

--- a/crates/openlake_kv_client/smoke-wheel.sh
+++ b/crates/openlake_kv_client/smoke-wheel.sh
@@ -4,7 +4,13 @@ set -euo pipefail
 
 WHEEL_DIR="${1:?usage: $0 WHEEL_DIR EXPECTED_VERSION}"
 EXPECTED_VERSION="${2:?usage: $0 WHEEL_DIR EXPECTED_VERSION}"
+MODE="${3:-full}"
 WHEELS=("$WHEEL_DIR"/*.whl)
+
+case "$MODE" in
+  dependencies-only|full) ;;
+  *) echo "mode must be dependencies-only or full" >&2; exit 2 ;;
+esac
 
 if [ "${#WHEELS[@]}" -ne 1 ] || [ ! -f "${WHEELS[0]}" ]; then
   echo "expected exactly one wheel in $WHEEL_DIR" >&2
@@ -51,6 +57,10 @@ print(package / "_native.abi3.so")
 print(package / "openlaked")
 PY
 )
+
+if [ "$MODE" = "dependencies-only" ]; then
+  exit 0
+fi
 
 SMOKE_DIR="$(mktemp -d)"
 cat > "$SMOKE_DIR/kv.toml" <<'TOML'

--- a/crates/openlake_kv_client/smoke-wheel.sh
+++ b/crates/openlake_kv_client/smoke-wheel.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Install and exercise the non-RDMA wheel in a disposable minimal Linux image.
+set -euo pipefail
+
+WHEEL_DIR="${1:?usage: $0 WHEEL_DIR EXPECTED_VERSION}"
+EXPECTED_VERSION="${2:?usage: $0 WHEEL_DIR EXPECTED_VERSION}"
+WHEELS=("$WHEEL_DIR"/*.whl)
+
+if [ "${#WHEELS[@]}" -ne 1 ] || [ ! -f "${WHEELS[0]}" ]; then
+  echo "expected exactly one wheel in $WHEEL_DIR" >&2
+  exit 1
+fi
+
+python -m pip install --disable-pip-version-check \
+  --no-deps --no-index "${WHEELS[0]}"
+
+python - "$EXPECTED_VERSION" <<'PY'
+import importlib.metadata
+import sys
+
+import openlake_client
+
+expected = sys.argv[1]
+assert importlib.metadata.version("openlake-vllm") == expected
+assert openlake_client.__version__ == expected
+PY
+
+openlaked --version | grep -Fx "openlaked $EXPECTED_VERSION"
+
+LDD_OUTPUT="$(mktemp)"
+cleanup_ldd() {
+  rm -f "$LDD_OUTPUT"
+}
+trap cleanup_ldd EXIT
+while IFS= read -r elf; do
+  if ! ldd "$elf" > "$LDD_OUTPUT" 2>&1; then
+    cat "$LDD_OUTPUT" >&2
+    exit 1
+  fi
+  if grep -q "not found" "$LDD_OUTPUT"; then
+    echo "unresolved shared library in $elf" >&2
+    cat "$LDD_OUTPUT" >&2
+    exit 1
+  fi
+done < <(
+  python - <<'PY'
+from importlib.resources import files
+
+package = files("openlake_client")
+print(package / "_native.abi3.so")
+print(package / "openlaked")
+PY
+)
+
+SMOKE_DIR="$(mktemp -d)"
+cat > "$SMOKE_DIR/kv.toml" <<'TOML'
+self_id = 0
+mode = "kv"
+transport = "h2"
+rpc_addr = "127.0.0.1:19400"
+s3_addr = "127.0.0.1:19000"
+region = "us-east-1"
+data_dirs = []
+set_drive_count = 1
+default_parity_count = 1
+
+[[credentials]]
+access_key = "openlake"
+secret_key = "openlake"
+
+[[nodes]]
+id = 0
+rpc_addr = "127.0.0.1:19400"
+disk_count = 0
+
+[kv_slab]
+capacity_gb = 1
+reserve_ttl_secs = 60
+TOML
+
+openlaked --config "$SMOKE_DIR/kv.toml" > "$SMOKE_DIR/openlaked.log" 2>&1 &
+DAEMON_PID=$!
+cleanup() {
+  kill "$DAEMON_PID" 2>/dev/null || true
+  wait "$DAEMON_PID" 2>/dev/null || true
+  if [ -s "$SMOKE_DIR/openlaked.log" ]; then
+    cat "$SMOKE_DIR/openlaked.log"
+  fi
+  cleanup_ldd
+  rm -rf "$SMOKE_DIR"
+}
+trap cleanup EXIT
+
+python - "$EXPECTED_VERSION" <<'PY'
+import ctypes
+import json
+import socket
+import sys
+import time
+import urllib.request
+
+from openlake_client import Client
+
+for _ in range(100):
+    try:
+        with socket.create_connection(("127.0.0.1", 19400), 0.2):
+            break
+    except OSError:
+        time.sleep(0.1)
+else:
+    raise SystemExit("openlaked did not become ready")
+
+for _ in range(100):
+    try:
+        with urllib.request.urlopen(
+            "http://127.0.0.1:19401/v1/telemetry/openlake", timeout=1
+        ) as response:
+            telemetry = json.load(response)
+        break
+    except OSError:
+        time.sleep(0.1)
+else:
+    raise SystemExit("openlaked telemetry did not become ready")
+assert telemetry["openlake"]["version"] == sys.argv[1]
+
+key = bytes(range(54))
+source = bytearray((index * 17) % 256 for index in range(512))
+destination = bytearray(len(source))
+source_address = ctypes.addressof(ctypes.c_char.from_buffer(source))
+destination_address = ctypes.addressof(ctypes.c_char.from_buffer(destination))
+
+client = Client("local", 2048)
+assert client.attach("127.0.0.1:19400", 0, 4096) > 0
+assert client.batch_is_exist([key]) == [0]
+assert client.put_batch([key], [[source_address]], [[len(source)]]) == [0]
+assert client.batch_is_exist([key]) == [1]
+assert client.get_batch([key], [[destination_address]], [[len(destination)]]) == [0]
+assert destination == source
+client.reset()
+client.close()
+PY

--- a/crates/openlake_kv_client/verify-wheel.sh
+++ b/crates/openlake_kv_client/verify-wheel.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Validate the exact non-RDMA artifact before it can be promoted.
+set -euo pipefail
+
+EXPECTED_VERSION="${1:-0.8.0}"
+WHEEL_DIR="${2:-dist}"
+WHEELS=("$WHEEL_DIR"/*.whl)
+
+if [ "${#WHEELS[@]}" -ne 1 ] || [ ! -f "${WHEELS[0]}" ]; then
+  echo "expected exactly one wheel in $WHEEL_DIR" >&2
+  exit 1
+fi
+
+WHEEL="${WHEELS[0]}"
+case "$(basename "$WHEEL")" in
+  openlake_vllm-"$EXPECTED_VERSION"-cp310-abi3-manylinux_2_28_x86_64.whl) ;;
+  *) echo "unexpected wheel name: $(basename "$WHEEL")" >&2; exit 1 ;;
+esac
+
+python -m twine check --strict "$WHEEL"
+auditwheel show "$WHEEL"
+
+EXTRACT_DIR="$(mktemp -d /tmp/openlake-wheel.XXXXXX)"
+SMOKE_VENV="$(mktemp -d /tmp/openlake-wheel-smoke.XXXXXX)"
+LDD_OUTPUT="$(mktemp /tmp/openlake-wheel-ldd.XXXXXX)"
+trap 'rm -rf "$EXTRACT_DIR" "$SMOKE_VENV"; rm -f "$LDD_OUTPUT"' EXIT
+
+python - "$WHEEL" "$EXPECTED_VERSION" "$EXTRACT_DIR" <<'PY'
+import base64
+import csv
+import hashlib
+import io
+import sys
+import zipfile
+
+wheel_path, expected_version, extract_dir = sys.argv[1:]
+required = {
+    "openlake_client/__init__.py",
+    "openlake_client/__main__.py",
+    "openlake_client/_native.abi3.so",
+    "openlake_client/openlaked",
+    "openlake_client/openlake_adapter.py",
+    "openlake_client/openlake_connector.py",
+    "openlake_client/openlake_metrics.py",
+    "openlake_client/configs/default.toml",
+    "openlake_client/configs/kv_local.toml",
+}
+forbidden = {
+    "openlake_client/configs/kv_rdma.toml",
+    "openlake_client/configs/kv_ucx.toml",
+}
+
+with zipfile.ZipFile(wheel_path) as archive:
+    names = set(archive.namelist())
+    missing = required - names
+    present_forbidden = forbidden & names
+    assert not missing, f"wheel is missing: {sorted(missing)}"
+    assert not present_forbidden, (
+        f"non-RDMA wheel contains RDMA configs: {sorted(present_forbidden)}"
+    )
+    configs = {
+        name
+        for name in names
+        if name.startswith("openlake_client/configs/") and name.endswith(".toml")
+    }
+    expected_configs = {
+        "openlake_client/configs/default.toml",
+        "openlake_client/configs/kv_local.toml",
+    }
+    assert configs == expected_configs, f"unexpected configs: {sorted(configs)}"
+
+    elf_files = set()
+    for name in names:
+        if name.endswith("/"):
+            continue
+        with archive.open(name) as member:
+            if member.read(4) == b"\x7fELF":
+                elf_files.add(name)
+    assert elf_files == {
+        "openlake_client/_native.abi3.so",
+        "openlake_client/openlaked",
+    }, f"unexpected ELF files: {sorted(elf_files)}"
+
+    daemon = archive.getinfo("openlake_client/openlaked")
+    assert (daemon.external_attr >> 16) & 0o111, "openlaked is not executable"
+
+    metadata_name = next(name for name in names if name.endswith(".dist-info/METADATA"))
+    metadata = archive.read(metadata_name).decode()
+    assert f"Version: {expected_version}\n" in metadata
+    assert "Requires-Python: >=3.10\n" in metadata
+
+    wheel_name = next(name for name in names if name.endswith(".dist-info/WHEEL"))
+    wheel_metadata = archive.read(wheel_name).decode()
+    assert "Tag: cp310-abi3-manylinux_2_28_x86_64\n" in wheel_metadata
+
+    record_name = next(name for name in names if name.endswith(".dist-info/RECORD"))
+    record = {
+        row[0]: row[1]
+        for row in csv.reader(io.StringIO(archive.read(record_name).decode()))
+    }
+    for name in required:
+        algorithm, digest = record[name].split("=", 1)
+        assert algorithm == "sha256"
+        actual = hashlib.sha256(archive.read(name)).digest()
+        encoded = base64.urlsafe_b64encode(actual).rstrip(b"=").decode()
+        assert encoded == digest, f"RECORD mismatch for {name}"
+
+    old_import = "vllm.distributed.kv_transfer.kv_connector.v1.openlake_"
+    for name in names:
+        if name.startswith("openlake_client/openlake_") and name.endswith(".py"):
+            assert old_import not in archive.read(name).decode(), name
+
+    archive.extractall(extract_dir)
+PY
+
+ELF_FILES=(
+  "$EXTRACT_DIR/openlake_client/openlaked"
+  "$EXTRACT_DIR/openlake_client/_native.abi3.so"
+)
+for elf in "${ELF_FILES[@]}"; do
+  file "$elf" | grep -Eq 'ELF 64-bit.*x86-64'
+  if readelf -d "$elf" | grep -Eiq \
+    '\(NEEDED\).*(libucp|libucs|libuct|libucm|libibverbs|libmlx5|libcuda|libcudart)'; then
+    echo "non-RDMA wheel links an RDMA or CUDA runtime: $elf" >&2
+    readelf -d "$elf" >&2
+    exit 1
+  fi
+  if ! ldd "$elf" > "$LDD_OUTPUT" 2>&1; then
+    cat "$LDD_OUTPUT" >&2
+    exit 1
+  fi
+  if grep -q 'not found' "$LDD_OUTPUT"; then
+    echo "unresolved shared library in $elf" >&2
+    cat "$LDD_OUTPUT" >&2
+    exit 1
+  fi
+  max_glibc="$(
+    readelf --version-info "$elf" |
+      grep -oE 'GLIBC_[0-9]+(\.[0-9]+)*' |
+      sed 's/^GLIBC_//' |
+      sort -Vu |
+      tail -1
+  )"
+  if [ -n "$max_glibc" ] &&
+     [ "$(printf '%s\n' "$max_glibc" 2.28 | sort -V | tail -1)" != "2.28" ]; then
+    echo "$elf requires GLIBC_$max_glibc, above the 2.28 ceiling" >&2
+    exit 1
+  fi
+done
+
+python -m venv "$SMOKE_VENV"
+"$SMOKE_VENV/bin/python" -m pip install --disable-pip-version-check \
+  --no-deps --no-index "$WHEEL"
+"$SMOKE_VENV/bin/python" - "$EXPECTED_VERSION" <<'PY'
+import importlib.metadata
+import sys
+
+import openlake_client
+
+expected = sys.argv[1]
+assert importlib.metadata.version("openlake-vllm") == expected
+assert openlake_client.__version__ == expected
+PY
+"$SMOKE_VENV/bin/openlaked" --version | grep -Fx "openlaked $EXPECTED_VERSION"

--- a/crates/openlake_server/src/lock_server.rs
+++ b/crates/openlake_server/src/lock_server.rs
@@ -207,15 +207,31 @@ mod tests {
 
     #[test]
     fn refresh_matches_uid_and_extends_lease() {
-        let s = short();
+        let validity = Duration::from_secs(60);
+        let s = LockServer::with_validity(validity);
         assert!(s.acquire("k", "u1", NO_TTL));
-        // Mid lease refresh keeps the entry alive past what would
-        // otherwise be expiry.
-        std::thread::sleep(Duration::from_millis(20));
+
+        // Put the initial lease 40 seconds into its 60-second validity window.
+        // Mutating the test-only state avoids scheduler-sensitive sleeps.
+        {
+            let mut map = s.locks.lock().unwrap();
+            map.get_mut("k").unwrap().last_refresh =
+                Instant::now().checked_sub(Duration::from_secs(40)).unwrap();
+        }
+
         assert!(s.refresh("k", "u1"));
-        std::thread::sleep(Duration::from_millis(20));
-        // 40 ms since acquire but only 20 ms since the last refresh,
-        // so the entry is still live and u2 cannot take it.
+
+        // Simulate another 30 seconds after the refresh. Without the refresh,
+        // the original lease would now be 70 seconds old and expired; with the
+        // refresh it is only 30 seconds old and remains held by u1.
+        {
+            let mut map = s.locks.lock().unwrap();
+            let entry = map.get_mut("k").unwrap();
+            entry.last_refresh = entry
+                .last_refresh
+                .checked_sub(Duration::from_secs(30))
+                .unwrap();
+        }
         assert!(!s.acquire("k", "u2", NO_TTL));
     }
 

--- a/crates/openlake_server/src/main.rs
+++ b/crates/openlake_server/src/main.rs
@@ -30,7 +30,11 @@ use crate::lock_server::{LocalLockPeer, LockServer};
 use crate::tls_material::TlsMaterial;
 
 #[derive(Parser)]
-#[command(about = "openlaked: distributed object storage node")]
+#[command(
+    name = "openlaked",
+    version,
+    about = "openlaked: distributed object storage node"
+)]
 struct Args {
     /// Path to the TOML config file describing this node and its peers.
     #[arg(long)]


### PR DESCRIPTION
## Summary

Prepare the non-RDMA `openlake-vllm` 0.8.0 release without publishing it.

- make Cargo the single version source for the Python package, native module, and embedded daemon
- build one `cp310-abi3-manylinux_2_28_x86_64` wheel in a digest-pinned manylinux container
- inspect wheel contents, RECORD hashes, ELF dependencies, and GLIBC ceiling
- install on CPython 3.10 and 3.14
- run the packaged daemon plus local KV miss/put/hit/get in a digest-pinned minimal Linux image
- promote the same SHA-256 artifact through protected staging, TestPyPI, and PyPI environments using OIDC trusted publishing
- document the guarded release procedure

## Deliberate v0.8 scope

This PR prepares only the portable non-RDMA x86-64 wheel. It intentionally does **not** publish an sdist, RDMA/UCX wheel, ExANS CUDA codec, control-plane UI, or aarch64 wheel. The RDMA artifact currently has external UCX/verbs/mlx5 dependencies and skips auditwheel, so it needs a separate packaging contract and clean-host validation.

## Validation performed locally

- `actionlint .github/workflows/release-python.yml`
- `bash -n` for all release scripts
- `cargo metadata --locked --no-deps`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked --workspace --exclude openlake_kv_client` (174 tests passed)
- Maturin 1.14.1 metadata: `openlake-vllm 0.8.0`, `abi3-py310`
- `openlaked --version`: `openlaked 0.8.0`

The PyO3 crate is intentionally exercised from the built wheel rather than linked as a standalone Rust test binary because it uses `extension-module`.

## Before any tag

The repository still needs protected `release-staging`, `testpypi`, and `pypi` environments; PyPI/TestPyPI Trusted Publishers for this exact workflow; and `main`/`v*` protection. No release tag should be created until this PR's Linux packaging checks pass and those controls exist.
