### PR TITLE
(#251) [v0.9] Improve the fleet topology reporting and realtime peer capabilities

### DIFF
--- a/console/app/control-plane-data.ts
+++ b/console/app/control-plane-data.ts
@@ -384,7 +384,7 @@ export function aggregateNodeHistory(snapshot: ControlPlaneSnapshot | null, maxi
   const histories = activeNodes(snapshot)
     .filter(node => !node.errors.openlake)
     .map(node => node.openlake?.openlake.history)
-    .filter(history => history !== undefined && history.interval_seconds > 0);
+    .filter(history => history != null && history.interval_seconds > 0);
   if (!histories.length) return null;
 
   const intervalSeconds = histories[0].interval_seconds;

--- a/console/app/control-plane.tsx
+++ b/console/app/control-plane.tsx
@@ -6,7 +6,6 @@ import {
   activeNodes,
   aggregateNodeHistory,
   aggregateOpenLakeTokensServed,
-  averageMetric,
   formatBytes,
   formatCount,
   formatDuration,
@@ -24,7 +23,6 @@ import { AppShell } from "./shell";
 
 const metricNames = {
   completed: ["vllm:request_success_total", "vllm:request_success"],
-  gpuKv: ["vllm:kv_cache_usage_perc", "vllm:gpu_cache_usage_perc"],
   running: ["vllm:num_requests_running"],
   waiting: ["vllm:num_requests_waiting"],
 };
@@ -254,8 +252,6 @@ function LiveDashboard({ snapshot }: { snapshot: ControlPlaneSnapshot }) {
   const running = sumMetric(snapshot, metricNames.running);
   const waiting = sumMetric(snapshot, metricNames.waiting);
   const completed = sumMetric(snapshot, metricNames.completed);
-  const gpuKvRaw = averageMetric(snapshot, metricNames.gpuKv);
-  const gpuKvPercent = gpuKvRaw === null ? null : gpuKvRaw > 1 ? gpuKvRaw : gpuKvRaw * 100;
   const finishReasons = groupMetricByLabel(snapshot, metricNames.completed, "finished_reason");
   const finishTotal = finishReasons.reduce((total, reason) => total + reason.value, 0);
   const vllm = vllmSamples(snapshot);
@@ -287,13 +283,14 @@ function LiveDashboard({ snapshot }: { snapshot: ControlPlaneSnapshot }) {
     { label: "Active nodes", value: String(nodes.length), detail: `${snapshot.totals.configured} configured`, subdetail: `${snapshot.totals.unreachable} unreachable` },
     ...(completed === null ? [] : [{ label: "Completed requests", value: formatCount(completed), detail: "vLLM process lifetime", subdetail: "Cumulative successful requests" }]),
     ...(running === null ? [] : [{ label: "Running requests", value: formatCount(running), detail: "Currently executing", subdetail: waiting === null ? "Queue metric not reported" : `${formatCount(waiting)} waiting` }]),
-    ...(openLakeServed ? [{
+    {
       label: "Tokens served by OpenLake",
-      value: formatCount(openLakeServed.tokens),
-      detail: `${formatCount(openLakeServed.blocks)} confirmed KV blocks`,
-      subdetail: `${openLakeServed.blockSizes.join(" / ")} tokens per block · server GET hits`,
-    }] : []),
-    ...(!openLakeServed && gpuKvPercent !== null ? [{ label: "vLLM GPU KV cache", value: `${gpuKvPercent.toFixed(1)}%`, detail: "Current engine utilization", subdetail: "Reported by vLLM" }] : []),
+      value: formatCount(openLakeServed?.tokens ?? 0),
+      detail: `${formatCount(openLakeServed?.blocks ?? 0)} KV blocks served`,
+      subdetail: openLakeServed
+        ? `Block size: ${openLakeServed.blockSizes.join(" / ")} tokens`
+        : "No KV blocks served",
+    },
   ];
 
   const finishAvailable = finishTotal > 0;

--- a/console/app/fleet/fleet-view.tsx
+++ b/console/app/fleet/fleet-view.tsx
@@ -35,7 +35,7 @@ function FleetSummary({ snapshot }: { snapshot: ControlPlaneSnapshot }) {
   const openlakeReporting = active.filter(node => node.openlake && !node.errors.openlake).length;
   const vllmReporting = active.filter(node => node.vllm && !node.errors.vllm).length;
   const cards = [
-    ["Configured nodes", String(snapshot.totals.configured), "Read from [[nodes]]"],
+    ["Configured nodes", String(snapshot.totals.configured), "Total nodes in this fleet"],
     ["Active nodes", String(active.length), `${snapshot.totals.unreachable} unreachable`],
     ["OpenLake reporting", String(openlakeReporting), "Runtime telemetry available"],
     ["vLLM reporting", String(vllmReporting), "Metrics endpoint available"],

--- a/console/app/globals.css
+++ b/console/app/globals.css
@@ -541,11 +541,14 @@ a { color: inherit; text-decoration: none; }
 .signal-canvas button { cursor: pointer; }
 .operator-scroll-pad { display: flex; min-width: min-content; min-height: min-content; justify-content: flex-start; align-items: flex-start; padding: 420px 520px; }
 .operator-stage-space { position: relative; flex: none; }
-.operator-stage { position: absolute; top: 0; left: 0; transform-origin: top left; }
+.operator-stage { position: absolute; top: 0; left: 0; display: flex; width: max-content; height: max-content; align-items: flex-start; gap: 180px; transform-origin: top left; will-change: transform; backface-visibility: hidden; }
 .topology-node-row { display: flex; height: 100%; align-items: center; }
 .node-interconnect { display: flex; width: 120px; flex: 0 0 120px; align-items: center; flex-direction: column; justify-content: center; gap: 10px; color: var(--signal-muted); font-size: 8px; font-weight: 700; letter-spacing: .1em; white-space: nowrap; }
 .node-interconnect i { width: 100%; border-top: 1px solid var(--signal-border-strong); }
-.fabric-node-slot, .fabric-spine-slot { position: absolute; }
+.fabric-layout-group { display: grid; width: max-content; grid-template-columns: repeat(var(--fabric-columns, 1), var(--node-width, 1244px)); grid-template-rows: auto; column-gap: var(--node-gap, 120px); align-items: start; }
+.fabric-layout-group.has-rail { grid-template-rows: auto var(--fabric-spine-height, 148px); }
+.fabric-layout-group.has-rail.is-split { grid-template-rows: auto var(--fabric-spine-height, 148px) auto; }
+.fabric-node-slot, .fabric-spine-slot { position: relative; }
 .fabric-node-slot { z-index: 2; }
 .fabric-spine-slot { z-index: 1; }
 .fabric-spine { position: relative; width: 100%; height: 100%; color: var(--signal-copy); }
@@ -565,13 +568,11 @@ a { color: inherit; text-decoration: none; }
 .fabric-node-slot.is-below .fabric-node-drop { bottom: 100%; }
 .fabric-node-drop i { display: block; width: 1px; height: 100%; background: linear-gradient(180deg, color-mix(in srgb, var(--signal-active) 24%, var(--signal-border-strong)), color-mix(in srgb, var(--signal-active) 68%, var(--signal-copy))); box-shadow: 0 0 12px color-mix(in srgb, var(--signal-active) 18%, transparent); }
 .fabric-node-slot.is-below .fabric-node-drop i { background: linear-gradient(180deg, color-mix(in srgb, var(--signal-active) 68%, var(--signal-copy)), color-mix(in srgb, var(--signal-active) 24%, var(--signal-border-strong))); }
+.fabric-node-drop.is-unverified i { background: repeating-linear-gradient(180deg, color-mix(in srgb, var(--signal-copy) 30%, transparent) 0 5px, transparent 5px 10px); box-shadow: none; }
 .fabric-node-drop b { position: absolute; left: 10px; max-width: 210px; overflow: hidden; color: var(--signal-muted); font-size: 7px; font-weight: 700; letter-spacing: .09em; text-overflow: ellipsis; white-space: nowrap; }
 .fabric-node-slot.is-above .fabric-node-drop b { top: 12px; }
 .fabric-node-slot.is-below .fabric-node-drop b { bottom: 12px; }
-.fabric-unverified { position: absolute; top: 50%; left: 50%; display: flex; min-width: 390px; min-height: 66px; align-items: center; justify-content: center; flex-direction: column; gap: 5px; transform: translate(-50%, -50%); border: 1px dashed color-mix(in srgb, var(--signal-copy) 16%, transparent); border-radius: 4px; background: color-mix(in srgb, var(--signal-panel) 64%, transparent); color: var(--signal-muted); }
-.fabric-unverified span, .fabric-unverified small { font-size: 7px; font-weight: 680; letter-spacing: .11em; }
-.fabric-unverified strong { color: color-mix(in srgb, var(--signal-copy) 58%, transparent); font-size: 9px; font-weight: 720; letter-spacing: .13em; }
-.operator-node { position: relative; width: var(--node-width, 1244px); height: var(--node-height, 850px); padding: 14px 26px 16px; border: 1px solid color-mix(in srgb, var(--signal-copy) 8%, transparent); border-radius: 3px; background: linear-gradient(180deg, color-mix(in srgb, var(--signal-panel) 18%, transparent), transparent 22%), var(--signal-canvas); box-shadow: inset 0 1px 0 color-mix(in srgb, var(--signal-copy) 3.5%, transparent), 0 20px 60px rgba(0,0,0,.08); color: var(--signal-copy); letter-spacing: .055em; }
+.operator-node { position: relative; width: var(--node-width, 1244px); height: auto; padding: 14px 26px 12px; border: 1px solid color-mix(in srgb, var(--signal-copy) 8%, transparent); border-radius: 3px; background: linear-gradient(180deg, color-mix(in srgb, var(--signal-panel) 18%, transparent), transparent 22%), var(--signal-canvas); box-shadow: inset 0 1px 0 color-mix(in srgb, var(--signal-copy) 3.5%, transparent), 0 20px 60px rgba(0,0,0,.08); color: var(--signal-copy); letter-spacing: .055em; }
 .operator-node-meta { display: flex; height: 24px; align-items: center; justify-content: space-between; color: var(--signal-muted); font-size: 10px; font-weight: 650; letter-spacing: .08em; }
 .operator-node-meta span { display: flex; align-items: center; gap: 10px; }
 .node-identity-button { display: flex; min-width: 0; align-items: center; gap: 12px; padding: 0; border: 0; background: transparent; color: inherit; font: inherit; letter-spacing: inherit; }
@@ -602,17 +603,20 @@ a { color: inherit; text-decoration: none; }
 /* Data-driven locality topology. Relationships appear only when inventory proves them. */
 .topology-configuration-label { display: flex; height: 28px; align-items: center; justify-content: space-between; margin-top: 5px; color: var(--signal-muted); font-size: 8px; font-weight: 670; letter-spacing: .11em; }
 .topology-configuration-label b { color: color-mix(in srgb, var(--signal-copy) 74%, transparent); font-weight: 680; }
-.locality-groups { display: grid; height: 430px; grid-template-columns: repeat(var(--topology-groups, 1), minmax(540px, 1fr)); gap: 18px; }
-.locality-group { display: grid; min-width: 0; height: 430px; grid-template-rows: 27px auto 29px 148px; align-content: space-between; padding: 10px 12px 12px; border: 1px solid color-mix(in srgb, var(--signal-copy) 13%, transparent); border-radius: 2px; background: color-mix(in srgb, var(--signal-panel) 26%, transparent); box-shadow: inset 0 1px 0 color-mix(in srgb, var(--signal-copy) 2.5%, transparent); }
+.locality-groups { display: grid; height: auto; grid-template-columns: repeat(var(--topology-groups, 1), minmax(540px, 1fr)); align-items: start; gap: 18px; }
+.locality-group { display: grid; min-width: 0; height: auto; grid-template-rows: auto; align-content: start; gap: 12px; padding: 10px 12px 12px; border: 1px solid color-mix(in srgb, var(--signal-copy) 13%, transparent); border-radius: 2px; background: color-mix(in srgb, var(--signal-panel) 26%, transparent); box-shadow: inset 0 1px 0 color-mix(in srgb, var(--signal-copy) 2.5%, transparent); }
 .locality-group.locality-unreported { border-style: dashed; }
 .locality-header { display: flex; min-width: 0; align-items: flex-start; justify-content: space-between; gap: 16px; color: var(--signal-muted); font-size: 8px; font-weight: 680; letter-spacing: .12em; }
 .locality-header strong { color: var(--signal-copy); font-size: 10px; font-weight: 720; letter-spacing: .14em; }
 .locality-header span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.locality-gpu-grid { display: grid; width: min(100%, calc(var(--locality-gpu-columns, 1) * 128px + (var(--locality-gpu-columns, 1) - 1) * 8px)); min-width: 0; max-height: 222px; align-content: start; grid-template-columns: repeat(var(--locality-gpu-columns, 1), minmax(104px, 128px)); justify-self: center; gap: 8px; padding: 4px 3px 7px; overflow-y: auto; scrollbar-color: var(--signal-border-strong) transparent; scrollbar-width: thin; }
+.locality-gpu-grid { display: grid; width: min(100%, calc(var(--locality-gpu-columns, 1) * 128px + (var(--locality-gpu-columns, 1) - 1) * 8px)); min-width: 0; align-content: start; grid-template-columns: repeat(var(--locality-gpu-columns, 1), minmax(104px, 128px)); justify-self: center; gap: 8px; padding: 4px 3px 7px; }
 .locality-gpu { display: flex; min-width: 0; min-height: 104px; align-items: center; justify-content: center; flex-direction: column; gap: 7px; padding: 10px 8px 9px; border-color: color-mix(in srgb, var(--signal-copy) 14%, transparent); border-radius: 1px; background: color-mix(in srgb, var(--signal-panel) 68%, transparent); box-shadow: inset 0 1px 0 color-mix(in srgb, var(--signal-copy) 3%, transparent); text-align: center; }
 .locality-gpu:hover, .locality-bridge:hover, .locality-nic:hover, .locality-cpu:hover { border-color: color-mix(in srgb, var(--signal-copy) 26%, transparent); background: color-mix(in srgb, var(--signal-panel-strong) 72%, transparent); box-shadow: inset 0 1px 0 color-mix(in srgb, var(--signal-copy) 4%, transparent); }
 .locality-device-title { display: flex; min-width: 0; align-items: center; justify-content: center; gap: 7px; }
 .locality-device-title .telemetry-mark { width: 17px; height: 17px; flex-basis: 17px; }
+.hardware-class-mark { display: inline-grid; width: 17px; height: 17px; flex: 0 0 17px; place-items: center; }
+.hardware-class-mark svg { width: 17px; height: 17px; stroke-width: 1.65; }
+.hardware-class-mark.is-pcie { color: var(--signal-active); }
 .locality-device-title strong { overflow: hidden; font-size: 10px; font-weight: 750; letter-spacing: .1em; text-overflow: ellipsis; white-space: nowrap; }
 .locality-device-model { display: block; width: 100%; overflow: hidden; color: var(--signal-muted); font-size: 7.5px; font-weight: 650; letter-spacing: .06em; text-align: center; text-overflow: ellipsis; white-space: nowrap; }
 .locality-primary-metric { display: flex; min-width: 0; align-items: center; justify-content: center; gap: 6px; color: var(--signal-copy); font-variant-numeric: tabular-nums; }
@@ -628,8 +632,8 @@ a { color: inherit; text-decoration: none; }
 .locality-fabric-rail { display: flex; min-width: 0; align-items: center; justify-content: space-between; gap: 12px; padding: 0 10px; border: 1px solid color-mix(in srgb, var(--signal-copy) 12%, transparent); background: color-mix(in srgb, var(--signal-panel-strong) 42%, transparent); color: var(--signal-muted); font-size: 7px; font-weight: 660; letter-spacing: .1em; }
 .locality-fabric-rail b { overflow: hidden; color: color-mix(in srgb, var(--signal-copy) 72%, transparent); font-weight: 690; text-overflow: ellipsis; white-space: nowrap; }
 .locality-fabric-rail span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.locality-host-grid { display: grid; min-width: 0; grid-template-columns: minmax(0, .94fr) minmax(220px, 1.06fr); gap: 10px; padding-top: 10px; }
-.locality-io-bank { display: grid; min-width: 0; grid-template-columns: repeat(auto-fit, minmax(116px, 1fr)); align-content: stretch; gap: 8px; }
+.locality-host-grid { display: contents; }
+.locality-io-bank { display: grid; min-width: 0; grid-template-columns: repeat(auto-fit, minmax(116px, 1fr)); align-content: start; align-items: stretch; gap: 8px; }
 .locality-bridge, .locality-nic { display: flex; min-width: 0; align-items: stretch; justify-content: center; flex-direction: column; gap: 7px; padding: 10px; border-color: color-mix(in srgb, var(--signal-copy) 12%, transparent); border-radius: 1px; background: color-mix(in srgb, var(--signal-panel) 58%, transparent); text-align: left; }
 .locality-bridge > span { display: flex; min-width: 0; align-items: center; justify-content: space-between; gap: 8px; }
 .locality-bridge strong, .locality-nic .locality-device-title strong { font-size: 8px; font-weight: 720; letter-spacing: .09em; }
@@ -637,13 +641,15 @@ a { color: inherit; text-decoration: none; }
 .locality-bridge code, .locality-bridge small, .locality-nic small { overflow: hidden; color: var(--signal-muted); font-family: inherit; font-size: 7px; font-weight: 640; letter-spacing: .06em; text-overflow: ellipsis; white-space: nowrap; }
 .nic-primary-metric { justify-content: flex-start; }
 .locality-io-empty { display: flex; min-height: 100%; align-items: center; justify-content: center; padding: 12px; border: 1px dashed color-mix(in srgb, var(--signal-copy) 10%, transparent); color: var(--signal-muted); font-size: 7px; font-weight: 650; letter-spacing: .08em; line-height: 1.5; text-align: center; }
-.locality-cpu { position: relative; display: flex; min-width: 0; align-items: center; justify-content: center; flex-direction: column; gap: 8px; padding: 12px 15px 10px; overflow: hidden; border-color: color-mix(in srgb, var(--signal-copy) 14%, transparent); border-radius: 1px; background: color-mix(in srgb, var(--signal-panel) 68%, transparent); text-align: center; }
+.locality-cpu { position: relative; display: grid; min-width: 0; min-height: 82px; grid-template-columns: minmax(0, 1fr) minmax(250px, .9fr); grid-template-areas: "title facts" "model facts"; align-self: start; align-items: center; gap: 4px 18px; padding: 10px 14px; overflow: hidden; border-color: color-mix(in srgb, var(--signal-copy) 14%, transparent); border-radius: 1px; background: color-mix(in srgb, var(--signal-panel) 68%, transparent); text-align: left; }
+.locality-cpu .locality-device-title { grid-area: title; justify-content: flex-start; }
 .locality-cpu .locality-device-title strong { font-size: 9px; }
-.locality-cpu-facts { display: grid; width: 100%; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 6px; padding-top: 9px; border-top: 1px solid color-mix(in srgb, var(--signal-copy) 11%, transparent); color: color-mix(in srgb, var(--signal-copy) 76%, transparent); }
+.locality-cpu .locality-device-model { grid-area: model; text-align: left; }
+.locality-cpu-facts { display: grid; width: 100%; grid-area: facts; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 6px; padding-left: 14px; border-left: 1px solid color-mix(in srgb, var(--signal-copy) 11%, transparent); color: color-mix(in srgb, var(--signal-copy) 76%, transparent); }
 .locality-cpu-facts span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .locality-cpu-facts b { display: block; margin-bottom: 5px; color: var(--signal-muted); font-size: 6.5px; font-weight: 650; letter-spacing: .1em; }
 .locality-cpu-facts strong { display: block; overflow: hidden; color: var(--signal-copy); font-size: 12px; font-weight: 700; letter-spacing: -.015em; line-height: 1; text-overflow: ellipsis; white-space: nowrap; }
-.locality-cpu-unreported { display: flex; min-width: 0; align-items: center; justify-content: center; flex-direction: column; gap: 7px; padding: 12px; border: 1px dashed color-mix(in srgb, var(--signal-copy) 10%, transparent); color: var(--signal-muted); text-align: center; }
+.locality-cpu-unreported { display: flex; min-width: 0; min-height: 72px; align-items: center; justify-content: center; flex-direction: column; gap: 7px; padding: 12px; border: 1px dashed color-mix(in srgb, var(--signal-copy) 10%, transparent); color: var(--signal-muted); text-align: center; }
 .locality-cpu-unreported strong { color: color-mix(in srgb, var(--signal-copy) 62%, transparent); font-size: 8px; font-weight: 680; letter-spacing: .1em; }
 .locality-cpu-unreported span { max-width: 240px; font-size: 7px; line-height: 1.5; letter-spacing: .06em; }
 .host-device-rail { display: grid; height: 54px; grid-template-columns: 270px minmax(0, 1fr); align-items: center; gap: 16px; margin-top: 10px; padding: 7px 10px; border: 1px solid color-mix(in srgb, var(--signal-copy) 10%, transparent); border-radius: 2px; background: color-mix(in srgb, var(--signal-panel) 22%, transparent); }
@@ -735,7 +741,7 @@ a { color: inherit; text-decoration: none; }
 .nic-module-card .nic-row small { color: var(--signal-muted); font-size: 7.5px; letter-spacing: .08em; }
 .pcie-rail { height: 32px; margin-top: 0; }
 
-.openlake-slab { position: relative; height: 186px; margin-top: 23px; padding: 0; border: 0; background: transparent; transition: filter .14s ease; }
+.openlake-slab { position: relative; height: auto; margin-top: 23px; padding: 0; border: 0; background: transparent; transition: filter .14s ease; }
 .openlake-slab.has-telemetry { border: 0; background: transparent; box-shadow: none; }
 .openlake-slab.is-selected { filter: none; }
 .openlake-slab.is-selected .openlake-runtime-node { border-color: color-mix(in srgb, var(--signal-active) 72%, var(--signal-copy)); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--signal-active) 62%, transparent), 0 0 14px color-mix(in srgb, var(--signal-active) 9%, transparent); }
@@ -751,7 +757,7 @@ a { color: inherit; text-decoration: none; }
 .openlake-runtime-state.is-waiting i { background: var(--signal-active); box-shadow: 0 0 8px color-mix(in srgb, var(--signal-active) 34%, transparent); }
 .openlake-runtime-state.is-attached { color: var(--signal-copy); }
 .openlake-runtime-state.is-attached i { background: var(--signal-live); box-shadow: 0 0 8px color-mix(in srgb, var(--signal-live) 40%, transparent); }
-.openlake-resources { display: grid; height: 136px; grid-template-columns: 1fr 1.12fr; gap: 20px; padding: 12px 12px 0; }
+.openlake-resources { display: grid; height: auto; grid-template-columns: 1fr 1.12fr; grid-auto-rows: minmax(118px, auto); gap: 20px; padding: 12px 12px 0; }
 .resource-module { padding: 13px 16px 10px; border-color: transparent; background-color: color-mix(in srgb, var(--signal-panel) 74%, transparent); background-image: linear-gradient(180deg, color-mix(in srgb, var(--signal-copy) 2.5%, transparent), transparent); box-shadow: inset 0 1px 0 color-mix(in srgb, var(--signal-copy) 5%, transparent); }
 .resource-module:hover { border-color: color-mix(in srgb, var(--signal-copy) 12%, transparent); }
 .resource-module > strong { display: block; font-size: 11px; font-weight: 740; letter-spacing: .1em; }
@@ -770,15 +776,9 @@ a { color: inherit; text-decoration: none; }
 .ib-anchor-left.ib-anchor-1 { top: 464px; }
 .ib-anchor-right.ib-anchor-0 { top: 438px; }
 .ib-anchor-right.ib-anchor-1 { top: 502px; }
-.node-boundary-annotation { position: absolute; right: 26px; bottom: 3px; left: 26px; display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; color: color-mix(in srgb, var(--signal-copy) 42%, transparent); font-size: 8px; font-weight: 650; letter-spacing: .1em; pointer-events: none; }
+.node-boundary-annotation { position: static; display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; margin-top: 10px; color: color-mix(in srgb, var(--signal-copy) 42%, transparent); font-size: 8px; font-weight: 650; letter-spacing: .1em; pointer-events: none; }
 .node-boundary-annotation b { padding: 0 12px; color: var(--signal-muted); font-weight: 700; }
 .node-boundary-annotation span:last-child { text-align: right; }
-
-.operator-zoom { position: fixed; z-index: 16; right: 35px; bottom: 37px; display: grid; height: 44px; grid-template-columns: 42px 62px 42px 48px; border: 1px solid var(--signal-border); border-radius: 2px; background: color-mix(in srgb, var(--signal-panel) 96%, transparent); box-shadow: 0 12px 32px rgba(0,0,0,.2); color: var(--signal-muted); }
-.operator-zoom button { border: 0; background: transparent; color: inherit; font-family: var(--font-geist-mono); font-size: 20px; font-weight: 520; cursor: pointer; }
-.operator-zoom button:hover { background: var(--signal-panel-strong); color: var(--signal-copy); }
-.operator-zoom .zoom-value { display: grid; place-items: center; border-right: 1px solid var(--signal-border); border-left: 1px solid var(--signal-border); font-size: 10px; font-weight: 680; letter-spacing: .08em; }
-.operator-zoom .zoom-fit { border-left: 1px solid var(--signal-border); font-size: 9px; font-weight: 720; letter-spacing: .1em; }
 
 .signal-inspector { position: fixed; z-index: 18; top: calc(var(--header-height) + 20px); right: 24px; width: 360px; max-height: calc(100vh - var(--header-height) - 32px); overflow-y: auto; border: 1px solid var(--signal-border-strong); border-radius: 10px; background: linear-gradient(145deg, color-mix(in oklab, var(--primary) 3.5%, var(--signal-panel)), color-mix(in srgb, var(--signal-panel) 97%, transparent) 42%); box-shadow: 0 28px 80px rgba(0,0,0,.42); color: var(--signal-copy); font-family: var(--font-geist-sans); scrollbar-color: var(--signal-border-strong) transparent; scrollbar-width: thin; backdrop-filter: blur(18px); animation: inspector-in .18s ease-out; }
 @keyframes inspector-in { from { opacity: 0; transform: translateX(10px); } to { opacity: 1; transform: translateX(0); } }
@@ -814,7 +814,6 @@ a { color: inherit; text-decoration: none; }
   .view-nodes .app-main { height: 100vh; margin: 0; }
   .view-nodes .topbar { border-color: var(--signal-border); background: var(--signal-canvas); }
   .view-nodes .app-main > main.node-main { height: calc(100vh - var(--header-height)); }
-  .operator-zoom { right: 14px; bottom: 14px; }
   .signal-inspector { top: calc(var(--header-height) + 14px); right: 14px; width: min(360px, calc(100vw - 28px)); max-height: calc(100vh - var(--header-height) - 28px); }
 }
 @media (max-width: 520px) {

--- a/console/app/nodes/node-signal-plane.tsx
+++ b/console/app/nodes/node-signal-plane.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { type CSSProperties, type PointerEvent as ReactPointerEvent, useEffect, useRef, useState } from "react";
-import { X } from "lucide-react";
+import { type CSSProperties, type PointerEvent as ReactPointerEvent, useCallback, useEffect, useRef, useState } from "react";
+import { CircuitBoard, X } from "lucide-react";
 import { activeNodes, formatBytes, type ControlPlaneNode, type HardwareSnapshot, useControlPlaneSnapshot } from "../control-plane-data";
 import { ControlPlaneStatus, TelemetryUnavailable } from "../control-plane-status";
 import { AppShell } from "../shell";
 import { brandFromCpuModel, brandFromVendor } from "./telemetry-brand";
 import { TelemetryMark } from "./telemetry-mark";
-import { buildFabricTopology, buildTopologyGroups, pcieDeviceForAddress, shouldRenderAsHostDeviceRail, type FabricBackbone, type TopologyBridge, type TopologyGpu, type TopologyGroup, type TopologyNic } from "./topology-model";
+import { buildFabricLayoutGroups, buildFabricTopology, buildTopologyGroups, pcieDeviceForAddress, shouldRenderAsHostDeviceRail, type FabricBackbone, type TopologyBridge, type TopologyGpu, type TopologyGroup, type TopologyNic } from "./topology-model";
 
 type InspectorRecord = {
   nodeId: number;
@@ -21,25 +21,21 @@ type InspectorRecord = {
 type InspectorAttribute = [string, string | number | null | undefined];
 
 const BASE_NODE_WIDTH = 1244;
-const NODE_HEIGHT = 850;
 const NODE_GAP = 120;
-const FABRIC_GROUP_GAP = 180;
 const FABRIC_SPINE_HEIGHT = 148;
-const HOST_DEVICE_RAIL_HEIGHT = 64;
+const MIN_ZOOM = 0.12;
+const MAX_ZOOM = 1.4;
+const INITIAL_ZOOM = 0.72;
 
 function topologyNodeWidth(hardware: HardwareSnapshot) {
   const localityCount = buildTopologyGroups(hardware).filter(group => !shouldRenderAsHostDeviceRail(group)).length;
   return Math.max(BASE_NODE_WIDTH, Math.max(1, localityCount) * 570 + 70);
 }
 
-function topologyNodeHeight(hardware: HardwareSnapshot) {
-  return NODE_HEIGHT + (buildTopologyGroups(hardware).some(shouldRenderAsHostDeviceRail) ? HOST_DEVICE_RAIL_HEIGHT : 0);
-}
-
-function fitTopology(viewport: HTMLDivElement | null, stageWidth: number, stageHeight: number, updateZoom: (zoom: number) => void) {
-  if (!viewport) return;
-  const next = Math.max(0.35, Math.min(1, (viewport.clientWidth - 80) / stageWidth, (viewport.clientHeight - 80) / stageHeight));
-  updateZoom(next);
+function fitTopology(viewport: HTMLDivElement | null, stageWidth: number, stageHeight: number, applyZoom: (zoom: number) => void) {
+  if (!viewport || !stageWidth || !stageHeight) return;
+  const next = Math.max(MIN_ZOOM, Math.min(1, (viewport.clientWidth - 80) / stageWidth, (viewport.clientHeight - 80) / stageHeight));
+  applyZoom(next);
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
       const stage = viewport.querySelector<HTMLElement>(".operator-stage-space");
@@ -169,21 +165,12 @@ function FabricSpine({ backbone, columns, nodeWidth, width }: {
   </div>;
 }
 
-function UnverifiedFabric({ count }: { count: number }) {
-  return <div className="fabric-unverified" aria-label="No reciprocal fabric path observed">
-    <span>FABRIC DISCOVERY</span>
-    <strong>NO RECIPROCAL DATA PATH OBSERVED</strong>
-    <small>{count ? `${count} ONE-SIDED OBSERVATION${count === 1 ? "" : "S"} HELD OUT OF THE MAP` : "WAITING FOR PEER CAPABILITIES"}</small>
-  </div>;
-}
-
-function NodeDiagram({ node, hardware, select, selected, width, height }: {
+function NodeDiagram({ node, hardware, select, selected, width }: {
   node: ControlPlaneNode;
   hardware: HardwareSnapshot;
   select: (record: InspectorRecord) => void;
   selected: InspectorRecord | null;
   width: number;
-  height: number;
 }) {
   const gpus = hardware.gpus;
   const reportedNics = hardware.network_interfaces.filter(network => network.name !== "lo");
@@ -283,6 +270,11 @@ function NodeDiagram({ node, hardware, select, selected, width, height }: {
     ["Slot count", kv?.slot_count],
     ["Committed slots", kv?.used_slots],
   ];
+  const isSelected = (kind: string, identifier: string) => (
+    selected?.nodeId === node.id &&
+    selected.kind === kind &&
+    selected.identifier === identifier
+  );
 
   const selectSystem = () => select(inspector(
     node.id,
@@ -404,13 +396,11 @@ function NodeDiagram({ node, hardware, select, selected, width, height }: {
   ));
 
   const nicModule = (network: TopologyNic, compact = false) => {
-    const nicPci = pcieDeviceForAddress(hardware, network.pci_address);
-    const nicBrand = brandFromVendor(nicPci?.vendor_name);
     const bandwidth = nicCapability(network, hardware);
     const primaryMetric = bandwidth ?? network.operational_state?.toUpperCase() ?? "UNREPORTED";
-    return <button className={`operator-module locality-nic ${compact ? "host-device-nic" : ""} ${selected?.identifier === (network.pci_address ?? network.mac_address ?? network.name) ? "is-selected" : ""}`} key={network.name} onClick={() => selectNic(network)}>
+    const identifier = network.pci_address ?? network.mac_address ?? network.name;
+    return <button className={`operator-module locality-nic ${compact ? "host-device-nic" : ""} ${isSelected("nic", identifier) ? "is-selected" : ""}`} key={network.name} onClick={() => selectNic(network)}>
       <span className="locality-device-title">
-        {nicBrand ? <TelemetryMark brand={nicBrand} matchedFrom="NIC PCI vendor"/> : null}
         <strong>NIC · {network.name}</strong>
       </span>
       <span className="locality-primary-metric nic-primary-metric">
@@ -421,7 +411,7 @@ function NodeDiagram({ node, hardware, select, selected, width, height }: {
     </button>;
   };
 
-  return <section className="operator-node" style={{ "--node-width": `${width}px`, "--node-height": `${height}px` } as CSSProperties} aria-label={`Hardware topology for node-${node.id}`}>
+  return <section className="operator-node" style={{ "--node-width": `${width}px` } as CSSProperties} aria-label={`Hardware topology for node-${node.id}`}>
     <div className="operator-node-meta">
       <button className="node-identity-button" onClick={selectSystem}><span>NODE-{node.id}</span><b>{systemName}</b></button>
       <span>{topologyGroups.some(group => group.locality === "numa") ? "NUMA LOCALITY REPORTED" : "HOST LOCALITY"} · {hardware.collection_status.toUpperCase()} · {hardware.system.architecture.toUpperCase()}</span>
@@ -436,12 +426,28 @@ function NodeDiagram({ node, hardware, select, selected, width, height }: {
           <span>{group.gpus.length} GPU · {group.nics.length} NIC{group.memoryTotalBytes ? ` · ${optionalBytes(group.memoryTotalBytes)}` : ""}</span>
         </header>
 
+        {group.cpuAffinityReported ? <button className={`operator-module locality-cpu ${isSelected("cpu", group.numaNode === null ? `node-${node.id}-cpu` : `node-${node.id}-numa-${group.numaNode}`) ? "is-selected" : ""}`} onClick={() => selectCpuGroup(group)}>
+          <span className="locality-device-title">
+            {cpuBrand ? <TelemetryMark brand={cpuBrand} matchedFrom="CPU model signature"/> : null}
+            <strong>{group.locality === "numa" ? `CPU AFFINITY / NUMA ${group.numaNode}` : "CPU"}</strong>
+          </span>
+          <span className="locality-device-model">{hardware.cpu.model ?? hardware.cpu.architecture}</span>
+          <div className="locality-cpu-facts">
+            <span><b>PACKAGE ID</b><strong>{group.cpuPackageIds.length ? group.cpuPackageIds.join(", ") : "UNREPORTED"}</strong></span>
+            <span><b>LOGICAL CPU</b><strong>{group.logicalCpuCount ?? hardware.cpu.logical_cpu_count}</strong></span>
+            <span><b>MEMORY</b><strong>{optionalBytes(group.memoryTotalBytes ?? hardware.memory.total_bytes)}</strong></span>
+          </div>
+        </button> : <div className="locality-cpu-unreported">
+          <strong>CPU LOCALITY NOT REPORTED</strong>
+          <span>No CPU package or memory affinity is inferred for these devices.</span>
+        </div>}
+
         {group.gpus.length ? <div className="locality-gpu-grid" style={{ "--locality-gpu-columns": Math.min(group.gpus.length, 4) } as CSSProperties}>
           {group.gpus.map((gpu, position) => {
             const recordIdentifier = gpu.uuid ?? gpu.pci_address ?? `gpu-${position}`;
             const gpuBrand = brandFromVendor(gpu.vendor);
             const pciDevice = pcieDeviceForAddress(hardware, gpu.pci_address);
-            return <button className={`operator-module locality-gpu ${selected?.identifier === recordIdentifier ? "is-selected" : ""}`} key={recordIdentifier} onClick={() => selectGpu(gpu, position)}>
+            return <button className={`operator-module locality-gpu ${isSelected("gpu", recordIdentifier) ? "is-selected" : ""}`} key={recordIdentifier} onClick={() => selectGpu(gpu, position)}>
               <span className="locality-device-title">
                 {gpuBrand && gpuBrand !== "apple" ? <TelemetryMark brand={gpuBrand} matchedFrom="GPU vendor"/> : null}
                 <strong>GPU {gpu.index ?? position}</strong>
@@ -461,32 +467,14 @@ function NodeDiagram({ node, hardware, select, selected, width, height }: {
           <span>{group.bridges.length ? `${group.bridges.length} BRIDGE${group.bridges.length === 1 ? "" : "S"} IN REPORTED PARENT CHAIN` : pciSubsystem?.status?.toUpperCase() ?? "UNAVAILABLE"}</span>
         </div> : null}
 
-        <div className="locality-host-grid">
-          <div className="locality-io-bank">
-            {group.bridges.map(bridge => <button className={`operator-module locality-bridge ${selected?.identifier === bridge.address ? "is-selected" : ""}`} key={bridge.address} onClick={() => selectBridge(bridge)}>
-              <span><strong>PCI BRIDGE</strong><b>{pcieCapability(bridge)}</b></span>
-              <code>{bridge.address}</code>
-              <small>{bridge.vendor_name ?? bridge.vendor_id ?? "VENDOR UNREPORTED"}</small>
-            </button>)}
-            {group.nics.map(network => nicModule(network))}
-            {!group.bridges.length && !group.nics.length ? <span className="locality-io-empty">NO LOCAL PCI BRIDGE OR NIC RELATIONSHIP REPORTED</span> : null}
-          </div>
-
-          {group.cpuAffinityReported ? <button className={`operator-module locality-cpu ${selected?.identifier === (group.numaNode === null ? `node-${node.id}-cpu` : `node-${node.id}-numa-${group.numaNode}`) ? "is-selected" : ""}`} onClick={() => selectCpuGroup(group)}>
-            <span className="locality-device-title">
-              {cpuBrand ? <TelemetryMark brand={cpuBrand} matchedFrom="CPU model signature"/> : null}
-              <strong>{group.locality === "numa" ? `CPU AFFINITY / NUMA ${group.numaNode}` : "CPU"}</strong>
-            </span>
-            <span className="locality-device-model">{hardware.cpu.model ?? hardware.cpu.architecture}</span>
-            <div className="locality-cpu-facts">
-              <span><b>PACKAGE ID</b><strong>{group.cpuPackageIds.length ? group.cpuPackageIds.join(", ") : "UNREPORTED"}</strong></span>
-              <span><b>LOGICAL CPU</b><strong>{group.logicalCpuCount ?? hardware.cpu.logical_cpu_count}</strong></span>
-              <span><b>MEMORY</b><strong>{optionalBytes(group.memoryTotalBytes ?? hardware.memory.total_bytes)}</strong></span>
-            </div>
-          </button> : <div className="locality-cpu-unreported">
-            <strong>CPU LOCALITY NOT REPORTED</strong>
-            <span>No CPU package or memory affinity is inferred for these devices.</span>
-          </div>}
+        <div className="locality-io-bank">
+          {group.bridges.map(bridge => <button className={`operator-module locality-bridge ${isSelected("pcie", bridge.address) ? "is-selected" : ""}`} key={bridge.address} onClick={() => selectBridge(bridge)}>
+            <span><span className="hardware-class-mark is-pcie" aria-hidden="true"><CircuitBoard/></span><strong>PCI BRIDGE</strong><b>{pcieCapability(bridge)}</b></span>
+            <code>{bridge.address}</code>
+            <small>{bridge.vendor_name ?? bridge.vendor_id ?? "VENDOR UNREPORTED"}</small>
+          </button>)}
+          {group.nics.map(network => nicModule(network))}
+          {!group.bridges.length && !group.nics.length ? <span className="locality-io-empty">NO LOCAL PCI BRIDGE OR NIC RELATIONSHIP REPORTED</span> : null}
         </div>
       </section>)}
     </div>
@@ -577,66 +565,100 @@ function NodeDiagram({ node, hardware, select, selected, width, height }: {
 function HardwareTopology({ nodes }: { nodes: ControlPlaneNode[] }) {
   const available = nodes.flatMap(node => node.openlake?.hardware ? [{ node, hardware: node.openlake.hardware }] : []);
   const canvas = useRef<HTMLDivElement>(null);
+  const stageSpace = useRef<HTMLDivElement>(null);
+  const stage = useRef<HTMLDivElement>(null);
   const drag = useRef<{ x: number; y: number; left: number; top: number } | null>(null);
-  const [zoom, setZoom] = useState(0.72);
-  const zoomRef = useRef(zoom);
+  const zoomRef = useRef(INITIAL_ZOOM);
+  const zoomFrame = useRef<number | null>(null);
+  const pendingZoom = useRef<{ zoom: number; x: number; y: number } | null>(null);
   const [selected, setSelected] = useState<InspectorRecord | null>(null);
+  const [stageSize, setStageSize] = useState({ width: 0, height: 0 });
   const nodeWidth = Math.max(BASE_NODE_WIDTH, ...available.map(({ hardware }) => topologyNodeWidth(hardware)));
-  const nodeHeight = Math.max(NODE_HEIGHT, ...available.map(({ hardware }) => topologyNodeHeight(hardware)));
   const fabric = buildFabricTopology(available.map(({ node }) => node));
   const availableById = new Map(available.map(entry => [entry.node.id, entry]));
-  const groups: Array<{ id: string; nodeIds: number[]; backbone: FabricBackbone | null }> = [
-    ...fabric.backbones.map(backbone => ({ id: backbone.id, nodeIds: backbone.nodeIds, backbone })),
-    ...(fabric.isolatedNodeIds.length ? [{ id: "fabric-unverified", nodeIds: fabric.isolatedNodeIds, backbone: null }] : []),
-  ];
-  const placements: Array<{
-    id: number;
-    left: number;
-    top: number;
-    side: "above" | "below";
-    backbone: FabricBackbone | null;
-  }> = [];
-  const rails: Array<{ id: string; left: number; width: number; columns: number; backbone: FabricBackbone | null }> = [];
-  let cursor = 0;
-  for (const group of groups) {
-    const columns = Math.max(1, Math.ceil(group.nodeIds.length / 2));
-    const width = columns * nodeWidth + Math.max(0, columns - 1) * NODE_GAP;
-    const splitRows = Boolean(group.backbone) || group.nodeIds.length > 2;
-    group.nodeIds.forEach((id, index) => {
-      const side = splitRows && index % 2 ? "below" : "above";
-      const column = splitRows ? Math.floor(index / 2) : index;
-      placements.push({
-        id,
-        left: cursor + column * (nodeWidth + NODE_GAP),
-        top: side === "below" ? nodeHeight + FABRIC_SPINE_HEIGHT : 0,
-        side,
-        backbone: group.backbone,
-      });
-    });
-    if (group.backbone || splitRows) rails.push({ id: group.id, left: cursor, width, columns, backbone: group.backbone });
-    cursor += width + FABRIC_GROUP_GAP;
-  }
-  const stageWidth = Math.max(nodeWidth, cursor ? cursor - FABRIC_GROUP_GAP : nodeWidth);
-  const stageHeight = placements.some(placement => placement.side === "below")
-    ? nodeHeight * 2 + FABRIC_SPINE_HEIGHT
-    : nodeHeight;
+  const layoutGroups = buildFabricLayoutGroups(fabric);
 
-  useEffect(() => { zoomRef.current = zoom; }, [zoom]);
-  useEffect(() => { fitTopology(canvas.current, stageWidth, stageHeight, setZoom); }, [stageWidth, stageHeight]);
+  const applyZoom = useCallback((requestedZoom: number, anchor?: { x: number; y: number }) => {
+    const viewport = canvas.current;
+    const space = stageSpace.current;
+    const stageElement = stage.current;
+    const next = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, requestedZoom));
+    const current = zoomRef.current;
+    zoomRef.current = next;
+    if (!viewport || !space || !stageElement || !stageSize.width || !stageSize.height) return;
+
+    const viewportRect = viewport.getBoundingClientRect();
+    const spaceRect = space.getBoundingClientRect();
+    const anchorX = anchor?.x ?? viewportRect.left + viewport.clientWidth / 2;
+    const anchorY = anchor?.y ?? viewportRect.top + viewport.clientHeight / 2;
+    const localX = Math.max(0, (anchorX - spaceRect.left) / current);
+    const localY = Math.max(0, (anchorY - spaceRect.top) / current);
+
+    space.style.width = `${stageSize.width * next}px`;
+    space.style.height = `${stageSize.height * next}px`;
+    stageElement.style.transform = `scale(${next})`;
+    viewport.scrollLeft += localX * (next - current);
+    viewport.scrollTop += localY * (next - current);
+  }, [stageSize.height, stageSize.width]);
+
+  useEffect(() => {
+    const element = stage.current;
+    if (!element) return undefined;
+    const measure = () => {
+      const width = Math.ceil(element.scrollWidth);
+      const height = Math.ceil(element.scrollHeight);
+      setStageSize(current => current.width === width && current.height === height
+        ? current
+        : { width, height });
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [available.length, nodeWidth]);
+  useEffect(() => {
+    const viewport = canvas.current;
+    if (!viewport || !stageSize.width || !stageSize.height) return undefined;
+    const fit = () => fitTopology(viewport, stageSize.width, stageSize.height, applyZoom);
+    fit();
+    const observer = new ResizeObserver(fit);
+    observer.observe(viewport);
+    return () => observer.disconnect();
+  }, [applyZoom, stageSize.height, stageSize.width]);
   useEffect(() => {
     const viewport = canvas.current;
     if (!viewport) return undefined;
     const handleWheel = (event: globalThis.WheelEvent) => {
       event.preventDefault();
       event.stopPropagation();
-      const sensitivity = event.ctrlKey ? 0.006 : 0.001;
-      const next = Math.max(0.35, Math.min(1.4, zoomRef.current - event.deltaY * sensitivity));
-      zoomRef.current = next;
-      setZoom(next);
+      const delta = event.deltaMode === globalThis.WheelEvent.DOM_DELTA_LINE
+        ? event.deltaY * 16
+        : event.deltaMode === globalThis.WheelEvent.DOM_DELTA_PAGE
+          ? event.deltaY * viewport.clientHeight
+          : event.deltaY;
+      const sensitivity = event.ctrlKey || event.metaKey ? 0.01 : 0.0025;
+      const baseZoom = pendingZoom.current?.zoom ?? zoomRef.current;
+      pendingZoom.current = {
+        zoom: baseZoom * Math.exp(-delta * sensitivity),
+        x: event.clientX,
+        y: event.clientY,
+      };
+      if (zoomFrame.current !== null) return;
+      zoomFrame.current = requestAnimationFrame(() => {
+        zoomFrame.current = null;
+        const pending = pendingZoom.current;
+        pendingZoom.current = null;
+        if (pending) applyZoom(pending.zoom, { x: pending.x, y: pending.y });
+      });
     };
     viewport.addEventListener("wheel", handleWheel, { passive: false });
-    return () => viewport.removeEventListener("wheel", handleWheel);
-  }, []);
+    return () => {
+      viewport.removeEventListener("wheel", handleWheel);
+      if (zoomFrame.current !== null) cancelAnimationFrame(zoomFrame.current);
+      zoomFrame.current = null;
+      pendingZoom.current = null;
+    };
+  }, [applyZoom]);
 
   const pointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
     if ((event.target as HTMLElement).closest("button")) return;
@@ -659,38 +681,42 @@ function HardwareTopology({ nodes }: { nodes: ControlPlaneNode[] }) {
   };
   if (!available.length) return <div className="node-topology-empty"><TelemetryUnavailable title="Host inventory unavailable" detail="The connected OpenLake node has not returned the hardware inventory contract."/></div>;
 
+  const renderedStageWidth = stageSize.width || nodeWidth;
+  const renderedStageHeight = stageSize.height || 1;
+
   return <div className="node-console-page">
     <div className="signal-canvas" ref={canvas} onPointerDown={pointerDown} onPointerMove={pointerMove} onPointerUp={pointerUp} onPointerCancel={pointerUp}>
       <div className="operator-scroll-pad">
-        <div className="operator-stage-space" style={{ width: stageWidth * zoom, height: stageHeight * zoom }}>
-          <div className="operator-stage" style={{ width: stageWidth, height: stageHeight, transform: `scale(${zoom})` }}>
-            {rails.map(rail => <div className="fabric-spine-slot" style={{ left: rail.left, top: nodeHeight, width: rail.width, height: FABRIC_SPINE_HEIGHT }} key={rail.id}>
-              {rail.backbone
-                ? <FabricSpine backbone={rail.backbone} columns={rail.columns} nodeWidth={nodeWidth} width={rail.width}/>
-                : <UnverifiedFabric count={fabric.unverifiedLinkCount}/>}
-            </div>)}
-            {placements.map(placement => {
-              const entry = availableById.get(placement.id);
-              if (!entry) return null;
-              const devices = placement.backbone?.devicesByNode[placement.id] ?? [];
-              return <div
-                className={`fabric-node-slot is-${placement.side} ${placement.backbone ? "is-connected" : "is-unverified"}`}
-                style={{ left: placement.left, top: placement.top, width: nodeWidth, height: nodeHeight, "--fabric-spine-height": `${FABRIC_SPINE_HEIGHT}px` } as CSSProperties}
-                key={placement.id}
+        <div className="operator-stage-space" ref={stageSpace} style={{ width: renderedStageWidth * INITIAL_ZOOM, height: renderedStageHeight * INITIAL_ZOOM }}>
+          <div className="operator-stage" ref={stage} style={{ transform: `scale(${INITIAL_ZOOM})` }}>
+            {layoutGroups.map(group => {
+              const groupWidth = group.columns * nodeWidth + Math.max(0, group.columns - 1) * NODE_GAP;
+              return <section
+                className={`fabric-layout-group ${group.splitRows ? "is-split" : "is-single-row"} ${group.showRail ? "has-rail" : ""}`}
+                style={{ "--fabric-columns": group.columns, "--node-width": `${nodeWidth}px`, "--node-gap": `${NODE_GAP}px`, "--fabric-spine-height": `${FABRIC_SPINE_HEIGHT}px` } as CSSProperties}
+                key={group.id}
               >
-                <NodeDiagram node={entry.node} hardware={entry.hardware} select={setSelected} selected={selected} width={nodeWidth} height={nodeHeight}/>
-                {placement.backbone ? <span className="fabric-node-drop"><i/><b>{devices.join(" + ") || "SELECTED UCX LANE"}</b></span> : null}
-              </div>;
+                {group.showRail && group.backbone ? <div className="fabric-spine-slot" style={{ gridColumn: `1 / ${group.columns + 1}`, gridRow: 2, width: groupWidth, height: FABRIC_SPINE_HEIGHT }}>
+                  <FabricSpine backbone={group.backbone} columns={group.columns} nodeWidth={nodeWidth} width={groupWidth}/>
+                </div> : null}
+                {group.placements.map(placement => {
+                  const entry = availableById.get(placement.id);
+                  if (!entry) return null;
+                  const devices = group.backbone?.devicesByNode[placement.id] ?? [];
+                  return <div
+                    className={`fabric-node-slot is-${placement.side} ${group.backbone ? "is-connected" : "is-unverified"} ${group.showRail ? "has-fabric-rail" : ""}`}
+                    style={{ gridColumn: placement.column, gridRow: placement.row, width: nodeWidth } as CSSProperties}
+                    key={placement.id}
+                  >
+                    <NodeDiagram node={entry.node} hardware={entry.hardware} select={setSelected} selected={selected} width={nodeWidth}/>
+                    {group.showRail ? <span className={`fabric-node-drop ${group.backbone ? "" : "is-unverified"}`}><i/><b>{group.backbone ? devices.join(" + ") || "SELECTED UCX LANE" : "UNVERIFIED"}</b></span> : null}
+                  </div>;
+                })}
+              </section>;
             })}
           </div>
         </div>
       </div>
-    </div>
-    <div className="operator-zoom" aria-label="Topology zoom controls">
-      <button onClick={() => setZoom(current => Math.max(0.35, current - 0.1))} aria-label="Zoom out">−</button>
-      <span className="zoom-value">{Math.round(zoom * 100)}%</span>
-      <button onClick={() => setZoom(current => Math.min(1.4, current + 0.1))} aria-label="Zoom in">+</button>
-      <button className="zoom-fit" onClick={() => fitTopology(canvas.current, stageWidth, stageHeight, setZoom)}>FIT</button>
     </div>
     {selected ? <DeviceInspector record={selected} close={() => setSelected(null)}/> : null}
   </div>;

--- a/console/app/nodes/topology-model.ts
+++ b/console/app/nodes/topology-model.ts
@@ -40,6 +40,23 @@ export type FabricTopology = {
   unverifiedLinkCount: number;
 };
 
+export type FabricNodePlacement = {
+  id: number;
+  column: number;
+  row: 1 | 3;
+  side: "above" | "below";
+};
+
+export type FabricLayoutGroup = {
+  id: string;
+  nodeIds: number[];
+  backbone: FabricBackbone | null;
+  columns: number;
+  splitRows: boolean;
+  showRail: boolean;
+  placements: FabricNodePlacement[];
+};
+
 type PeerPath = {
   kind: "rdma" | "tcp";
   capabilities: Array<{ transport: string; device: string }>;
@@ -174,6 +191,51 @@ export function buildFabricTopology(nodes: ControlPlaneNode[]): FabricTopology {
   backbones.sort((left, right) => left.nodeIds[0] - right.nodeIds[0]);
   isolatedNodeIds.sort((left, right) => left - right);
   return { backbones, isolatedNodeIds, unverifiedLinkCount };
+}
+
+/**
+ * Produce stable grid coordinates for every fabric component. Connection
+ * health changes the rail treatment, not the host positions.
+ */
+export function buildFabricLayoutGroups(fabric: FabricTopology): FabricLayoutGroup[] {
+  const groups: Array<{
+    id: string;
+    nodeIds: number[];
+    backbone: FabricBackbone | null;
+  }> = [
+    ...fabric.backbones.map(backbone => ({
+      id: backbone.id,
+      nodeIds: backbone.nodeIds,
+      backbone,
+    })),
+    ...(fabric.isolatedNodeIds.length ? [{
+      id: "fabric-unverified",
+      nodeIds: fabric.isolatedNodeIds,
+      backbone: null,
+    }] : []),
+  ];
+
+  return groups.map(group => {
+    const splitRows = group.nodeIds.length > 2;
+    const columns = Math.max(1, splitRows
+      ? Math.ceil(group.nodeIds.length / 2)
+      : group.nodeIds.length);
+    return {
+      ...group,
+      columns,
+      splitRows,
+      showRail: Boolean(group.backbone),
+      placements: group.nodeIds.map((id, index) => {
+        const below = splitRows && index % 2 === 1;
+        return {
+          id,
+          column: splitRows ? Math.floor(index / 2) + 1 : index + 1,
+          row: below ? 3 : 1,
+          side: below ? "below" : "above",
+        };
+      }),
+    };
+  });
 }
 
 function isPhysicalNic(network: TopologyNic) {

--- a/console/configs/openlake.example.toml
+++ b/console/configs/openlake.example.toml
@@ -2,6 +2,7 @@ self_id              = 0
 mode                 = "kv"
 transport            = "h2"
 rpc_addr             = "127.0.0.1:9400"
+kv_agents            = ["127.0.0.1:9400"]
 s3_addr              = "127.0.0.1:9000"
 region               = "us-east-1"
 data_dirs            = []

--- a/console/server/telemetry.mjs
+++ b/console/server/telemetry.mjs
@@ -36,8 +36,12 @@ function urlHost(host) {
 export async function loadControlPlaneConfig(configPath) {
   const absolutePath = resolve(configPath);
   const document = parseToml(await readFile(absolutePath, "utf8"));
-  if (!Array.isArray(document.nodes) || document.nodes.length === 0) {
-    throw new Error(`${absolutePath} does not contain any [[nodes]] entries`);
+
+  if (document.mode !== "kv") {
+    throw new Error(`${absolutePath} console requires mode = "kv"`);
+  }
+  if (!Array.isArray(document.kv_agents) || document.kv_agents.length === 0) {
+    throw new Error(`${absolutePath} requires a non-empty kv_agents array`);
   }
 
   const tls = document.rpc_tls && typeof document.rpc_tls === "object" ? document.rpc_tls : null;
@@ -47,17 +51,16 @@ export async function loadControlPlaneConfig(configPath) {
   const ca = caPath ? await readFile(caPath) : undefined;
   const scheme = tls ? "https" : "http";
 
-  const nodes = document.nodes.map((node, index) => {
-    const id = Number(node.id);
-    if (!Number.isInteger(id) || id < 0) throw new Error(`nodes[${index}].id must be a non-negative integer`);
-    const rpc = parseSocketAddress(node.rpc_addr, `nodes[${index}].rpc_addr`);
-    if (rpc.port === 65535) throw new Error(`nodes[${index}].rpc_addr cannot derive a telemetry port from 65535`);
+  const nodes = document.kv_agents.map((rpcAddress, id) => {
+    const field = `kv_agents[${id}]`;
+    const rpc = parseSocketAddress(rpcAddress, field);
+    if (rpc.port === 65535) throw new Error(`${field} cannot derive a telemetry port from 65535`);
     const host = dialHost(rpc.host);
     const telemetryPort = rpc.port + 1;
     return {
       id,
-      diskCount: Number(node.disk_count ?? 1),
-      rpcAddress: node.rpc_addr,
+      diskCount: 0,
+      rpcAddress,
       telemetryAddress: `${host}:${telemetryPort}`,
       telemetryOrigin: `${scheme}://${urlHost(host)}:${telemetryPort}`,
       rpcOrigin: `${scheme}://${urlHost(host)}:${rpc.port}`,

--- a/console/tests/control-plane-data.test.mjs
+++ b/console/tests/control-plane-data.test.mjs
@@ -73,6 +73,12 @@ test("does not guess when an engine reports conflicting block sizes", () => {
   );
 });
 
+test("treats a null history payload as unavailable telemetry", () => {
+  const fleet = snapshot();
+  fleet.nodes[0].openlake.openlake.history = null;
+  assert.equal(aggregateNodeHistory(fleet), null);
+});
+
 test("aligns and sums the newest node history buckets as per-minute rates", () => {
   const fleet = snapshot();
   fleet.nodes[0].openlake.openlake.history = {

--- a/console/tests/control-plane-runtime.test.mjs
+++ b/console/tests/control-plane-runtime.test.mjs
@@ -18,6 +18,57 @@ test("parses Prometheus samples without forwarding comments", () => {
   ]);
 });
 
+test("uses the ordered KV agent list as the fleet inventory on every KV host", async context => {
+  const directory = await mkdtemp(join(tmpdir(), "openlake-kv-agent-inventory-"));
+  context.after(() => rm(directory, { force: true, recursive: true }));
+  const agents = ["10.0.0.10:9400", "10.0.0.11:9400"];
+  const configs = await Promise.all([0, 1].map(async selfId => {
+    const configPath = join(directory, `node-${selfId}.toml`);
+    await writeFile(configPath, `
+self_id = ${selfId}
+mode = "kv"
+kv_agents = ["${agents[0]}", "${agents[1]}"]
+
+[[nodes]]
+id = ${selfId}
+rpc_addr = "${agents[selfId]}"
+disk_count = 0
+`);
+    return loadControlPlaneConfig(configPath);
+  }));
+
+  for (const config of configs) {
+    assert.deepEqual(config.nodes.map(node => ({
+      id: node.id,
+      rpcAddress: node.rpcAddress,
+      telemetryAddress: node.telemetryAddress,
+    })), [
+      { id: 0, rpcAddress: agents[0], telemetryAddress: "10.0.0.10:9401" },
+      { id: 1, rpcAddress: agents[1], telemetryAddress: "10.0.0.11:9401" },
+    ]);
+  }
+});
+
+test("rejects a console configuration without KV agents", async context => {
+  const directory = await mkdtemp(join(tmpdir(), "openlake-missing-kv-agents-"));
+  context.after(() => rm(directory, { force: true, recursive: true }));
+  const configPath = join(directory, "openlake.toml");
+  await writeFile(configPath, `
+self_id = 0
+mode = "kv"
+
+[[nodes]]
+id = 0
+rpc_addr = "127.0.0.1:9400"
+disk_count = 0
+`);
+
+  await assert.rejects(
+    loadControlPlaneConfig(configPath),
+    /requires a non-empty kv_agents array/,
+  );
+});
+
 test("loads the existing OpenLake TOML and polls both node-agent routes", async context => {
   const telemetry = createServer((request, response) => {
     if (request.url === "/v1/telemetry/openlake") {
@@ -67,7 +118,9 @@ test("loads the existing OpenLake TOML and polls both node-agent routes", async 
   const configPath = join(directory, "openlake.toml");
   await writeFile(configPath, `
 self_id = 7
+mode = "kv"
 rpc_addr = "127.0.0.1:${address.port - 1}"
+kv_agents = ["127.0.0.1:${address.port - 1}"]
 
 [[credentials]]
 access_key = "must-not-leak"
@@ -119,8 +172,12 @@ test("falls back to the real OpenLake RPC listener when the dedicated telemetry 
   context.after(() => rm(directory, { force: true, recursive: true }));
   const configPath = join(directory, "openlake.toml");
   await writeFile(configPath, `
+self_id = 0
+mode = "kv"
+kv_agents = ["127.0.0.1:${address.port}"]
+
 [[nodes]]
-id = 4
+id = 0
 rpc_addr = "127.0.0.1:${address.port}"
 disk_count = 0
 `);
@@ -149,6 +206,10 @@ test("serves nested RSC routes through the application worker", async context =>
   context.after(() => rm(directory, { force: true, recursive: true }));
   const configPath = join(directory, "openlake.toml");
   await writeFile(configPath, `
+self_id = 0
+mode = "kv"
+kv_agents = ["127.0.0.1:${telemetryAddress.port - 1}"]
+
 [[nodes]]
 id = 0
 rpc_addr = "127.0.0.1:${telemetryAddress.port - 1}"

--- a/console/tests/rendered-html.test.mjs
+++ b/console/tests/rendered-html.test.mjs
@@ -62,8 +62,9 @@ test("ships Dashboard, Topology, and Fleet as the only product routes", async ()
 });
 
 test("ships no demo telemetry path", async () => {
-  const [dataSource, packageJson, layout, styles, shell, gitignore] = await Promise.all([
+  const [dataSource, dashboardSource, packageJson, layout, styles, shell, gitignore] = await Promise.all([
     readFile(new URL("app/control-plane-data.ts", projectRoot), "utf8"),
+    readFile(new URL("app/control-plane.tsx", projectRoot), "utf8"),
     readFile(new URL("package.json", projectRoot), "utf8"),
     readFile(new URL("app/layout.tsx", projectRoot), "utf8"),
     readFile(new URL("app/globals.css", projectRoot), "utf8"),
@@ -74,6 +75,8 @@ test("ships no demo telemetry path", async () => {
   assert.doesNotMatch(dataSource, /demoControlPlane|DEMO_MODE|demo-control-plane/);
   assert.match(dataSource, /snapshot: null,[\s\S]*loading: true,[\s\S]*error: null/);
   assert.match(dataSource, /fetch\("\/api\/control-plane\/snapshot"/);
+  assert.match(dashboardSource, /value: formatCount\(openLakeServed\?\.tokens \?\? 0\)/);
+  assert.doesNotMatch(dashboardSource, /vLLM GPU KV cache|Current engine utilization/);
   assert.match(gitignore, /\/app\/demo\/\*\.json/);
   assert.doesNotMatch(packageJson, /react-loading-skeleton/);
   assert.doesNotMatch(layout, /og\.png|summary_large_image/);

--- a/console/tests/topology-model.test.mjs
+++ b/console/tests/topology-model.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildFabricTopology, buildTopologyGroups, shouldRenderAsHostDeviceRail } from "../app/nodes/topology-model.ts";
+import { buildFabricLayoutGroups, buildFabricTopology, buildTopologyGroups, shouldRenderAsHostDeviceRail } from "../app/nodes/topology-model.ts";
 
 function hardware(overrides = {}) {
   return {
@@ -187,6 +187,54 @@ test("does not invent a backbone from a one-sided or failed probe", () => {
   assert.deepEqual(topology.backbones, []);
   assert.deepEqual(topology.isolatedNodeIds, [0, 1, 2]);
   assert.equal(topology.unverifiedLinkCount, 1);
+});
+
+test("places two unverified nodes without inventing a fabric rail", () => {
+  const topology = buildFabricTopology([
+    node(0, [ucxPeer(1, "rc_mlx5", "mlx5_ib1:1")]),
+    node(1, [ucxPeer(0, "rc_mlx5", "mlx5_ib0:1", false)]),
+  ]);
+  const [layout] = buildFabricLayoutGroups(topology);
+
+  assert.equal(layout.columns, 2);
+  assert.equal(layout.splitRows, false);
+  assert.equal(layout.showRail, false);
+  assert.deepEqual(layout.placements, [
+    { id: 0, column: 1, row: 1, side: "above" },
+    { id: 1, column: 2, row: 1, side: "above" },
+  ]);
+});
+
+test("keeps two-node placement stable when a fabric becomes reciprocal", () => {
+  const unverified = buildFabricLayoutGroups(buildFabricTopology([
+    node(0, [ucxPeer(1, "rc_mlx5", "mlx5_ib1:1")]),
+    node(1, [ucxPeer(0, "rc_mlx5", "mlx5_ib0:1", false)]),
+  ]))[0];
+  const verified = buildFabricLayoutGroups(buildFabricTopology([
+    node(0, [ucxPeer(1, "rc_mlx5", "mlx5_ib1:1")]),
+    node(1, [ucxPeer(0, "rc_mlx5", "mlx5_ib0:1")]),
+  ]))[0];
+
+  assert.deepEqual(verified.placements, unverified.placements);
+  assert.equal(verified.columns, unverified.columns);
+});
+
+test("packs larger fabric groups into stable rows around the rail", () => {
+  const [layout] = buildFabricLayoutGroups({
+    backbones: [],
+    isolatedNodeIds: [0, 1, 2, 3, 4],
+    unverifiedLinkCount: 0,
+  });
+
+  assert.equal(layout.columns, 3);
+  assert.equal(layout.splitRows, true);
+  assert.deepEqual(layout.placements, [
+    { id: 0, column: 1, row: 1, side: "above" },
+    { id: 1, column: 1, row: 3, side: "below" },
+    { id: 2, column: 2, row: 1, side: "above" },
+    { id: 3, column: 2, row: 3, side: "below" },
+    { id: 4, column: 3, row: 1, side: "above" },
+  ]);
 });
 
 test("labels a reciprocal TCP path as TCP rather than InfiniBand", () => {


### PR DESCRIPTION
 - Use the ordered kv_agents list as the console fleet inventory.
 - Keep node placement stable as fabric health changes.
 - Display fabric rails only for reciprocal UCX/RDMA observations.
 - Improve topology pan and zoom responsiveness.
