### PR TITLE
(#245) [v0.8] Bump OpenLake package versions to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2160,7 +2160,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openlake_cli"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "aws-credential-types",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "openlake_io"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "aligned-vec",
  "anyhow",
@@ -2229,7 +2229,7 @@ dependencies = [
 
 [[package]]
 name = "openlake_kv_client"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "compio",
  "futures",
@@ -2242,7 +2242,7 @@ dependencies = [
 
 [[package]]
 name = "openlake_server"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "openlake_storage"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members  = ["crates/*", "cli"]
 resolver = "2"
 
 [workspace.package]
-version      = "0.1.0"
+version      = "0.8.0"
 edition      = "2021"
 rust-version = "1.88"
 license      = "Apache-2.0"

--- a/crates/openlake_kv_client/pyproject.toml
+++ b/crates/openlake_kv_client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "openlake-vllm"
-version = "0.6.1"
+version = "0.8.0"
 description = "OpenLake high performance KV cache client and server for vLLM."
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
 - Bump the Rust workspace version from 0.1.0 to 0.8.0.
 - Bump the openlake-vllm Python package from 0.6.1 to 0.8.0.
 - Refresh the OpenLake workspace package entries in Cargo.lock.