### PR TITLE
[v0.8] Set OpenLake package version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2160,7 +2160,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openlake_cli"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "aws-credential-types",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "openlake_io"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "aligned-vec",
  "anyhow",
@@ -2229,7 +2229,7 @@ dependencies = [
 
 [[package]]
 name = "openlake_kv_client"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "compio",
  "futures",
@@ -2242,7 +2242,7 @@ dependencies = [
 
 [[package]]
 name = "openlake_server"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "openlake_storage"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members  = ["crates/*", "cli"]
 resolver = "2"
 
 [workspace.package]
-version      = "0.1.0"
+version      = "0.8.0"
 edition      = "2021"
 rust-version = "1.88"
 license      = "Apache-2.0"

--- a/crates/openlake_kv_client/build.sh
+++ b/crates/openlake_kv_client/build.sh
@@ -1,45 +1,73 @@
 #!/usr/bin/env bash
-# Build one wheel that carries all four artifacts:
+# Build one Linux wheel that carries all four artifacts:
 #   client .so (maturin compiles) + openlaked (cargo) + connector .py + configs.
-#   ./build.sh          -> openlake-vllm      (non-RDMA)
+#   ./build.sh       -> openlake-vllm      (non-RDMA)
+#   ./build.sh rdma  -> openlake-vllm-ib   (environment-specific RDMA build)
 set -euo pipefail
 cd "$(dirname "$0")"
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "OpenLake wheels embed a Linux openlaked binary; build on Linux/manylinux." >&2
+  exit 1
+fi
 
 VARIANT="${1:-cpu}"
 case "$VARIANT" in
   cpu|rdma) ;;
-  *) echo "usage: $0 [rdma]" >&2; exit 2 ;;
+  *) echo "usage: $0 [cpu|rdma]" >&2; exit 2 ;;
 esac
-PKG="python/openlake_client"
-FEAT=""
-AUDIT=""
+
+MATURIN_FEATURES=()
+MATURIN_POLICY=(--compatibility pypi --auditwheel repair)
 if [ "$VARIANT" = "rdma" ]; then
-  FEAT="--features rdma"
-  AUDIT="--auditwheel skip"
+  MATURIN_FEATURES=(--features rdma)
+  # The RDMA artifact has external UCX/verbs/mlx5 runtime requirements and is
+  # not currently claimed to be a portable manylinux wheel.
+  MATURIN_POLICY=(--auditwheel skip)
   cp pyproject.toml pyproject.toml.orig
   trap 'mv pyproject.toml.orig pyproject.toml' EXIT
   sed 's/^name = "openlake-vllm"/name = "openlake-vllm-ib"/' pyproject.toml.orig > pyproject.toml
 fi
 
-# 1. server binary — cargo compiles it
-cargo build --release -p openlake_server --bin openlaked $FEAT --features vendored-hwloc
-cp ../../target/release/openlaked "$PKG/openlaked"
+# A release directory is single-use: stale wheels must never survive a build.
+rm -rf dist ../../target/maturin
 
-# 2. connector .py
-cp ../../external/connectors/vllm/*.py "$PKG/"
-sed -i 's|vllm\.distributed\.kv_transfer\.kv_connector\.v1\.openlake_|openlake_client.openlake_|g' "$PKG"/openlake_*.py
-
-# 3. default configs
+PKG="python/openlake_client"
+rm -f "$PKG/openlaked" "$PKG"/_native*.so "$PKG"/openlake_*.py
 rm -rf "$PKG/configs"
+
+SERVER_FEATURES="vendored-hwloc"
+if [ "$VARIANT" = "rdma" ]; then
+  SERVER_FEATURES+=",rdma"
+fi
+cargo build \
+  --locked \
+  --release \
+  -p openlake_server \
+  --bin openlaked \
+  --features "$SERVER_FEATURES"
+install -m 0755 ../../target/release/openlaked "$PKG/openlaked"
+
+cp ../../external/connectors/vllm/*.py "$PKG/"
+sed -i \
+  's|vllm\.distributed\.kv_transfer\.kv_connector\.v1\.openlake_|openlake_client.openlake_|g' \
+  "$PKG"/openlake_*.py
+
 mkdir -p "$PKG/configs"
 cp ../openlake_server/configs/kv_local.toml "$PKG/configs/"
 if [ "$VARIANT" = "rdma" ]; then
-  cp ../openlake_server/configs/kv_rdma.toml ../openlake_server/configs/kv_ucx.toml "$PKG/configs/"
+  cp \
+    ../openlake_server/configs/kv_rdma.toml \
+    ../openlake_server/configs/kv_ucx.toml \
+    "$PKG/configs/"
   cp ../openlake_server/configs/kv_rdma.toml "$PKG/configs/default.toml"
 else
   cp ../openlake_server/configs/kv_local.toml "$PKG/configs/default.toml"
 fi
 
-# 4. maturin compiles the client .so and packs the wheel
-rm -rf ../../target/maturin
-maturin build --release $FEAT $AUDIT -o dist
+maturin build \
+  --release \
+  --locked \
+  "${MATURIN_FEATURES[@]}" \
+  "${MATURIN_POLICY[@]}" \
+  --out dist

--- a/crates/openlake_kv_client/pyproject.toml
+++ b/crates/openlake_kv_client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "openlake-vllm"
-version = "0.6.1"
+dynamic = ["version"]
 description = "OpenLake high performance KV cache client and server for vLLM."
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }

--- a/crates/openlake_server/src/main.rs
+++ b/crates/openlake_server/src/main.rs
@@ -30,7 +30,11 @@ use crate::lock_server::{LocalLockPeer, LockServer};
 use crate::tls_material::TlsMaterial;
 
 #[derive(Parser)]
-#[command(about = "openlaked: distributed object storage node")]
+#[command(
+    name = "openlaked",
+    version,
+    about = "openlaked: distributed object storage node"
+)]
 struct Args {
     /// Path to the TOML config file describing this node and its peers.
     #[arg(long)]


### PR DESCRIPTION
## Summary

- set the Rust workspace package version to 0.8.0
- derive the Python wheel version from Cargo metadata
- expose the package version through `openlaked --version`
- harden the retained wheel build script for clean CPU and RDMA builds

## Validation

- `bash -n crates/openlake_kv_client/build.sh`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo check --locked -p openlake_server`