### PR TITLE
(#247) [v0.9] Make the OpenLake KV connector pipeline parallel aware

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,3 +36,6 @@
 
         - name: test
           run: cargo test --workspace
+
+        - name: Connector regression tests
+          run: python3 external/connectors/vllm/tests/test_openlake_adapter.py

--- a/crates/openlake_io/src/kv.rs
+++ b/crates/openlake_io/src/kv.rs
@@ -381,6 +381,21 @@ mod tests {
     }
 
     #[test]
+    fn pipeline_namespace_bytes_are_part_of_the_storage_key() {
+        let mut pool = new_pool(2);
+        let slots = pool.reserve(2);
+        let mut pp0 = k(0xA5);
+        let mut pp1 = pp0;
+        pp0[52..54].copy_from_slice(&0u16.to_le_bytes());
+        pp1[52..54].copy_from_slice(&1u16.to_le_bytes());
+
+        assert!(pool.commit(slots[0], pp0));
+        assert!(pool.commit(slots[1], pp1));
+        assert_eq!(pool.lookup(pp0), Some(slots[0]));
+        assert_eq!(pool.lookup(pp1), Some(slots[1]));
+    }
+
+    #[test]
     fn release_returns_slot_to_free_list() {
         let mut pool = new_pool(2);
         let slots = pool.reserve(2);

--- a/crates/openlake_kv_client/src/ucx_protocol.rs
+++ b/crates/openlake_kv_client/src/ucx_protocol.rs
@@ -19,7 +19,8 @@ use openlake_io::ucx::{UcxEndpoint, UcxMemory, UcxRequest, UcxRkey, UcxWorker};
 use crate::transport::{Protocol, Scatter, Waiter};
 
 const KEY_BYTES: usize = 54;
-const ATTACH_TIMEOUT: Duration = Duration::from_secs(60);
+// The first attach may synchronously register a very large host slab with UCX.
+const ATTACH_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 const OPERATION_TIMEOUT: Duration = Duration::from_secs(60);
 const RPC_PATH: &str = "/v1/rpc";
 

--- a/crates/openlake_storage/src/kv_engine.rs
+++ b/crates/openlake_storage/src/kv_engine.rs
@@ -9,6 +9,7 @@ use openlake_io::kv::{self, HostSlab, KvRequest, KvResponse, KvSlab};
 use serde::Serialize;
 
 const BLOCK_HASH_BYTES: usize = 32;
+const KEY_HEADER_BYTES: usize = std::mem::size_of::<openlake_io::kv::KeyHash>();
 
 fn logical_block_ids(keys: &[Vec<u8>]) -> Option<Vec<[u8; BLOCK_HASH_BYTES]>> {
     keys.iter()
@@ -218,6 +219,22 @@ impl KvEngine {
         let host_backed = true;
 
         if let KvRequest::Attach { slot_bytes } = &req {
+            if *slot_bytes != 0 && *slot_bytes <= KEY_HEADER_BYTES as u32 {
+                return KvResponse::Err(format!(
+                    "slot_bytes {slot_bytes} must exceed the {KEY_HEADER_BYTES}-byte key header"
+                ));
+            }
+            if *slot_bytes != 0 {
+                let slab = self.slab.borrow();
+                if let Some(slab) = slab.as_ref() {
+                    if slab.slot_bytes() != *slot_bytes {
+                        return KvResponse::Err(format!(
+                            "slot size mismatch: slab uses {}, client requested {slot_bytes}",
+                            slab.slot_bytes()
+                        ));
+                    }
+                }
+            }
             if host_backed && *slot_bytes > 0 && self.slab.borrow().is_none() {
                 let slot_count = (self.capacity_bytes / *slot_bytes as u64).max(1) as u32;
                 match HostSlab::new(*slot_bytes, slot_count, self.reserve_ttl) {
@@ -315,9 +332,9 @@ impl KvEngine {
         slot_bytes: u32,
         dry_run: bool,
     ) -> Result<openlake_io::rpc::UcxEndpointReply, String> {
-        if slot_bytes != 0 && slot_bytes <= BLOCK_HASH_BYTES as u32 {
+        if slot_bytes != 0 && slot_bytes <= KEY_HEADER_BYTES as u32 {
             return Err(format!(
-                "slot_bytes {slot_bytes} must exceed the {BLOCK_HASH_BYTES}-byte key header"
+                "slot_bytes {slot_bytes} must exceed the {KEY_HEADER_BYTES}-byte key header"
             ));
         }
 
@@ -432,6 +449,22 @@ impl KvEngine {
         epoch: u64,
         slot_bytes: u32,
     ) -> Result<(), String> {
+        if slot_bytes != 0 && slot_bytes <= KEY_HEADER_BYTES as u32 {
+            return Err(format!(
+                "slot_bytes {slot_bytes} must exceed the {KEY_HEADER_BYTES}-byte key header"
+            ));
+        }
+        if slot_bytes != 0 {
+            let slab = self.slab.borrow();
+            if let Some(slab) = slab.as_ref() {
+                if slab.slot_bytes() != slot_bytes {
+                    return Err(format!(
+                        "slot size mismatch: slab uses {}, client requested {slot_bytes}",
+                        slab.slot_bytes()
+                    ));
+                }
+            }
+        }
         eps.iter().try_for_each(|ep| -> Result<(), String> {
             self.backend.attach(client, ep, epoch)?;
             if let Some(f) = &*self.on_attach.borrow() {
@@ -599,12 +632,16 @@ mod tests {
     }
 
     #[test]
-    fn re_attach_returns_the_existing_slab() {
+    fn re_attach_requires_the_existing_slab_geometry() {
         let e = KvEngine::new_tcp(64 * 1024, Duration::from_secs(60));
         let (first, _, _) = attach(&e, 4096);
-        let (again, sb, sc) = attach(&e, 8192);
+        let (again, sb, sc) = attach(&e, 4096);
         assert_eq!(again, first);
         assert_eq!((sb, sc), (4096, 16));
+        assert!(matches!(
+            e.serve_tcp(KvRequest::Attach { slot_bytes: 8192 }),
+            KvResponse::Err(message) if message.contains("slot size mismatch")
+        ));
     }
 
     #[test]

--- a/external/connectors/vllm/openlake_adapter.py
+++ b/external/connectors/vllm/openlake_adapter.py
@@ -23,7 +23,14 @@ from vllm.v1.core.kv_cache_utils import (
     resolve_kv_cache_block_sizes,
 )
 from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager
-from vllm.v1.kv_cache_interface import FullAttentionSpec, UniformTypeKVCacheSpecs
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheSpec,
+    MLAAttentionSpec,
+    MambaSpec,
+    SlidingWindowMLASpec,
+    UniformTypeKVCacheSpecs,
+)
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 
 logger = init_logger(__name__)
@@ -37,8 +44,10 @@ _FLCH_RETURNS_LENGTH = str(
     inspect.signature(FullAttentionManager.find_longest_cache_hit).return_annotation
 ).endswith(", int]")
 
-KEY_BYTES = 16
 SLOT_HEADER_BYTES = 54
+MAX_SLOT_BYTES = (1 << 32) - 1
+CLIENT_NODE_ID_BASE = 2_048
+CLIENT_NODE_ID_MAX = 0xFFF
 
 _HASH_SEED_HELP = (
     "OpenLake external KV offloading requires PYTHONHASHSEED to be set for "
@@ -56,18 +65,6 @@ def _unwrap(spec):
     if isinstance(spec, UniformTypeKVCacheSpecs):
         return next(iter(spec.kv_cache_specs.values()))
     return spec
-
-
-def _num_kv_head(model_config) -> int:
-    if getattr(model_config, "use_mla", False):
-        return 1
-    return model_config.get_total_num_kv_heads()
-
-
-def _fold_tp_rank(tp_rank: int, tp_size: int, num_kv_head: int) -> int:
-    if 0 < num_kv_head < tp_size:
-        return tp_rank // (tp_size // num_kv_head)
-    return tp_rank
 
 
 class ChunkHashes(BlockHashListWithBlockSize):
@@ -459,10 +456,16 @@ def _group_key_spaces(vllm_config, kv_cache_config):
     speculative = vllm_config.speculative_config
     use_eagle = bool(speculative and speculative.use_eagle())
     model_name = getattr(vllm_config.model_config, "model", "") or ""
-    model_tag = (
-        hashlib.blake2b(model_name.encode(), digest_size=12).digest()
-        if model_name else bytes(12)
+    extra = (
+        vllm_config.kv_transfer_config.kv_connector_extra_config
+        if vllm_config.kv_transfer_config is not None else {}
     )
+    cache_prefix = str(extra.get("cache_prefix", ""))
+    if model_name or cache_prefix:
+        tag_source = model_name if not cache_prefix else f"{cache_prefix}\0{model_name}"
+        model_tag = hashlib.blake2b(tag_source.encode(), digest_size=12).digest()
+    else:
+        model_tag = bytes(12)
     group_keys = [
         GroupKeys(i, _unwrap(g.kv_cache_spec), hash_bs, model_tag)
         for i, g in enumerate(groups)
@@ -470,9 +473,38 @@ def _group_key_spaces(vllm_config, kv_cache_config):
     return groups, group_keys, sched_bs, hash_bs, use_eagle
 
 
+def _group_tp_replication_factors(
+    kv_cache_groups,
+    *,
+    tp_size: int,
+    dcp_size: int,
+    num_kv_heads: int,
+) -> tuple[int, ...]:
+    """Return the number of byte-identical TP replicas per cache group."""
+
+    def factor_for(spec: KVCacheSpec) -> int:
+        if dcp_size > 1:
+            return 1
+        inner_specs = (
+            tuple(spec.kv_cache_specs.values())
+            if isinstance(spec, UniformTypeKVCacheSpecs)
+            else (spec,)
+        )
+        if any(isinstance(inner, MambaSpec) for inner in inner_specs):
+            return 1
+        if all(
+            isinstance(inner, (MLAAttentionSpec, SlidingWindowMLASpec))
+            for inner in inner_specs
+        ):
+            return tp_size
+        return max(1, tp_size // num_kv_heads)
+
+    return tuple(factor_for(group.kv_cache_spec) for group in kv_cache_groups)
+
+
 class KVTransferThread(threading.Thread):
 
-    def __init__(self, client, group_keys, block_size, tp_rank, ns, layout,
+    def __init__(self, client, group_keys, block_size, tp_rank, namespaces, layout,
                  coord, ready_event, name, request_queue=None,
                  record_operation=None):
         super().__init__(daemon=True, name=name)
@@ -482,7 +514,7 @@ class KVTransferThread(threading.Thread):
         self.group_keys = group_keys
         self.block_size = block_size
         self.tp_rank = tp_rank
-        self.ns = ns
+        self.namespaces = namespaces
         self.layout = layout
         self.ready_event = ready_event
         self.done_task_lock = threading.Lock()
@@ -545,13 +577,13 @@ class KVTransferThread(threading.Thread):
 
 class KVCacheSendingThread(KVTransferThread):
 
-    def __init__(self, client, group_keys, block_size, tp_rank, ns, layout,
-                 coord, ready_event, put_step: int = 1,
+    def __init__(self, client, group_keys, block_size, tp_rank, namespaces, layout,
+                 coord, ready_event, replication_factors,
                  enable_kv_event: bool = False, record_operation=None):
-        super().__init__(client, group_keys, block_size, tp_rank, ns, layout,
+        super().__init__(client, group_keys, block_size, tp_rank, namespaces, layout,
                          coord, ready_event, name="KVCacheSendingThread",
                          record_operation=record_operation)
-        self.put_step = put_step
+        self.replication_factors = replication_factors
         self.stored_requests: dict[str, int] = {}
         self.enable_kv_event = enable_kv_event
         self._store_pressure_active = False
@@ -626,17 +658,20 @@ class KVCacheSendingThread(KVTransferThread):
             entries: list[tuple] = []
             keys: list[bytes] = []
             for group in self.group_keys:
-                put_step_rank = (self.tp_rank + group.g_idx) % self.put_step
+                put_step = self.replication_factors[group.g_idx]
+                put_step_rank = (self.tp_rank + group.g_idx) % put_step
                 for start, end, block_hash in group.process_tokens(
                     token_len,
                     req_meta.block_hashes,
                     mask_num=save_start,
                     chunk_mask=store_masks[group.g_idx],
-                    put_step=self.put_step,
+                    put_step=put_step,
                     put_step_rank=put_step_rank,
                 ):
                     entries.append((group, start // group.block_size, block_hash))
-                    keys.append(group.key_for(block_hash, self.ns))
+                    keys.append(
+                        group.key_for(block_hash, self.namespaces[group.g_idx])
+                    )
             if not keys:
                 self._record_saved(req_id, token_len)
                 return
@@ -688,7 +723,7 @@ class KVCacheSendingThread(KVTransferThread):
                                        num_failed_keys=len(keys))
                 logger.error("put_batch failed (req=%s): %s", req_id, err)
                 return
-            failed = [i for i, v in enumerate(res) if v < 0]
+            failed = [i for i, value in enumerate(res) if value < 0]
             self._record_operation(
                 "save_put", put_start, len(keys), num_bytes=batch_bytes,
                 status="partial_failure" if failed else "ok",
@@ -716,9 +751,9 @@ class KVCacheSendingThread(KVTransferThread):
 
 class KVCacheRecvingThread(KVTransferThread):
 
-    def __init__(self, client, group_keys, block_size, tp_rank, ns, layout,
+    def __init__(self, client, group_keys, block_size, tp_rank, namespaces, layout,
                  coord, ready_event, request_queue=None, record_operation=None):
-        super().__init__(client, group_keys, block_size, tp_rank, ns, layout,
+        super().__init__(client, group_keys, block_size, tp_rank, namespaces, layout,
                          coord, ready_event, name="KVCacheRecvingThread",
                          request_queue=request_queue,
                          record_operation=record_operation)
@@ -753,7 +788,9 @@ class KVCacheRecvingThread(KVTransferThread):
                 if chunk_idx >= len(mask) or not mask[chunk_idx]:
                     continue
                 entries.append((req_meta.block_ids[group.g_idx][chunk_idx],
-                                group.key_for(block_hash, self.ns)))
+                                group.key_for(
+                                    block_hash, self.namespaces[group.g_idx]
+                                )))
         if not entries:
             self.set_finished_request(req_id)
             self.request_queue.task_done()
@@ -809,40 +846,96 @@ class KVCacheRecvingThread(KVTransferThread):
 
 
 class OpenLakeWorker:
+    @staticmethod
+    def _client_id(base_id: int, parallel_config) -> int:
+        if (getattr(parallel_config, "distributed_executor_backend", None)
+                == "external_launcher"):
+            client_id = base_id + 2 * int(parallel_config.rank) + 1
+        else:
+            model_world_size = (
+                parallel_config.pipeline_parallel_size
+                * parallel_config.prefill_context_parallel_size
+                * parallel_config.tensor_parallel_size
+            )
+            dp_rank = int(getattr(parallel_config, "data_parallel_index", 0))
+            scheduler_id = base_id + dp_rank * (model_world_size + 1)
+            model_rank = int(parallel_config.rank) % model_world_size
+            client_id = scheduler_id + 1 + model_rank
+        if not CLIENT_NODE_ID_BASE <= client_id <= CLIENT_NODE_ID_MAX:
+            raise ValueError(
+                f"OpenLake worker client_id {client_id} outside "
+                f"[{CLIENT_NODE_ID_BASE}, {CLIENT_NODE_ID_MAX}]"
+            )
+        return client_id
+
     def __init__(self, vllm_config, kv_cache_config):
         _require_fixed_hash_seed()
         import openlake_client
-        from vllm.distributed.parallel_state import get_tensor_model_parallel_rank
+        from vllm.distributed.parallel_state import (
+            get_dcp_group,
+            get_pcp_group,
+            get_tensor_model_parallel_rank,
+            get_tensor_model_parallel_world_size,
+        )
+
+        model_config = vllm_config.model_config
+        parallel_config = vllm_config.parallel_config
+
+        self.tp_rank = get_tensor_model_parallel_rank()
+        self.tp_size = get_tensor_model_parallel_world_size()
+        self.pp_size = parallel_config.pipeline_parallel_size
+        self.pp_rank = (parallel_config.rank // self.tp_size) % self.pp_size
+        self.pcp_size = get_pcp_group().world_size
+        self.pcp_rank = (
+            get_pcp_group().rank_in_group if self.pcp_size > 1 else 0
+        )
+        self.dcp_size = get_dcp_group().world_size
+        self.dcp_rank = (
+            get_dcp_group().rank_in_group if self.dcp_size > 1 else 0
+        )
+        self.num_kv_head = model_config.get_total_num_kv_heads()
 
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         extra = vllm_config.kv_transfer_config.kv_connector_extra_config
         nodes = extra.get("openlake_nodes")
         if not nodes:
             raise ValueError("kv_connector_extra_config.openlake_nodes required")
-        self.tp_rank = get_tensor_model_parallel_rank()
         base_id = int(extra.get("openlake_client_id", 2048))
         self._client = openlake_client.Client(
             device=extra.get("openlake_device", "mlx5_ib0"),
-            client_id=base_id + 1 + self.tp_rank,
+            client_id=self._client_id(base_id, parallel_config),
         )
         self._nodes = nodes
         self._num_blocks = vllm_config.cache_config.num_gpu_blocks
         groups, self.group_keys, self.block_size, hash_bs, use_eagle = (
             _group_key_spaces(vllm_config, kv_cache_config)
         )
-        parallel = vllm_config.parallel_config
-        dcp = parallel.decode_context_parallel_size
-        head = _fold_tp_rank(
-            self.tp_rank, parallel.tensor_parallel_size,
-            _num_kv_head(vllm_config.model_config),
+        self._kv_cache_groups = groups
+        self._group_tp_replication_factors = _group_tp_replication_factors(
+            self._kv_cache_groups,
+            tp_size=self.tp_size,
+            dcp_size=self.dcp_size,
+            num_kv_heads=self.num_kv_head,
         )
-        self.ns = (head, 0, self.tp_rank % dcp if dcp > 1 else 0, 0)
+        self.namespaces = tuple(
+            (
+                self.tp_rank // self._group_tp_replication_factors[g_idx],
+                self.pcp_rank,
+                self.dcp_rank,
+                self.pp_rank,
+            )
+            for g_idx in range(len(self._kv_cache_groups))
+        )
         self.coord = Coordinator(
             groups, self.group_keys, self.block_size, hash_bs, use_eagle,
             getattr(envs, "VLLM_PREFIX_CACHE_RETENTION_INTERVAL", None),
         )
         self.load_async = extra.get("load_async", True)
-        self.put_step = max(1, int(extra.get("openlake_put_step", 1)))
+        if "openlake_put_step" in extra:
+            logger.warning(
+                "openlake_put_step is ignored; TP store striping is derived "
+                "from each KV cache group's byte replication"
+            )
         self.num_recv_threads = max(1, int(extra.get("openlake_recv_threads", 1)))
         self.enable_kv_events = bool(extra.get("openlake_kv_events", False))
         self.layout = GroupLayout()
@@ -857,10 +950,45 @@ class OpenLakeWorker:
         self.kv_connector_stats = OpenLakeConnectorStats()
         self._kv_connector_stats_lock = threading.Lock()
 
+    @staticmethod
+    def _sync_max_slot_bytes(local_slot_bytes: int) -> int:
+        """Use one fixed OpenLake slab slot size across all model workers."""
+        local_slot_bytes = int(local_slot_bytes)
+        if local_slot_bytes < 0 or local_slot_bytes > MAX_SLOT_BYTES:
+            raise ValueError(
+                f"OpenLake local slot size {local_slot_bytes} is outside the "
+                f"u32 range [0, {MAX_SLOT_BYTES}]"
+            )
+        if 0 < local_slot_bytes <= SLOT_HEADER_BYTES:
+            raise ValueError(
+                f"OpenLake local slot size {local_slot_bytes} must exceed the "
+                f"{SLOT_HEADER_BYTES}-byte key header"
+            )
+
+        from vllm.distributed.parallel_state import get_world_group
+
+        world = get_world_group()
+        if world.world_size == 1:
+            return local_slot_bytes
+
+        value = torch.tensor(local_slot_bytes, dtype=torch.int64, device="cpu")
+        torch.distributed.all_reduce(
+            value,
+            op=torch.distributed.ReduceOp.MAX,
+            group=world.cpu_group,
+        )
+        global_slot_bytes = int(value.item())
+        if not local_slot_bytes <= global_slot_bytes <= MAX_SLOT_BYTES:
+            raise RuntimeError(
+                "OpenLake slot-size MAX reduction returned invalid value "
+                f"{global_slot_bytes} for local value {local_slot_bytes}"
+            )
+        return global_slot_bytes
+
+    def register_cross_layers_kv_caches(self, kv_cache) -> None:
+        self.register_kv_caches({"__cross_layer__": kv_cache})
+
     def register_kv_caches(self, kv_caches) -> None:
-        if not kv_caches:
-            logger.warning("openlake: no kv caches to register")
-            return
         seen_ptrs: set[int] = set()
         addrs: list[int] = []
         block_lens: list[int] = []
@@ -888,12 +1016,21 @@ class OpenLakeWorker:
                     addrs.append(base_addr + idx * seg_stride)
                     block_lens.append(seg_stride // self._num_blocks)
         self.layout.set(addrs, block_lens)
-        slot_bytes = SLOT_HEADER_BYTES + sum(block_lens)
+        local_slot_bytes = SLOT_HEADER_BYTES + sum(block_lens) if addrs else 0
+        slot_bytes = self._sync_max_slot_bytes(local_slot_bytes)
+        if not addrs:
+            logger.warning(
+                "openlake: no local kv caches to register; synchronized "
+                "%d B/slot across model workers",
+                slot_bytes,
+            )
+            return
         for node_id, addr in enumerate(self._nodes):
             self._client.attach(addr, node_id, slot_bytes)
         logger.info(
-            "openlake: registered %d segments over %d blocks, %d B/slot",
-            len(addrs), self._num_blocks, slot_bytes,
+            "openlake: registered %d segments over %d blocks, "
+            "%d B local payload slot, %d B server slot",
+            len(addrs), self._num_blocks, local_slot_bytes, slot_bytes,
         )
 
         if self.kv_role in ("kv_producer", "kv_both"):
@@ -903,11 +1040,11 @@ class OpenLakeWorker:
                 self.group_keys,
                 self.block_size,
                 self.tp_rank,
-                self.ns,
+                self.namespaces,
                 self.layout,
                 self.coord,
                 ready_event_sending,
-                self.put_step,
+                self._group_tp_replication_factors,
                 self.enable_kv_events,
                 record_operation=self._record_kv_connector_operation,
             )
@@ -922,7 +1059,7 @@ class OpenLakeWorker:
                 self.group_keys,
                 self.block_size,
                 self.tp_rank,
-                self.ns,
+                self.namespaces,
                 self.layout,
                 self.coord,
                 ready_event_recving,
@@ -1033,6 +1170,26 @@ class OpenLakeWorker:
 
 
 class OpenLakeScheduler:
+    @staticmethod
+    def _client_id(base_id: int, parallel_config) -> int:
+        if (getattr(parallel_config, "distributed_executor_backend", None)
+                == "external_launcher"):
+            client_id = base_id + 2 * int(parallel_config.rank)
+        else:
+            model_world_size = (
+                parallel_config.pipeline_parallel_size
+                * parallel_config.prefill_context_parallel_size
+                * parallel_config.tensor_parallel_size
+            )
+            dp_rank = int(getattr(parallel_config, "data_parallel_index", 0))
+            client_id = base_id + dp_rank * (model_world_size + 1)
+        if not CLIENT_NODE_ID_BASE <= client_id <= CLIENT_NODE_ID_MAX:
+            raise ValueError(
+                f"OpenLake scheduler client_id {client_id} outside "
+                f"[{CLIENT_NODE_ID_BASE}, {CLIENT_NODE_ID_MAX}]"
+            )
+        return client_id
+
     def __init__(self, vllm_config, kv_cache_config):
         _require_fixed_hash_seed()
         import openlake_client
@@ -1045,9 +1202,11 @@ class OpenLakeScheduler:
         self._min_external_lookup_tokens = extra.get(
             "openlake_min_external_lookup_tokens", 1000
         )
+        parallel = vllm_config.parallel_config
+        base_id = int(extra.get("openlake_client_id", 2048))
         self._client = openlake_client.Client(
             device=extra.get("openlake_device", "mlx5_ib0"),
-            client_id=int(extra.get("openlake_client_id", 2048)),
+            client_id=self._client_id(base_id, parallel),
         )
         for node_id, addr in enumerate(nodes):
             self._client.attach(addr, node_id)
@@ -1055,39 +1214,49 @@ class OpenLakeScheduler:
         groups, self._group_keys, self._sched_bs, self._hash_bs, use_eagle = (
             _group_key_spaces(vllm_config, kv_cache_config)
         )
-        parallel = vllm_config.parallel_config
-        self._dcp = parallel.decode_context_parallel_size
-        self._pcp = parallel.prefill_context_parallel_size
+        self._kv_cache_groups = groups
+        self.tp_size = parallel.tensor_parallel_size
+        self.pp_size = parallel.pipeline_parallel_size
+        self.pcp_size = parallel.prefill_context_parallel_size
+        self.dcp_size = parallel.decode_context_parallel_size
+        self.num_kv_head = vllm_config.model_config.get_total_num_kv_heads()
         self.load_async = extra.get("load_async", True)
         self._coord = Coordinator(
             groups, self._group_keys, self._sched_bs, self._hash_bs, use_eagle,
             getattr(envs, "VLLM_PREFIX_CACHE_RETENTION_INTERVAL", None),
         )
 
-        tp, pp = parallel.tensor_parallel_size, parallel.pipeline_parallel_size
-        heads = _num_kv_head(vllm_config.model_config)
-        if self._dcp > 1:
-            self._namespaces = [
-                (t, c, t % self._dcp, q)
-                for c in range(self._pcp)
-                for t in range(tp)
-                for q in range(pp)
-            ]
-        else:
-            self._namespaces = [
-                (t, c, 0, q)
-                for c in range(self._pcp)
-                for t in range(min(tp, heads))
-                for q in range(pp)
-            ]
+        self._group_tp_replication_factors = _group_tp_replication_factors(
+            self._kv_cache_groups,
+            tp_size=self.tp_size,
+            dcp_size=self.dcp_size,
+            num_kv_heads=self.num_kv_head,
+        )
+        self._init_lookup_key_prefixes()
         logger.info(
-            "openlake: %d nodes, %d groups, %d rank namespaces",
-            len(nodes), len(self._group_keys), len(self._namespaces),
+            "openlake: %d nodes, %d groups, rank namespaces=%s",
+            len(nodes), len(self._group_keys),
+            [len(value) for value in self._namespaces_by_group],
         )
         self._loads: dict[str, PendingLoad] = {}
         self._request_trackers: dict[str, RequestTracker] = {}
         self._unfinished_requests: dict[str, tuple[object, tuple[list[int], ...]]] = {}
         self._unfinished_request_ids: set[str] = set()
+
+    def _init_lookup_key_prefixes(self) -> None:
+        def rank_namespaces(factor: int) -> tuple[tuple[int, int, int, int], ...]:
+            assert self.dcp_size == 1 or factor == 1
+            return tuple(
+                (shard_rank, pcp_rank, shard_rank % self.dcp_size, pp_rank)
+                for pcp_rank in range(self.pcp_size)
+                for shard_rank in range(self.tp_size // factor)
+                for pp_rank in range(self.pp_size)
+            )
+
+        self._namespaces_by_group = tuple(
+            rank_namespaces(self._group_tp_replication_factors[g_idx])
+            for g_idx in range(len(self._kv_cache_groups))
+        )
 
     def _contains(self, keys: list[bytes]) -> list[bool]:
         try:
@@ -1098,7 +1267,7 @@ class OpenLakeScheduler:
             return [False] * len(keys)
 
     def _gather_exists(self, block_hashes, token_len: int) -> set[tuple[int, bytes]]:
-        candidates: list[tuple[int, bytes]] = []
+        candidates: list[tuple[int, bytes, int]] = []
         candidate_keys: list[bytes] = []
         lookup_masks = self._coord.lookup_mask(token_len)
         for group in self._group_keys:
@@ -1110,9 +1279,10 @@ class OpenLakeScheduler:
                 if mask is not None and not mask[chunk_id]:
                     continue
                 chunk_hash = bytes(chunk_hashes[chunk_id])
-                candidates.append((group.g_idx, chunk_hash))
+                namespaces = self._namespaces_by_group[group.g_idx]
+                candidates.append((group.g_idx, chunk_hash, len(namespaces)))
                 candidate_keys.extend(
-                    group.key_for(chunk_hash, ns) for ns in self._namespaces
+                    group.key_for(chunk_hash, ns) for ns in namespaces
                 )
         if not candidate_keys:
             return set()
@@ -1122,12 +1292,13 @@ class OpenLakeScheduler:
             "openlake: %d keys in %.0f us", len(candidate_keys),
             (time.perf_counter() - lookup_start) * 1e6,
         )
-        per_candidate = len(self._namespaces)
-        return {
-            candidate
-            for i, candidate in enumerate(candidates)
-            if all(hits[i * per_candidate : (i + 1) * per_candidate])
-        }
+        exists: set[tuple[int, bytes]] = set()
+        offset = 0
+        for group_idx, chunk_hash, namespace_count in candidates:
+            if all(hits[offset : offset + namespace_count]):
+                exists.add((group_idx, chunk_hash))
+            offset += namespace_count
+        return exists
 
 
     def get_num_new_matched_tokens(

--- a/external/connectors/vllm/openlake_connector.py
+++ b/external/connectors/vllm/openlake_connector.py
@@ -59,6 +59,11 @@ class OpenLakeKVEvents(KVConnectorKVEvents):
 
 
 class OpenLakeConnector(KVConnectorBase_V1, SupportsHMA):
+    @property
+    def prefer_cross_layer_blocks(self) -> bool:
+        extra = self._kv_transfer_config.kv_connector_extra_config
+        return str(extra.get("enable_cross_layers_blocks", "False")).lower() == "true"
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -85,23 +90,30 @@ class OpenLakeConnector(KVConnectorBase_V1, SupportsHMA):
 
     @staticmethod
     def _validate(vllm_config: VllmConfig, kv_cache_config: KVCacheConfig) -> None:
-        from vllm.v1.kv_cache_interface import CrossAttentionSpec
+        from vllm.v1.kv_cache_interface import CrossAttentionSpec, MambaSpec
 
-        p = vllm_config.parallel_config
-        bad: list[str] = []
+        unsupported: list[str] = []
+        cache_block_size = vllm_config.cache_config.block_size
         for g_idx, g in enumerate(kv_cache_config.kv_cache_groups):
-            if isinstance(g.kv_cache_spec, CrossAttentionSpec):
-                bad.append(f"group {g_idx}: CrossAttentionSpec")
-        pcp = p.prefill_context_parallel_size
-        dcp = p.decode_context_parallel_size
+            spec = g.kv_cache_spec
+            if isinstance(spec, CrossAttentionSpec):
+                unsupported.append(f"group {g_idx}: CrossAttentionSpec")
+            if isinstance(spec, MambaSpec) and spec.block_size != cache_block_size:
+                unsupported.append(
+                    f"group {g_idx}: MambaSpec with block_size="
+                    f"{spec.block_size} != cache_config.block_size="
+                    f"{cache_block_size} (mamba_cache_mode != 'align')"
+                )
+        pcp = vllm_config.parallel_config.prefill_context_parallel_size
+        dcp = vllm_config.parallel_config.decode_context_parallel_size
         if len(kv_cache_config.kv_cache_groups) > 1 and pcp * dcp > 1:
-            bad.append(f"PCP/DCP > 1 (pcp={pcp}, dcp={dcp}) with hybrid attention")
-        if (len(kv_cache_config.kv_cache_groups) > 255
-                or p.tensor_parallel_size > 255
-                or p.pipeline_parallel_size > 255 or pcp > 15 or dcp > 15):
-            bad.append("parallel/group sizes exceed the key namespace bytes")
-        if bad:
-            raise ValueError("OpenLakeConnector does not support: " + "; ".join(bad))
+            unsupported.append(
+                f"PCP/DCP > 1 (pcp={pcp}, dcp={dcp}) with hybrid attention"
+            )
+        if unsupported:
+            raise ValueError(
+                "OpenLakeConnector does not support: " + "; ".join(unsupported)
+            )
 
 
     def get_num_new_matched_tokens(
@@ -157,6 +169,16 @@ class OpenLakeConnector(KVConnectorBase_V1, SupportsHMA):
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]) -> None:
         self._worker.register_kv_caches(kv_caches)
+
+    def register_cross_layers_kv_cache(
+        self, kv_cache: torch.Tensor, attn_backend: type
+    ) -> None:
+        assert self._worker is not None
+        assert (
+            self._kv_cache_config is not None
+            and len(self._kv_cache_config.kv_cache_groups) == 1
+        ), "Cross-layer KV cache is not supported with hybrid models"
+        self._worker.register_cross_layers_kv_caches(kv_cache)
 
     def start_load_kv(self, forward_context: ForwardContext, **kwargs: Any) -> None:
         pass

--- a/external/connectors/vllm/tests/test_openlake_adapter.py
+++ b/external/connectors/vllm/tests/test_openlake_adapter.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU-only regression tests for OpenLake's vLLM rank namespaces.
+
+The connector normally imports torch and vLLM on GPU serving hosts.  These
+tests exercise its pure rank/key logic with small import stubs so they can run
+in the repository's standard Python environment as well.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import math
+import os
+import struct
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _module(name: str) -> types.ModuleType:
+    module = types.ModuleType(name)
+    sys.modules[name] = module
+    if "." in name:
+        parent_name, child_name = name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, child_name, module)
+    return module
+
+
+def _install_import_stubs() -> None:
+    torch = _module("torch")
+    torch.cuda = SimpleNamespace(Event=object)
+    torch.int64 = "int64"
+
+    _module("vllm")
+    envs = _module("vllm.envs")
+    envs.VLLM_PREFIX_CACHE_RETENTION_INTERVAL = None
+
+    _module("vllm.distributed")
+    parallel_state = _module("vllm.distributed.parallel_state")
+    parallel_state.get_world_group = lambda: SimpleNamespace(
+        world_size=1, cpu_group="cpu-world"
+    )
+    kv_events = _module("vllm.distributed.kv_events")
+
+    class BlockStored:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    kv_events.BlockStored = BlockStored
+
+    _module("vllm.distributed.kv_transfer")
+    _module("vllm.distributed.kv_transfer.kv_connector")
+    _module("vllm.distributed.kv_transfer.kv_connector.v1")
+    base = _module("vllm.distributed.kv_transfer.kv_connector.v1.base")
+
+    class KVConnectorMetadata:
+        pass
+
+    base.KVConnectorMetadata = KVConnectorMetadata
+
+    logger = _module("vllm.logger")
+    logger.init_logger = logging.getLogger
+
+    _module("vllm.utils")
+    math_utils = _module("vllm.utils.math_utils")
+    math_utils.cdiv = lambda a, b: math.ceil(a / b)
+
+    _module("vllm.v1")
+    _module("vllm.v1.core")
+    kv_cache_utils = _module("vllm.v1.core.kv_cache_utils")
+
+    class BlockHashListWithBlockSize:
+        pass
+
+    class KVCacheBlock:
+        def __init__(self, block_id):
+            self.block_id = block_id
+
+    kv_cache_utils.BlockHashListWithBlockSize = BlockHashListWithBlockSize
+    kv_cache_utils.KVCacheBlock = KVCacheBlock
+    kv_cache_utils.maybe_convert_block_hash = lambda value: value
+    kv_cache_utils.resolve_kv_cache_block_sizes = lambda *_: (16, 16)
+
+    manager_module = _module("vllm.v1.core.single_type_kv_cache_manager")
+
+    class FullAttentionManager:
+        @staticmethod
+        def reachable_block_mask(**_kwargs):
+            return None
+
+        @staticmethod
+        def find_longest_cache_hit(**_kwargs):
+            return []
+
+    manager_module.FullAttentionManager = FullAttentionManager
+
+    interface = _module("vllm.v1.kv_cache_interface")
+
+    class KVCacheSpec:
+        pass
+
+    class FullAttentionSpec(KVCacheSpec):
+        pass
+
+    class MLAAttentionSpec(KVCacheSpec):
+        pass
+
+    class SlidingWindowMLASpec(KVCacheSpec):
+        pass
+
+    class MambaSpec(KVCacheSpec):
+        pass
+
+    class UniformTypeKVCacheSpecs(KVCacheSpec):
+        def __init__(self, kv_cache_specs=None):
+            self.kv_cache_specs = kv_cache_specs or {}
+
+    interface.FullAttentionSpec = FullAttentionSpec
+    interface.KVCacheSpec = KVCacheSpec
+    interface.MLAAttentionSpec = MLAAttentionSpec
+    interface.SlidingWindowMLASpec = SlidingWindowMLASpec
+    interface.MambaSpec = MambaSpec
+    interface.UniformTypeKVCacheSpecs = UniformTypeKVCacheSpecs
+
+    registry = _module("vllm.v1.kv_cache_spec_registry")
+
+    class KVCacheSpecRegistry:
+        @staticmethod
+        def get_manager_class(_spec):
+            return FullAttentionManager
+
+    registry.KVCacheSpecRegistry = KVCacheSpecRegistry
+
+
+_install_import_stubs()
+MODULE_PATH = Path(__file__).parents[1] / "openlake_adapter.py"
+SPEC = importlib.util.spec_from_file_location(
+    "openlake_adapter_under_test", MODULE_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+ADAPTER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = ADAPTER
+SPEC.loader.exec_module(ADAPTER)
+
+
+def _parallel(**overrides):
+    values = {
+        "rank": 0,
+        "tensor_parallel_size": 8,
+        "pipeline_parallel_size": 2,
+        "prefill_context_parallel_size": 1,
+        "decode_context_parallel_size": 1,
+        "data_parallel_index": 0,
+        "data_parallel_size": 1,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class OpenLakeRankNamespaceTests(unittest.TestCase):
+    def test_cross_layer_cache_uses_the_standard_registration_path(self):
+        worker = ADAPTER.OpenLakeWorker.__new__(ADAPTER.OpenLakeWorker)
+        captured = []
+        worker.register_kv_caches = captured.append
+        cache = object()
+
+        worker.register_cross_layers_kv_caches(cache)
+
+        self.assertEqual(captured, [{"__cross_layer__": cache}])
+
+    def test_slot_size_uses_cpu_world_max_for_unequal_pp_stages(self):
+        torch = sys.modules["torch"]
+        parallel_state = sys.modules["vllm.distributed.parallel_state"]
+        calls = []
+
+        class FakeTensor:
+            def __init__(self, value):
+                self.value = value
+
+            def item(self):
+                return self.value
+
+        def all_reduce(value, *, op, group):
+            calls.append((value.value, op, group))
+            value.value = 4096
+
+        torch.tensor = lambda value, **_kwargs: FakeTensor(value)
+        torch.distributed = SimpleNamespace(
+            ReduceOp=SimpleNamespace(MAX="max"),
+            all_reduce=all_reduce,
+        )
+        parallel_state.get_world_group = lambda: SimpleNamespace(
+            world_size=16, cpu_group="cpu-world"
+        )
+
+        self.assertEqual(ADAPTER.OpenLakeWorker._sync_max_slot_bytes(3072), 4096)
+        self.assertEqual(calls, [(3072, "max", "cpu-world")])
+
+    def test_slot_size_single_rank_and_range_validation(self):
+        parallel_state = sys.modules["vllm.distributed.parallel_state"]
+        parallel_state.get_world_group = lambda: SimpleNamespace(
+            world_size=1, cpu_group="cpu-world"
+        )
+
+        sync_slot_bytes = ADAPTER.OpenLakeWorker._sync_max_slot_bytes
+        self.assertEqual(sync_slot_bytes(1024), 1024)
+        self.assertEqual(sync_slot_bytes(0), 0)
+        with self.assertRaisesRegex(ValueError, "must exceed"):
+            sync_slot_bytes(ADAPTER.SLOT_HEADER_BYTES)
+        with self.assertRaisesRegex(ValueError, "u32"):
+            sync_slot_bytes(1 << 32)
+
+    def test_model_tag_preserves_default_and_isolates_cache_prefix(self):
+        interface = sys.modules["vllm.v1.kv_cache_interface"]
+        spec = interface.FullAttentionSpec()
+        spec.block_size = 16
+        kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[SimpleNamespace(kv_cache_spec=spec)]
+        )
+
+        def model_tag(cache_prefix=""):
+            config = SimpleNamespace(
+                model_config=SimpleNamespace(model="org/model"),
+                kv_transfer_config=SimpleNamespace(
+                    kv_connector_extra_config={"cache_prefix": cache_prefix}
+                ),
+                speculative_config=None,
+            )
+            return ADAPTER._group_key_spaces(config, kv_cache_config)[1][0]._model_tag
+
+        expected = __import__("hashlib").blake2b(b"org/model", digest_size=12).digest()
+        default = model_tag()
+
+        self.assertEqual(default, expected)
+        self.assertNotEqual(default, model_tag("tenant-a"))
+        self.assertNotEqual(model_tag("tenant-a"), model_tag("tenant-b"))
+
+    def test_replication_factors_match_mooncake(self):
+        interface = sys.modules["vllm.v1.kv_cache_interface"]
+        full = interface.FullAttentionSpec()
+        mla = interface.MLAAttentionSpec()
+        sliding_mla = interface.SlidingWindowMLASpec()
+        mamba = interface.MambaSpec()
+        pure_mla = interface.UniformTypeKVCacheSpecs(
+            {"mla": mla, "sliding_mla": sliding_mla}
+        )
+        mixed_mamba = interface.UniformTypeKVCacheSpecs(
+            {"attention": full, "state": mamba}
+        )
+
+        groups = [
+            SimpleNamespace(kv_cache_spec=full),
+            SimpleNamespace(kv_cache_spec=pure_mla),
+            SimpleNamespace(kv_cache_spec=mixed_mamba),
+        ]
+
+        def factors(dcp_size):
+            return ADAPTER._group_tp_replication_factors(
+                groups, tp_size=8, dcp_size=dcp_size, num_kv_heads=4)
+
+        self.assertEqual(factors(1), (2, 8, 1))
+        self.assertEqual(factors(2), (1, 1, 1))
+
+    def test_tp8_pp2_workers_get_unique_client_ids(self):
+        client_ids = {
+            ADAPTER.OpenLakeWorker._client_id(2048, _parallel(rank=rank))
+            for rank in range(16)
+        }
+
+        self.assertEqual(client_ids, set(range(2049, 2065)))
+        self.assertNotIn(2048, client_ids)  # Scheduler retains the base ID.
+
+    def test_client_ids_are_unique_across_dp_pcp_pp_tp_and_role(self):
+        client_ids = set()
+        for dp_rank in range(2):
+            base_parallel = _parallel(
+                rank=0,
+                tensor_parallel_size=2,
+                pipeline_parallel_size=2,
+                prefill_context_parallel_size=2,
+                data_parallel_index=dp_rank,
+                data_parallel_size=2,
+            )
+            client_ids.add(ADAPTER.OpenLakeScheduler._client_id(2048, base_parallel))
+            for rank in range(8):
+                parallel = _parallel(
+                    rank=rank,
+                    tensor_parallel_size=2,
+                    pipeline_parallel_size=2,
+                    prefill_context_parallel_size=2,
+                    data_parallel_index=dp_rank,
+                    data_parallel_size=2,
+                )
+                client_ids.add(ADAPTER.OpenLakeWorker._client_id(2048, parallel))
+
+        self.assertEqual(len(client_ids), 18)
+        self.assertEqual(client_ids, set(range(2048, 2066)))
+
+    def test_client_ids_normalize_external_launcher_global_rank(self):
+        # External launcher creates a complete scheduler+worker engine for
+        # every global rank, so every role/rank pair needs a distinct peer ID.
+        client_ids = set()
+        for dp_rank in range(2):
+            first_global_rank = dp_rank * 8
+            for model_rank in range(8):
+                global_rank = first_global_rank + model_rank
+                parallel = _parallel(
+                    rank=global_rank,
+                    tensor_parallel_size=2,
+                    pipeline_parallel_size=2,
+                    prefill_context_parallel_size=2,
+                    data_parallel_index=dp_rank,
+                    data_parallel_size=2,
+                    distributed_executor_backend="external_launcher",
+                )
+                client_ids.add(ADAPTER.OpenLakeScheduler._client_id(2048, parallel))
+                client_ids.add(ADAPTER.OpenLakeWorker._client_id(2048, parallel))
+
+        self.assertEqual(len(client_ids), 32)
+        self.assertEqual(client_ids, set(range(2048, 2080)))
+
+    def test_client_id_range_is_validated_before_native_client_creation(self):
+        with self.assertRaisesRegex(ValueError, "outside"):
+            ADAPTER.OpenLakeScheduler._client_id(2047, _parallel())
+        with self.assertRaisesRegex(ValueError, "outside"):
+            ADAPTER.OpenLakeWorker._client_id(4080, _parallel(rank=15))
+
+    def test_worker_init_builds_mooncake_equivalent_namespace(self):
+        interface = sys.modules["vllm.v1.kv_cache_interface"]
+        parallel_state = sys.modules["vllm.distributed.parallel_state"]
+        parallel_state.get_tensor_model_parallel_rank = lambda: 6
+        parallel_state.get_tensor_model_parallel_world_size = lambda: 8
+        parallel_state.get_pcp_group = lambda: SimpleNamespace(
+            world_size=1, rank_in_group=0
+        )
+        parallel_state.get_dcp_group = lambda: SimpleNamespace(
+            world_size=1, rank_in_group=0
+        )
+
+        client_module = _module("openlake_client")
+        client_module.Client = lambda **_kwargs: SimpleNamespace()
+        metrics = _module(
+            "vllm.distributed.kv_transfer.kv_connector.v1.openlake_metrics"
+        )
+        metrics.OpenLakeConnectorStats = type("OpenLakeConnectorStats", (), {})
+
+        group = SimpleNamespace(kv_cache_spec=interface.FullAttentionSpec())
+        config = SimpleNamespace(
+            model_config=SimpleNamespace(get_total_num_kv_heads=lambda: 4),
+            parallel_config=_parallel(rank=14),
+            kv_transfer_config=SimpleNamespace(
+                kv_role="kv_both",
+                kv_connector_extra_config={"openlake_nodes": ["node"]},
+            ),
+            cache_config=SimpleNamespace(num_gpu_blocks=1),
+        )
+        old_group_key_spaces = ADAPTER._group_key_spaces
+        old_coordinator = ADAPTER.Coordinator
+        old_hash_seed = os.environ.get("PYTHONHASHSEED")
+        try:
+            os.environ["PYTHONHASHSEED"] = "0"
+            ADAPTER._group_key_spaces = lambda *_args: ([group], [], 16, 16, False)
+            ADAPTER.Coordinator = lambda *_args: SimpleNamespace()
+            worker = ADAPTER.OpenLakeWorker(config, SimpleNamespace())
+        finally:
+            ADAPTER._group_key_spaces = old_group_key_spaces
+            ADAPTER.Coordinator = old_coordinator
+            if old_hash_seed is None:
+                os.environ.pop("PYTHONHASHSEED", None)
+            else:
+                os.environ["PYTHONHASHSEED"] = old_hash_seed
+
+        self.assertEqual(worker._group_tp_replication_factors, (2,))
+        self.assertEqual(worker.namespaces, ((3, 0, 0, 1),))
+
+    def test_scheduler_namespaces_match_mooncake_dcp_relationship(self):
+        scheduler = ADAPTER.OpenLakeScheduler.__new__(ADAPTER.OpenLakeScheduler)
+        scheduler.tp_size = 8
+        scheduler.pp_size = 2
+        scheduler.pcp_size = 2
+        scheduler.dcp_size = 2
+        scheduler._kv_cache_groups = [object()]
+        scheduler._group_tp_replication_factors = (1,)
+        scheduler._init_lookup_key_prefixes()
+        namespaces = scheduler._namespaces_by_group[0]
+
+        self.assertEqual(len(namespaces), 32)
+        self.assertEqual(len(set(namespaces)), 32)
+        self.assertTrue(all(dcp == tp % 2 for tp, _pcp, dcp, _pp in namespaces))
+        self.assertEqual({pcp for _tp, pcp, _dcp, _pp in namespaces}, {0, 1})
+        self.assertEqual({pp for _tp, _pcp, _dcp, pp in namespaces}, {0, 1})
+        self.assertEqual({tp for tp, _pcp, _dcp, _pp in namespaces}, set(range(8)))
+
+    def test_scheduler_namespaces_fold_non_dcp_tp_replicas(self):
+        scheduler = ADAPTER.OpenLakeScheduler.__new__(ADAPTER.OpenLakeScheduler)
+        scheduler.tp_size = 8
+        scheduler.pp_size = 2
+        scheduler.pcp_size = 2
+        scheduler.dcp_size = 1
+        scheduler._kv_cache_groups = [object()]
+        scheduler._group_tp_replication_factors = (2,)
+        scheduler._init_lookup_key_prefixes()
+        namespaces = scheduler._namespaces_by_group[0]
+
+        self.assertEqual(len(namespaces), 16)
+        self.assertEqual(len(set(namespaces)), 16)
+        self.assertEqual({tp for tp, _pcp, _dcp, _pp in namespaces}, set(range(4)))
+        self.assertEqual({pcp for _tp, pcp, _dcp, _pp in namespaces}, {0, 1})
+        self.assertEqual({dcp for _tp, _pcp, dcp, _pp in namespaces}, {0})
+        self.assertEqual({pp for _tp, _pcp, _dcp, pp in namespaces}, {0, 1})
+
+    def test_pp_rank_changes_only_pp_bytes_of_storage_key(self):
+        spec = SimpleNamespace(block_size=16)
+        key_space = ADAPTER.GroupKeys(7, spec, 16, b"model-tag-12")
+        block_hash = bytes(range(32))
+
+        pp0 = key_space.key_for(block_hash, (3, 2, 1, 0))
+        pp1 = key_space.key_for(block_hash, (3, 2, 1, 1))
+
+        self.assertEqual(len(pp0), ADAPTER.SLOT_HEADER_BYTES)
+        self.assertEqual(pp0[:52], pp1[:52])
+        self.assertNotEqual(pp0, pp1)
+        self.assertEqual(pp0[52:54], struct.pack("<H", 0))
+        self.assertEqual(pp1[52:54], struct.pack("<H", 1))
+
+    def test_scheduler_requires_every_pp_namespace_for_a_hit(self):
+        spec = SimpleNamespace(block_size=16)
+        key_space = ADAPTER.GroupKeys(0, spec, 16, b"model-tag-12")
+        scheduler = ADAPTER.OpenLakeScheduler.__new__(ADAPTER.OpenLakeScheduler)
+        scheduler._group_keys = [key_space]
+        scheduler._namespaces_by_group = (((0, 0, 0, 0), (0, 0, 0, 1)),)
+        scheduler._coord = SimpleNamespace(lookup_mask=lambda _token_len: (None,))
+        looked_up = []
+
+        def contains_with_missing_pp1(keys):
+            looked_up.extend(keys)
+            return [True, False]
+
+        scheduler._contains = contains_with_missing_pp1
+        block_hash = b"h" * 32
+        self.assertEqual(scheduler._gather_exists([block_hash], 16), set())
+        self.assertEqual(len(looked_up), 2)
+        self.assertNotEqual(looked_up[0], looked_up[1])
+
+        scheduler._contains = lambda keys: [True] * len(keys)
+        self.assertEqual(scheduler._gather_exists([block_hash], 16), {(0, block_hash)})
+
+    def test_scheduler_slices_variable_per_group_namespace_counts(self):
+        spec = SimpleNamespace(block_size=16)
+        groups = [
+            ADAPTER.GroupKeys(0, spec, 16, b"model-tag-12"),
+            ADAPTER.GroupKeys(1, spec, 16, b"model-tag-12"),
+        ]
+        scheduler = ADAPTER.OpenLakeScheduler.__new__(ADAPTER.OpenLakeScheduler)
+        scheduler._group_keys = groups
+        scheduler._namespaces_by_group = (
+            ((0, 0, 0, 0), (0, 0, 0, 1)),
+            (
+                (0, 0, 0, 0),
+                (0, 0, 0, 1),
+                (1, 0, 0, 0),
+                (1, 0, 0, 1),
+            ),
+        )
+        scheduler._coord = SimpleNamespace(lookup_mask=lambda _token_len: (None, None))
+        looked_up = []
+
+        def contains_with_group_one_incomplete(keys):
+            looked_up.extend(keys)
+            # Group 0 owns the first two keys and is complete. Group 1 owns
+            # four keys and is missing one shard.
+            return [True, True, True, False, True, True]
+
+        scheduler._contains = contains_with_group_one_incomplete
+        block_hash = b"v" * 32
+        self.assertEqual(scheduler._gather_exists([block_hash], 16), {(0, block_hash)})
+        self.assertEqual(len(looked_up), 6)
+
+        scheduler._contains = lambda keys: [True] * len(keys)
+        self.assertEqual(
+            scheduler._gather_exists([block_hash], 16),
+            {(0, block_hash), (1, block_hash)},
+        )
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("PYTHONHASHSEED", "0")
+    unittest.main()


### PR DESCRIPTION
 - Include PP, PCP, DCP, and TP rank information in KV namespaces.
 - Derive TP replication per KV cache group.
 - Assign unique scheduler and worker client IDs.
 - Synchronize slab slot size across pipeline workers.
 - Support cross layer KV registration.
 - Increase the initial UCX attach timeout for large slabs.