### PR TITLE
feat(helm): add Kubernetes orchestration for OpenLake KV

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,20 @@
     cancel-in-progress: true
 
   jobs:
+    helm:
+      name: helm chart
+      runs-on: ubuntu-latest
+      timeout-minutes: 5
+      steps:
+        - uses: actions/checkout@v4
+
+        - uses: azure/setup-helm@v5.0.1
+          with:
+            version: v4.2.0
+
+        - name: lint and render chart
+          run: charts/openlake/tests/render.sh
+
     test:
       name: cargo test
       runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ vllm serve <model_name> --kv-transfer-config '{"kv_connector":"OpenLakeConnector
 
 Note: By default OpenLake offloads to the same host. To enable OpenLake across your GPU fleet, please start `openlaked` with a `--config`.
 
+For Kubernetes clusters, use the [Helm KV deployment guide](charts/openlake/README.md)
+to place one OpenLake instance on each selected node and generate the ordered
+vLLM peer configuration.
+
 OpenLake enabled vs disabled:
 
 <img width="1914" height="720" alt="openlake-video" src="https://raw.githubusercontent.com/openlake-project/openlake/main/assets/openlake-perf.gif" />

--- a/charts/openlake/Chart.yaml
+++ b/charts/openlake/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: openlake
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
-description: openlake high performance object storage for GPU workloads
+version: 0.2.0
+appVersion: "0.8.0"
+description: OpenLake object storage and KV cache engine for GPU workloads
 kubeVersion: ">=1.28.0-0"
 icon: https://openlake.dev/favicon.png
 sources:

--- a/charts/openlake/README.md
+++ b/charts/openlake/README.md
@@ -1,0 +1,233 @@
+# OpenLake Helm chart
+
+This chart supports two separate OpenLake workloads:
+
+- Object storage is the existing default deployment.
+- External KV-cache offload is enabled with `kv.enabled=true`.
+
+Do not combine the object-storage `nodes`, disks, or credentials with the KV
+settings. A KV process owns one in-memory slab and is standalone; `kv_agents`
+is only its ordered list of KV peers.
+
+## What the KV deployment creates
+
+Given this ordered target list:
+
+```yaml
+kv:
+  enabled: true
+  targets:
+    - nodeName: gpu-worker-0
+      ip: 10.0.0.11
+    - nodeName: gpu-worker-1
+      ip: 10.0.0.12
+```
+
+the chart creates:
+
+- one ConfigMap containing the ordered IP set, an OpenLake TOML template, and
+  optionally the vLLM connector JSON;
+- one headless Service for RPC and telemetry discovery; and
+- one host-networked StatefulSet replica on each named Kubernetes node.
+
+Required node affinity limits placement to the listed node names. Required pod
+anti-affinity places at most one replica on each node. A pod derives `self_id`
+from the node on which Kubernetes schedules it, rather than assuming that a
+StatefulSet ordinal maps to a particular machine. Every pod consequently gets:
+
+```text
+gpu-worker-0 / 10.0.0.11 -> self_id 0
+gpu-worker-1 / 10.0.0.12 -> self_id 1
+```
+
+Every generated server configuration has the same ordered `kv_agents` list but
+only its own entry in `[[nodes]]`. The generated vLLM `openlake_nodes` list uses
+that exact order, so every vLLM instance can attach the same peer IDs.
+
+## Prerequisites
+
+- Kubernetes 1.28 or newer and Helm.
+- Exact Kubernetes `.metadata.name` values for all target nodes.
+- A unique, stable IPv4 address for each target. It must be reachable by every vLLM
+  instance and must belong to the intended host/fabric; the chart deliberately
+  does not guess which of a node's addresses is the data-plane address.
+- An OpenLake image matching the chosen transport.
+- Enough allocatable RAM for `kv.slab.capacityGB` plus process and operating
+  system overhead. Set a memory request/limit above the slab size.
+
+The chart mounts a memory-backed `emptyDir` of `kv.slab.capacityGB` at
+`/dev/shm`, where host-backed H2 and UCX slabs are created. This memory counts
+against pod/node memory; it is not persistent storage.
+
+Inspect the node names and Kubernetes InternalIPs with:
+
+```bash
+kubectl get nodes -o wide
+```
+
+For RDMA, also verify the actual device and transport on every selected host;
+do not infer them from the sample values:
+
+```bash
+ibv_devices
+ibv_devinfo
+rdma link
+ucx_info -d
+```
+
+## H2 orchestration smoke test
+
+Start with [`examples/kv-h2-values.yaml`](examples/kv-h2-values.yaml). Replace
+the sample node names and IPs, then render it before installation:
+
+```bash
+helm lint charts/openlake -f charts/openlake/examples/kv-h2-values.yaml
+helm template openlake charts/openlake \
+  -f charts/openlake/examples/kv-h2-values.yaml
+```
+
+Install or update it with:
+
+```bash
+helm upgrade --install openlake charts/openlake \
+  --namespace openlake \
+  --create-namespace \
+  -f charts/openlake/examples/kv-h2-values.yaml
+```
+
+H2 is useful for validating Helm rendering, placement, process startup, and
+health without IB/UCX. It is not a multi-node KV data transport. The `local`
+client opens POSIX shared memory on the vLLM host, so it cannot map a remote
+server's slab. For that reason the multi-node H2 example disables connector
+output, and the chart rejects an enabled H2 connector with multiple targets.
+
+A one-target H2 connector is valid only when vLLM and OpenLake share the host
+and compatible IPC/shared-memory access. Kubernetes pod co-location by itself
+does not create shared IPC namespaces.
+
+## Production P2P transport
+
+Use [`examples/kv-ucx-values.yaml`](examples/kv-ucx-values.yaml) for UCX or
+[`examples/kv-dct-values.yaml`](examples/kv-dct-values.yaml) for direct
+verbs/DCT. Replace the example image with an OpenLake image built on Linux with
+the `rdma` feature and the matching runtime libraries.
+
+For UCX:
+
+```yaml
+kv:
+  transport: rdma
+  rdma:
+    backend: ucx
+  connector:
+    enabled: true
+    device: "" # automatically becomes "ucx"
+```
+
+For DCT:
+
+```yaml
+kv:
+  transport: rdma
+  rdma:
+    backend: dct
+    devName: mlx5_0
+  connector:
+    enabled: true
+    device: "" # automatically becomes rdma.devName
+```
+
+The RDMA deployment mounts `/dev/infiniband` and grants `IPC_LOCK` and
+`NET_RAW`. It does not install drivers, a Kubernetes device plugin, OFED, UCX,
+or configure the IB/RoCE fabric. Those remain cluster-operator responsibilities.
+`kv.rdma.env` can pass settings such as `UCX_NET_DEVICES` after they have been
+verified on the target hosts.
+
+## Give every vLLM instance the peer list
+
+For an RDMA deployment with `kv.connector.enabled=true`, inspect the generated
+connector configuration:
+
+```bash
+kubectl --namespace openlake get configmap openlake-openlake-kv-config \
+  --output jsonpath='{.data.vllm-kv-transfer-config\.json}'
+```
+
+The value can be passed to `vllm serve --kv-transfer-config` or mounted from
+the ConfigMap by a separately managed vLLM Deployment. This chart does not
+install or restart vLLM. Every vLLM instance must receive the same rendered
+JSON; in particular, do not reorder `openlake_nodes` in a second manifest.
+
+Example output for UCX is:
+
+```json
+{
+  "kv_connector": "OpenLakeConnector",
+  "kv_connector_module_path": "openlake_client.openlake_connector",
+  "kv_role": "kv_both",
+  "kv_connector_extra_config": {
+    "openlake_nodes": ["10.0.0.11:9400", "10.0.0.12:9400"],
+    "openlake_device": "ucx"
+  }
+}
+```
+
+## Validate an installation
+
+Check scheduling and startup without changing the cluster:
+
+```bash
+kubectl --namespace openlake get pods \
+  --selector app.kubernetes.io/instance=openlake \
+  --output wide
+kubectl --namespace openlake rollout status statefulset/openlake-openlake
+kubectl --namespace openlake logs statefulset/openlake-openlake
+```
+
+Each log should report its list-derived node ID and selected Kubernetes node.
+The readiness probe requests `/v1/telemetry/openlake` on
+`kv.ports.telemetry`. To inspect one response locally:
+
+```bash
+kubectl --namespace openlake port-forward pod/openlake-openlake-0 9401:9401
+curl http://127.0.0.1:9401/v1/telemetry/openlake
+```
+
+For production correctness, health is only the first check. Initialize the
+matching OpenLake connector from vLLM, attach every listed peer, register the
+same memory type used in production, put known KV blocks, read them into a
+cleared destination, synchronize the GPU when applicable, and compare the
+retrieved bytes.
+
+## Updates and failure modes
+
+- `helm upgrade` regenerates the ConfigMap and rolls KV pods when any KV value
+  changes. There is no continuously running ConfigMap controller.
+- Adding, removing, or reordering targets changes peer IDs and cache placement.
+  Coordinate that change with all vLLM deployments and restart them with the
+  newly generated connector JSON. Treat the KV slab as an ephemeral cache.
+- A `Pending` pod usually means a `nodeName` does not exist, a target node is
+  unschedulable, another process owns a host port, or requested memory is not
+  available. Inspect `kubectl describe pod <pod-name>`.
+- An RDMA pod that cannot open `/dev/infiniband` or load UCX needs its host,
+  device-plugin, image, library, and permissions checked. The chart cannot make
+  a missing or incompatible transport healthy.
+- Target IPs are deliberately not required to equal Kubernetes InternalIPs;
+  they may be dedicated RDMA addresses. A wrong or unreachable address will
+  still render successfully and must be caught by cluster validation.
+
+## Main KV values
+
+| Value | Meaning | Default |
+| --- | --- | --- |
+| `kv.enabled` | Select external KV-cache mode | `false` |
+| `kv.transport` | Server transport: `h2` or `rdma` | `h2` |
+| `kv.targets` | Ordered `{nodeName, ip}` identity and placement list | `[]` |
+| `kv.ports.rpc` | Host-networked OpenLake RPC port | `9400` |
+| `kv.ports.telemetry` | Host-networked health/telemetry port | `9401` |
+| `kv.slab.capacityGB` | Explicit per-node in-memory slab capacity | `1` |
+| `kv.rdma.backend` | RDMA backend: `ucx` or `dct` | `ucx` |
+| `kv.rdma.devName` | Observed device required by DCT | `""` |
+| `kv.rdma.env` | Environment-specific UCX/RDMA variables | `{}` |
+| `kv.connector.enabled` | Include vLLM connector JSON in the ConfigMap | `true` |
+| `kv.connector.device` | Explicit connector device; empty selects by backend | `""` |

--- a/charts/openlake/README.md
+++ b/charts/openlake/README.md
@@ -51,7 +51,8 @@ that exact order, so every vLLM instance can attach the same peer IDs.
 - A unique, stable IPv4 address for each target. It must be reachable by every vLLM
   instance and must belong to the intended host/fabric; the chart deliberately
   does not guess which of a node's addresses is the data-plane address.
-- An OpenLake image matching the chosen transport.
+- An OpenLake image matching the chosen transport, pushed to a registry that
+  every selected node can pull from.
 - Enough allocatable RAM for `kv.slab.capacityGB` plus process and operating
   system overhead. Set a memory request/limit above the slab size.
 
@@ -78,7 +79,16 @@ ucx_info -d
 ## H2 orchestration smoke test
 
 Start with [`examples/kv-h2-values.yaml`](examples/kv-h2-values.yaml). Replace
-the sample node names and IPs, then render it before installation:
+the placeholder image repository, sample node names, and IPs. An H2 image can
+be built from this repository and pushed to your registry with:
+
+```bash
+docker build --file docker/openlaked.Dockerfile \
+  --tag registry.example.com/openlake/openlaked:0.8.0 .
+docker push registry.example.com/openlake/openlaked:0.8.0
+```
+
+Then render it before installation:
 
 ```bash
 helm lint charts/openlake -f charts/openlake/examples/kv-h2-values.yaml

--- a/charts/openlake/README.md
+++ b/charts/openlake/README.md
@@ -25,8 +25,8 @@ kv:
 
 the chart creates:
 
-- one ConfigMap containing the ordered IP set, an OpenLake TOML template, and
-  optionally the vLLM connector JSON;
+- one ConfigMap containing the ordered IP set (`target-ips`), the node identity
+  mapping, an OpenLake TOML template, and optionally the vLLM connector JSON;
 - one headless Service for RPC and telemetry discovery; and
 - one host-networked StatefulSet replica on each named Kubernetes node.
 
@@ -141,7 +141,8 @@ The RDMA deployment mounts `/dev/infiniband` and grants `IPC_LOCK` and
 `NET_RAW`. It does not install drivers, a Kubernetes device plugin, OFED, UCX,
 or configure the IB/RoCE fabric. Those remain cluster-operator responsibilities.
 `kv.rdma.env` can pass settings such as `UCX_NET_DEVICES` after they have been
-verified on the target hosts.
+verified on the target hosts. The same ordered IP list is available to each KV
+pod at `/etc/openlake/target-ips` for cluster-managed handshake automation.
 
 ## Give every vLLM instance the peer list
 

--- a/charts/openlake/README.md
+++ b/charts/openlake/README.md
@@ -151,11 +151,15 @@ helm upgrade --install openlake charts/openlake \
 kubectl --namespace openlake rollout status statefulset/openlake-openlake
 ```
 
-Run the test and stream its logs:
+Run the test, then read the retained Job logs:
 
 ```bash
-helm test openlake --namespace openlake --logs --timeout 20m
+helm test openlake --namespace openlake --timeout 20m
+kubectl --namespace openlake logs job/openlake-openlake-vllm-smoke
 ```
+
+The completed Job and its logs are retained for 10 minutes. The next test run
+also removes the previous Job before creating its replacement.
 
 The default `facebook/opt-125m` model is intentionally small and public because
 this test checks startup and connector configuration, not model quality. Set

--- a/charts/openlake/README.md
+++ b/charts/openlake/README.md
@@ -56,9 +56,11 @@ that exact order, so every vLLM instance can attach the same peer IDs.
 - Enough allocatable RAM for `kv.slab.capacityGB` plus process and operating
   system overhead. Set a memory request/limit above the slab size.
 
-The chart mounts a memory-backed `emptyDir` of `kv.slab.capacityGB` at
-`/dev/shm`, where host-backed H2 and UCX slabs are created. This memory counts
-against pod/node memory; it is not persistent storage.
+By default, the chart mounts a memory-backed `emptyDir` of
+`kv.slab.capacityGB` at `/dev/shm`, where host-backed H2 and UCX slabs are
+created. This memory counts against pod/node memory; it is not persistent
+storage. The opt-in vLLM smoke test is the sole example that selects a host
+`/dev/shm` mount so its two co-located pods can see the same POSIX object.
 
 Inspect the node names and Kubernetes InternalIPs with:
 
@@ -115,6 +117,56 @@ A one-target H2 connector is valid only when vLLM and OpenLake share the host
 and compatible IPC/shared-memory access. Kubernetes pod co-location by itself
 does not create shared IPC namespaces.
 
+## One-time vLLM CPU startup test
+
+The optional [`vllm-smoke-test.yaml`](templates/vllm-smoke-test.yaml) Helm test
+checks the maintainer-facing integration point that static rendering cannot:
+a real vLLM process reads the generated connector JSON, initializes against a
+running OpenLake H2 server, and reaches its health endpoint. The test Job exits
+after success and is not a production vLLM Deployment.
+
+The test uses one target node and mounts that host's `/dev/shm` into both pods.
+This is deliberately limited to the H2 smoke test. It does not make H2 a
+cross-node transport and should not be copied into the RDMA deployment.
+
+Build and push the OpenLake server image as described above. Then build the
+CPU vLLM test image, which adds the locally built `openlake-vllm` wheel to the
+[official vLLM CPU image](https://docs.vllm.ai/en/stable/getting_started/installation/cpu/):
+
+```bash
+docker build --file docker/vllm-openlake-cpu.Dockerfile \
+  --tag registry.example.com/openlake/vllm-openlake-cpu:0.26.0-openlake-0.8.0 .
+docker push registry.example.com/openlake/vllm-openlake-cpu:0.26.0-openlake-0.8.0
+```
+
+Copy [`examples/kv-vllm-smoke-values.yaml`](examples/kv-vllm-smoke-values.yaml)
+and replace its node name, node IP, and two image repositories. If the registry
+is private, configure `imagePullSecrets`. Install the single-node H2 release:
+
+```bash
+helm upgrade --install openlake charts/openlake \
+  --namespace openlake \
+  --create-namespace \
+  -f charts/openlake/examples/kv-vllm-smoke-values.yaml
+kubectl --namespace openlake rollout status statefulset/openlake-openlake
+```
+
+Run the test and stream its logs:
+
+```bash
+helm test openlake --namespace openlake --logs --timeout 20m
+```
+
+The default `facebook/opt-125m` model is intentionally small and public because
+this test checks startup and connector configuration, not model quality. Set
+`vllmSmokeTest.model` to the agreed Llama or Mistral model for a larger test. If
+that model needs a Hugging Face token, create a Secret whose `token` key holds
+it and set `vllmSmokeTest.hfTokenSecretName` to the Secret name.
+
+The Job passing proves that the command accepts `openlake_nodes` and that the
+H2 connector can attach on the same node. It does not validate multi-node KV
+transfer, GPU memory registration, RDMA, DCT, or UCX.
+
 ## Production P2P transport
 
 Use [`examples/kv-ucx-values.yaml`](examples/kv-ucx-values.yaml) for UCX or
@@ -165,9 +217,10 @@ kubectl --namespace openlake get configmap openlake-openlake-kv-config \
 ```
 
 The value can be passed to `vllm serve --kv-transfer-config` or mounted from
-the ConfigMap by a separately managed vLLM Deployment. This chart does not
-install or restart vLLM. Every vLLM instance must receive the same rendered
-JSON; in particular, do not reorder `openlake_nodes` in a second manifest.
+the ConfigMap by a separately managed vLLM Deployment. Apart from the optional,
+short-lived smoke-test Job, this chart does not install or restart vLLM. Every
+vLLM instance must receive the same rendered JSON; in particular, do not
+reorder `openlake_nodes` in a second manifest.
 
 Example output for UCX is:
 
@@ -237,8 +290,11 @@ retrieved bytes.
 | `kv.ports.rpc` | Host-networked OpenLake RPC port | `9400` |
 | `kv.ports.telemetry` | Host-networked health/telemetry port | `9401` |
 | `kv.slab.capacityGB` | Explicit per-node in-memory slab capacity | `1` |
+| `kv.sharedMemory.type` | `emptyDir`, or test-only shared `hostPath` | `emptyDir` |
 | `kv.rdma.backend` | RDMA backend: `ucx` or `dct` | `ucx` |
 | `kv.rdma.devName` | Observed device required by DCT | `""` |
 | `kv.rdma.env` | Environment-specific UCX/RDMA variables | `{}` |
 | `kv.connector.enabled` | Include vLLM connector JSON in the ConfigMap | `true` |
 | `kv.connector.device` | Explicit connector device; empty selects by backend | `""` |
+| `vllmSmokeTest.enabled` | Render the optional CPU `helm test` Job | `false` |
+| `vllmSmokeTest.model` | Model used for startup validation | `facebook/opt-125m` |

--- a/charts/openlake/examples/kv-dct-values.yaml
+++ b/charts/openlake/examples/kv-dct-values.yaml
@@ -1,0 +1,45 @@
+# Multi-node P2P KV deployment using the direct-verbs/DCT backend. Use only a
+# DCT-capable RDMA device observed on every selected Kubernetes node.
+image:
+  repository: registry.example.com/openlake/openlaked-rdma
+  tag: "0.8.0"
+
+kv:
+  enabled: true
+  transport: rdma
+
+  targets:
+    - nodeName: gpu-worker-0
+      ip: 10.0.0.11
+    - nodeName: gpu-worker-1
+      ip: 10.0.0.12
+
+  slab:
+    capacityGB: 64
+    reserveTtlSeconds: 60
+
+  rdma:
+    backend: dct
+    devName: mlx5_0
+    dcKey: "4919"
+    srqDepth: 4096
+    maxSendWr: 256
+    peerCredit: 4
+    maxClients: 512
+    qos:
+      trafficClass: 0
+      serviceLevel: 0
+    env: {}
+
+  connector:
+    enabled: true
+    # Empty automatically uses rdma.devName (`mlx5_0`) for the connector.
+    device: ""
+
+  resources:
+    requests:
+      cpu: "2"
+      memory: 68Gi
+    limits:
+      cpu: "4"
+      memory: 68Gi

--- a/charts/openlake/examples/kv-h2-values.yaml
+++ b/charts/openlake/examples/kv-h2-values.yaml
@@ -1,0 +1,37 @@
+# H2 starts one OpenLake KV instance on each selected node without requiring
+# IB, RDMA, or UCX. This two-node file is an orchestration/startup example only:
+# the H2 client uses same-host POSIX shared memory and cannot move KV data
+# between Kubernetes nodes.
+image:
+  repository: openlake/openlaked
+  tag: "0.8.0"
+
+kv:
+  enabled: true
+  transport: h2
+
+  # List order defines OpenLake node IDs: gpu-worker-0 is ID 0 and
+  # gpu-worker-1 is ID 1. Use exact values from `kubectl get nodes -o wide`.
+  targets:
+    - nodeName: gpu-worker-0
+      ip: 10.0.0.11
+    - nodeName: gpu-worker-1
+      ip: 10.0.0.12
+
+  slab:
+    capacityGB: 8
+    reserveTtlSeconds: 60
+
+  # Do not publish a multi-node local connector configuration. H2 can validate
+  # this chart and server health, but P2P vLLM traffic requires RDMA/UCX.
+  connector:
+    enabled: false
+    device: ""
+
+  resources:
+    requests:
+      cpu: "1"
+      memory: 10Gi
+    limits:
+      cpu: "2"
+      memory: 10Gi

--- a/charts/openlake/examples/kv-h2-values.yaml
+++ b/charts/openlake/examples/kv-h2-values.yaml
@@ -3,7 +3,7 @@
 # the H2 client uses same-host POSIX shared memory and cannot move KV data
 # between Kubernetes nodes.
 image:
-  repository: openlake/openlaked
+  repository: registry.example.com/openlake/openlaked
   tag: "0.8.0"
 
 kv:

--- a/charts/openlake/examples/kv-ucx-values.yaml
+++ b/charts/openlake/examples/kv-ucx-values.yaml
@@ -1,0 +1,45 @@
+# Multi-node P2P KV deployment over UCX. The cluster operator must provision
+# the IB/RoCE fabric, device plugin, UCX runtime, and an RDMA-enabled OpenLake
+# image before using this file.
+image:
+  repository: registry.example.com/openlake/openlaked-rdma
+  tag: "0.8.0"
+
+kv:
+  enabled: true
+  transport: rdma
+
+  # This exact order is copied to every OpenLake config and to the generated
+  # vLLM connector configuration. Reordering changes the node IDs used for key
+  # placement, so treat this as stable cluster identity.
+  targets:
+    - nodeName: gpu-worker-0
+      ip: 10.0.0.11
+    - nodeName: gpu-worker-1
+      ip: 10.0.0.12
+
+  slab:
+    capacityGB: 64
+    reserveTtlSeconds: 60
+
+  rdma:
+    backend: ucx
+    devName: ""
+    # Set only values verified for the target cluster. Examples:
+    # env:
+    #   UCX_NET_DEVICES: mlx5_0:1
+    #   UCX_TLS: rc,cuda_copy,cuda_ipc
+    env: {}
+
+  connector:
+    enabled: true
+    # Empty automatically selects `ucx` for this backend.
+    device: ""
+
+  resources:
+    requests:
+      cpu: "2"
+      memory: 68Gi
+    limits:
+      cpu: "4"
+      memory: 68Gi

--- a/charts/openlake/examples/kv-vllm-smoke-values.yaml
+++ b/charts/openlake/examples/kv-vllm-smoke-values.yaml
@@ -1,0 +1,52 @@
+# One-node, CPU-only integration test. Replace the node, IP, and both image
+# repositories before installing. This is not a production P2P deployment.
+image:
+  repository: registry.example.com/openlake/openlaked
+  tag: "0.8.0"
+
+kv:
+  enabled: true
+  transport: h2
+  targets:
+    - nodeName: gpu-worker-0
+      ip: 10.0.0.11
+  slab:
+    capacityGB: 1
+    reserveTtlSeconds: 60
+  sharedMemory:
+    # The OpenLake and vLLM test pods must see the same POSIX shared memory.
+    # Never use this to imply that H2 works between different hosts.
+    type: hostPath
+    hostPath: /dev/shm
+  connector:
+    enabled: true
+    device: ""
+  resources:
+    requests:
+      cpu: "1"
+      memory: 2Gi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+
+vllmSmokeTest:
+  enabled: true
+  image:
+    repository: registry.example.com/openlake/vllm-openlake-cpu
+    tag: "0.26.0-openlake-0.8.0"
+    pullPolicy: IfNotPresent
+  # This public 125M-parameter model keeps a startup-only CPU test small. It
+  # can be replaced with meta-llama/Llama-3.2-1B-Instruct or the agreed model.
+  model: facebook/opt-125m
+  port: 8000
+  maxModelLen: 512
+  startupTimeoutSeconds: 900
+  hfTokenSecretName: ""
+  env: {}
+  resources:
+    requests:
+      cpu: "2"
+      memory: 4Gi
+    limits:
+      cpu: "4"
+      memory: 8Gi

--- a/charts/openlake/templates/NOTES.txt
+++ b/charts/openlake/templates/NOTES.txt
@@ -16,7 +16,9 @@ Read the generated vLLM connector configuration:
 
 After the OpenLake StatefulSet is ready, run the one-time CPU vLLM test:
   helm test {{ .Release.Name }} --namespace {{ .Release.Namespace }} \
-    --logs --timeout 20m
+    --timeout 20m
+  kubectl --namespace {{ .Release.Namespace }} logs \
+    job/{{ include "openlake.vllmSmokeTest.fullname" . }}
 {{- end }}
 {{- else }}
 The vLLM connector output is disabled. Multi-node H2 validates orchestration

--- a/charts/openlake/templates/NOTES.txt
+++ b/charts/openlake/templates/NOTES.txt
@@ -12,6 +12,12 @@ Read the generated vLLM connector configuration:
   kubectl --namespace {{ .Release.Namespace }} get configmap \
     {{ include "openlake.fullname" . }}-kv-config \
     --output jsonpath='{.data.vllm-kv-transfer-config\.json}'
+{{- if .Values.vllmSmokeTest.enabled }}
+
+After the OpenLake StatefulSet is ready, run the one-time CPU vLLM test:
+  helm test {{ .Release.Name }} --namespace {{ .Release.Namespace }} \
+    --logs --timeout 20m
+{{- end }}
 {{- else }}
 The vLLM connector output is disabled. Multi-node H2 validates orchestration
 and server health only; use an RDMA backend for cross-node KV-cache traffic.

--- a/charts/openlake/templates/NOTES.txt
+++ b/charts/openlake/templates/NOTES.txt
@@ -1,0 +1,25 @@
+{{- if .Values.kv.enabled }}
+OpenLake KV was configured for {{ len .Values.kv.targets }} target node(s).
+
+Check placement and health:
+  kubectl --namespace {{ .Release.Namespace }} get pods \
+    --selector app.kubernetes.io/instance={{ .Release.Name }} --output wide
+  kubectl --namespace {{ .Release.Namespace }} rollout status \
+    statefulset/{{ include "openlake.fullname" . }}
+
+{{- if .Values.kv.connector.enabled }}
+Read the generated vLLM connector configuration:
+  kubectl --namespace {{ .Release.Namespace }} get configmap \
+    {{ include "openlake.fullname" . }}-kv-config \
+    --output jsonpath='{.data.vllm-kv-transfer-config\.json}'
+{{- else }}
+The vLLM connector output is disabled. Multi-node H2 validates orchestration
+and server health only; use an RDMA backend for cross-node KV-cache traffic.
+{{- end }}
+{{- else }}
+OpenLake object storage was installed.
+
+Check the StatefulSet:
+  kubectl --namespace {{ .Release.Namespace }} get pods \
+    --selector app.kubernetes.io/instance={{ .Release.Name }}
+{{- end }}

--- a/charts/openlake/templates/_helpers.tpl
+++ b/charts/openlake/templates/_helpers.tpl
@@ -50,6 +50,12 @@ ucx
   {{- if not (has .Values.kv.transport (list "h2" "rdma")) -}}
     {{- fail "kv.transport must be h2 or rdma" -}}
   {{- end -}}
+  {{- if gt (len .Values.kv.targets) 65536 -}}
+    {{- fail "kv.targets cannot contain more than 65536 entries (OpenLake node IDs are u16)" -}}
+  {{- end -}}
+  {{- if and .Values.kv.connector.enabled (eq .Values.kv.transport "h2") (gt (len .Values.kv.targets) 1) -}}
+    {{- fail "the H2/local connector supports one same-host KV target only; disable kv.connector.enabled for a multi-node H2 orchestration smoke test or use the rdma transport" -}}
+  {{- end -}}
   {{- if eq (int .Values.kv.ports.rpc) (int .Values.kv.ports.telemetry) -}}
     {{- fail "kv.ports.rpc and kv.ports.telemetry must be different" -}}
   {{- end -}}

--- a/charts/openlake/templates/_helpers.tpl
+++ b/charts/openlake/templates/_helpers.tpl
@@ -30,6 +30,10 @@ app.kubernetes.io/name: {{ include "openlake.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
+{{- define "openlake.vllmSmokeTest.fullname" -}}
+{{- printf "%s-vllm-smoke" (include "openlake.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{- define "openlake.kv.connectorDevice" -}}
 {{- if .Values.kv.connector.device -}}
 {{- .Values.kv.connector.device -}}
@@ -39,6 +43,27 @@ local
 ucx
 {{- else -}}
 {{- .Values.kv.rdma.devName -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "openlake.vllmSmokeTest.validate" -}}
+{{- if .Values.vllmSmokeTest.enabled -}}
+  {{- if not .Values.kv.enabled -}}
+    {{- fail "vllmSmokeTest.enabled=true requires kv.enabled=true" -}}
+  {{- end -}}
+  {{- include "openlake.kv.validate" . -}}
+  {{- if ne .Values.kv.transport "h2" -}}
+    {{- fail "the CPU vLLM smoke test requires kv.transport=h2" -}}
+  {{- end -}}
+  {{- if ne (len .Values.kv.targets) 1 -}}
+    {{- fail "the H2/local vLLM smoke test requires exactly one kv.targets entry" -}}
+  {{- end -}}
+  {{- if not .Values.kv.connector.enabled -}}
+    {{- fail "the vLLM smoke test requires kv.connector.enabled=true" -}}
+  {{- end -}}
+  {{- if ne .Values.kv.sharedMemory.type "hostPath" -}}
+    {{- fail "the H2/local vLLM smoke test requires kv.sharedMemory.type=hostPath" -}}
+  {{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/openlake/templates/_helpers.tpl
+++ b/charts/openlake/templates/_helpers.tpl
@@ -17,10 +17,73 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
-openlake.dev/mode: {{ .Values.mode }}
+openlake.dev/mode: {{ if .Values.kv.enabled }}kv{{ else }}{{ .Values.mode }}{{ end }}
+{{- if .Values.kv.enabled }}
+openlake.dev/workload: kv
+{{- else }}
+openlake.dev/workload: storage
+{{- end }}
 {{- end -}}
 
 {{- define "openlake.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "openlake.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "openlake.kv.connectorDevice" -}}
+{{- if .Values.kv.connector.device -}}
+{{- .Values.kv.connector.device -}}
+{{- else if eq .Values.kv.transport "h2" -}}
+local
+{{- else if eq .Values.kv.rdma.backend "ucx" -}}
+ucx
+{{- else -}}
+{{- .Values.kv.rdma.devName -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "openlake.kv.validate" -}}
+{{- if .Values.kv.enabled -}}
+  {{- if not .Values.kv.targets -}}
+    {{- fail "kv.enabled=true requires at least one kv.targets entry" -}}
+  {{- end -}}
+  {{- if not (has .Values.kv.transport (list "h2" "rdma")) -}}
+    {{- fail "kv.transport must be h2 or rdma" -}}
+  {{- end -}}
+  {{- if eq (int .Values.kv.ports.rpc) (int .Values.kv.ports.telemetry) -}}
+    {{- fail "kv.ports.rpc and kv.ports.telemetry must be different" -}}
+  {{- end -}}
+  {{- if lt (int .Values.kv.slab.capacityGB) 1 -}}
+    {{- fail "kv.slab.capacityGB must be at least 1" -}}
+  {{- end -}}
+  {{- $nodes := dict -}}
+  {{- $ips := dict -}}
+  {{- range $index, $target := .Values.kv.targets -}}
+    {{- if not $target.nodeName -}}
+      {{- fail (printf "kv.targets[%d].nodeName is required" $index) -}}
+    {{- end -}}
+    {{- if not $target.ip -}}
+      {{- fail (printf "kv.targets[%d].ip is required" $index) -}}
+    {{- end -}}
+    {{- if hasKey $nodes $target.nodeName -}}
+      {{- fail (printf "kv.targets contains duplicate nodeName %q" $target.nodeName) -}}
+    {{- end -}}
+    {{- if hasKey $ips $target.ip -}}
+      {{- fail (printf "kv.targets contains duplicate ip %q" $target.ip) -}}
+    {{- end -}}
+    {{- $_ := set $nodes $target.nodeName true -}}
+    {{- $_ := set $ips $target.ip true -}}
+  {{- end -}}
+  {{- if eq .Values.kv.transport "rdma" -}}
+    {{- if not (has .Values.kv.rdma.backend (list "dct" "ucx")) -}}
+      {{- fail "kv.rdma.backend must be dct or ucx" -}}
+    {{- end -}}
+    {{- if and (eq .Values.kv.rdma.backend "dct") (not .Values.kv.rdma.devName) -}}
+      {{- fail "kv.rdma.devName is required for the dct backend" -}}
+    {{- end -}}
+    {{- if and (eq .Values.kv.rdma.backend "dct") (gt (mul (int .Values.kv.rdma.maxClients) (add1 (int .Values.kv.rdma.peerCredit))) (int .Values.kv.rdma.srqDepth)) -}}
+      {{- fail "kv.rdma.maxClients x (peerCredit + 1) must not exceed srqDepth" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
 {{- end -}}

--- a/charts/openlake/templates/configmap.yaml
+++ b/charts/openlake/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.kv.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -52,3 +53,4 @@ data:
         -e "s|__SECRET_KEY__|${OPENLAKE_SECRET_KEY}|g" \
         /etc/openlake/openlake.toml.tpl > /tmp/openlake.toml
     exec /usr/local/bin/openlaked --config /tmp/openlake.toml
+{{- end }}

--- a/charts/openlake/templates/kv-configmap.yaml
+++ b/charts/openlake/templates/kv-configmap.yaml
@@ -1,0 +1,106 @@
+{{- if .Values.kv.enabled }}
+{{- include "openlake.kv.validate" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openlake.fullname" . }}-kv-config
+  labels:
+    {{- include "openlake.labels" . | nindent 4 }}
+data:
+  targets: |
+    {{- range $index, $target := .Values.kv.targets }}
+    {{ $index }}|{{ $target.nodeName }}|{{ $target.ip }}
+    {{- end }}
+
+  openlake.toml.tpl: |
+    self_id              = __SELF_ID__
+    mode                 = "kv"
+    transport            = {{ .Values.kv.transport | quote }}
+    rpc_addr             = "0.0.0.0:{{ .Values.kv.ports.rpc }}"
+    kv_agents            = [
+    {{- range .Values.kv.targets }}
+      "{{ .ip }}:{{ $.Values.kv.ports.rpc }}",
+    {{- end }}
+    ]
+    s3_addr              = "127.0.0.1:9000"
+    region               = "us-east-1"
+    data_dirs            = []
+    set_drive_count      = 1
+    default_parity_count = 1
+
+    # These fields are required by the shared server schema but are unused in
+    # KV mode because the S3 listener is not started.
+    [[credentials]]
+    access_key = "unused-kv-access-key"
+    secret_key = "unused-kv-secret-key"
+
+    # KV engines are standalone. Do not copy the peer list into [[nodes]].
+    [[nodes]]
+    id         = __SELF_ID__
+    rpc_addr   = "0.0.0.0:{{ .Values.kv.ports.rpc }}"
+    disk_count = 0
+
+    [kv_slab]
+    capacity_gb          = {{ .Values.kv.slab.capacityGB }}
+    reserve_ttl_secs     = {{ .Values.kv.slab.reserveTtlSeconds }}
+    {{- if eq .Values.kv.transport "rdma" }}
+
+    [rdma]
+    backend = {{ .Values.kv.rdma.backend | quote }}
+      {{- if eq .Values.kv.rdma.backend "dct" }}
+    self_node_id = __SELF_ID__
+    dev_name     = {{ .Values.kv.rdma.devName | quote }}
+    dc_key       = {{ .Values.kv.rdma.dcKey }}
+    srq_depth    = {{ .Values.kv.rdma.srqDepth }}
+    max_send_wr  = {{ .Values.kv.rdma.maxSendWr }}
+    peer_credit  = {{ .Values.kv.rdma.peerCredit }}
+    max_clients  = {{ .Values.kv.rdma.maxClients }}
+
+    [rdma.qos]
+    traffic_class = {{ .Values.kv.rdma.qos.trafficClass }}
+    service_level = {{ .Values.kv.rdma.qos.serviceLevel }}
+      {{- end }}
+    {{- end }}
+
+  entrypoint.sh: |
+    #!/bin/sh
+    set -eu
+
+    self_id=""
+    target_ip=""
+    while IFS='|' read -r candidate_id candidate_node candidate_ip; do
+      if [ "${candidate_node}" = "${NODE_NAME}" ]; then
+        self_id="${candidate_id}"
+        target_ip="${candidate_ip}"
+        break
+      fi
+    done < /etc/openlake/targets
+
+    if [ -z "${self_id}" ]; then
+      echo "OpenLake target list has no entry for Kubernetes node ${NODE_NAME}" >&2
+      exit 1
+    fi
+
+    sed -e "s/__SELF_ID__/${self_id}/g" \
+      /etc/openlake/openlake.toml.tpl > /tmp/openlake.toml
+    echo "Starting OpenLake KV node ${self_id} on ${NODE_NAME} (${target_ip})"
+    exec /usr/local/bin/openlaked --config /tmp/openlake.toml
+  {{- if .Values.kv.connector.enabled }}
+
+  vllm-kv-transfer-config.json: |
+    {
+      "kv_connector": "OpenLakeConnector",
+      "kv_connector_module_path": "openlake_client.openlake_connector",
+      "kv_role": "kv_both",
+      "kv_connector_extra_config": {
+        "openlake_nodes": [
+          {{- range $index, $target := .Values.kv.targets }}
+          {{- if $index }},{{ end }}
+          "{{ $target.ip }}:{{ $.Values.kv.ports.rpc }}"
+          {{- end }}
+        ],
+        "openlake_device": {{ include "openlake.kv.connectorDevice" . | quote }}
+      }
+    }
+  {{- end }}
+{{- end }}

--- a/charts/openlake/templates/kv-configmap.yaml
+++ b/charts/openlake/templates/kv-configmap.yaml
@@ -7,6 +7,13 @@ metadata:
   labels:
     {{- include "openlake.labels" . | nindent 4 }}
 data:
+  # Plain ordered input for cluster-managed IB/UCX handshake setup.
+  target-ips: |
+    {{- range .Values.kv.targets }}
+    {{ .ip }}
+    {{- end }}
+
+  # The entrypoint uses this mapping to derive self_id from its scheduled node.
   targets: |
     {{- range $index, $target := .Values.kv.targets }}
     {{ $index }}|{{ $target.nodeName }}|{{ $target.ip }}

--- a/charts/openlake/templates/kv-service.yaml
+++ b/charts/openlake/templates/kv-service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.kv.enabled }}
+{{- include "openlake.kv.validate" . }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openlake.fullname" . }}-rpc
+  labels:
+    {{- include "openlake.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    {{- include "openlake.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: rpc
+      port: {{ .Values.kv.ports.rpc }}
+      targetPort: rpc
+      protocol: TCP
+    - name: telemetry
+      port: {{ .Values.kv.ports.telemetry }}
+      targetPort: telemetry
+      protocol: TCP
+{{- end }}

--- a/charts/openlake/templates/kv-statefulset.yaml
+++ b/charts/openlake/templates/kv-statefulset.yaml
@@ -1,0 +1,137 @@
+{{- if .Values.kv.enabled }}
+{{- include "openlake.kv.validate" . }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "openlake.fullname" . }}
+  labels:
+    {{- include "openlake.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "openlake.fullname" . }}-rpc
+  replicas: {{ len .Values.kv.targets }}
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      {{- include "openlake.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "openlake.selectorLabels" . | nindent 8 }}
+        openlake.dev/workload: kv
+      annotations:
+        checksum/kv-config: {{ toJson .Values.kv | sha256sum }}
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchFields:
+                  - key: metadata.name
+                    operator: In
+                    values:
+                      {{- range .Values.kv.targets }}
+                      - {{ .nodeName | quote }}
+                      {{- end }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  {{- include "openlake.selectorLabels" . | nindent 18 }}
+                  openlake.dev/workload: kv
+              topologyKey: kubernetes.io/hostname
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        fsGroup: 10001
+      containers:
+        - name: openlaked
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /usr/bin/tini
+            - --
+            - /bin/sh
+            - /etc/openlake/entrypoint.sh
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OPENLAKE_TELEMETRY_ADDR
+              value: "0.0.0.0:{{ .Values.kv.ports.telemetry }}"
+            - name: RUST_LOG
+              value: info
+            - name: RUST_BACKTRACE
+              value: "1"
+            {{- range $name, $value := .Values.kv.rdma.env }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+          ports:
+            - name: rpc
+              containerPort: {{ .Values.kv.ports.rpc }}
+              hostPort: {{ .Values.kv.ports.rpc }}
+              protocol: TCP
+            - name: telemetry
+              containerPort: {{ .Values.kv.ports.telemetry }}
+              hostPort: {{ .Values.kv.ports.telemetry }}
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /v1/telemetry/openlake
+              port: telemetry
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 60
+          readinessProbe:
+            httpGet:
+              path: /v1/telemetry/openlake
+              port: telemetry
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /v1/telemetry/openlake
+              port: telemetry
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+              {{- if eq .Values.kv.transport "rdma" }}
+              add: ["IPC_LOCK", "NET_RAW"]
+              {{- end }}
+          volumeMounts:
+            - name: kv-config
+              mountPath: /etc/openlake
+              readOnly: true
+            {{- if eq .Values.kv.transport "rdma" }}
+            - name: infiniband
+              mountPath: /dev/infiniband
+            {{- end }}
+          resources:
+            {{- toYaml .Values.kv.resources | nindent 12 }}
+      volumes:
+        - name: kv-config
+          configMap:
+            name: {{ include "openlake.fullname" . }}-kv-config
+            defaultMode: 0555
+        {{- if eq .Values.kv.transport "rdma" }}
+        - name: infiniband
+          hostPath:
+            path: /dev/infiniband
+            type: Directory
+        {{- end }}
+{{- end }}

--- a/charts/openlake/templates/kv-statefulset.yaml
+++ b/charts/openlake/templates/kv-statefulset.yaml
@@ -23,6 +23,10 @@ spec:
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -42,6 +46,10 @@ spec:
                   openlake.dev/workload: kv
               topologyKey: kubernetes.io/hostname
       terminationGracePeriodSeconds: 30
+      {{- with .Values.kv.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         fsGroup: 10001
       containers:
@@ -131,9 +139,15 @@ spec:
             name: {{ include "openlake.fullname" . }}-kv-config
             defaultMode: 0555
         - name: kv-slab
+          {{- if eq .Values.kv.sharedMemory.type "hostPath" }}
+          hostPath:
+            path: {{ .Values.kv.sharedMemory.hostPath | quote }}
+            type: Directory
+          {{- else }}
           emptyDir:
             medium: Memory
             sizeLimit: {{ printf "%dGi" (int .Values.kv.slab.capacityGB) | quote }}
+          {{- end }}
         {{- if eq .Values.kv.transport "rdma" }}
         - name: infiniband
           hostPath:

--- a/charts/openlake/templates/kv-statefulset.yaml
+++ b/charts/openlake/templates/kv-statefulset.yaml
@@ -117,6 +117,8 @@ spec:
             - name: kv-config
               mountPath: /etc/openlake
               readOnly: true
+            - name: kv-slab
+              mountPath: /dev/shm
             {{- if eq .Values.kv.transport "rdma" }}
             - name: infiniband
               mountPath: /dev/infiniband
@@ -128,6 +130,10 @@ spec:
           configMap:
             name: {{ include "openlake.fullname" . }}-kv-config
             defaultMode: 0555
+        - name: kv-slab
+          emptyDir:
+            medium: Memory
+            sizeLimit: {{ printf "%dGi" (int .Values.kv.slab.capacityGB) | quote }}
         {{- if eq .Values.kv.transport "rdma" }}
         - name: infiniband
           hostPath:

--- a/charts/openlake/templates/kv-statefulset.yaml
+++ b/charts/openlake/templates/kv-statefulset.yaml
@@ -19,7 +19,7 @@ spec:
         {{- include "openlake.selectorLabels" . | nindent 8 }}
         openlake.dev/workload: kv
       annotations:
-        checksum/kv-config: {{ toJson .Values.kv | sha256sum }}
+        checksum/kv-config: {{ include (print $.Template.BasePath "/kv-configmap.yaml") . | sha256sum }}
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/charts/openlake/templates/secret.yaml
+++ b/charts/openlake/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.kv.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,3 +9,4 @@ type: Opaque
 stringData:
   accessKey: {{ .Values.credentials.accessKey | quote }}
   secretKey: {{ .Values.credentials.secretKey | quote }}
+{{- end }}

--- a/charts/openlake/templates/service.yaml
+++ b/charts/openlake/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.kv.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -30,3 +31,4 @@ spec:
     - name: s3
       port: {{ .Values.ports.s3 }}
       targetPort: s3
+{{- end }}

--- a/charts/openlake/templates/statefulset.yaml
+++ b/charts/openlake/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.kv.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -106,3 +107,4 @@ spec:
           requests:
             storage: {{ $.Values.storage.size }}
     {{- end }}
+{{- end }}

--- a/charts/openlake/templates/statefulset.yaml
+++ b/charts/openlake/templates/statefulset.yaml
@@ -20,6 +20,10 @@ spec:
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/openlake/templates/vllm-smoke-test.yaml
+++ b/charts/openlake/templates/vllm-smoke-test.yaml
@@ -9,9 +9,10 @@ metadata:
     {{- include "openlake.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   backoffLimit: 0
+  ttlSecondsAfterFinished: 600
   activeDeadlineSeconds: {{ add (int .Values.vllmSmokeTest.startupTimeoutSeconds) 120 }}
   template:
     metadata:

--- a/charts/openlake/templates/vllm-smoke-test.yaml
+++ b/charts/openlake/templates/vllm-smoke-test.yaml
@@ -1,0 +1,141 @@
+{{- if .Values.vllmSmokeTest.enabled }}
+{{- include "openlake.vllmSmokeTest.validate" . }}
+{{- $target := first .Values.kv.targets }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "openlake.vllmSmokeTest.fullname" . }}
+  labels:
+    {{- include "openlake.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: {{ add (int .Values.vllmSmokeTest.startupTimeoutSeconds) 120 }}
+  template:
+    metadata:
+      labels:
+        {{- include "openlake.selectorLabels" . | nindent 8 }}
+        openlake.dev/workload: vllm-smoke-test
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchFields:
+                  - key: metadata.name
+                    operator: In
+                    values:
+                      - {{ $target.nodeName | quote }}
+      {{- with .Values.kv.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: vllm
+          image: "{{ .Values.vllmSmokeTest.image.repository }}:{{ .Values.vllmSmokeTest.image.tag }}"
+          imagePullPolicy: {{ .Values.vllmSmokeTest.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+
+              cleanup() {
+                kill "${server_pid}" 2>/dev/null || true
+                wait "${server_pid}" 2>/dev/null || true
+              }
+
+              healthcheck() {
+                python3 -c \
+                  'import sys, urllib.request; urllib.request.urlopen(sys.argv[1], timeout=5).close()' \
+                  "$1" 2>/dev/null
+              }
+
+              deadline=$(( $(date +%s) + STARTUP_TIMEOUT_SECONDS ))
+              until healthcheck "${OPENLAKE_HEALTH_URL}"; do
+                if [ "$(date +%s)" -ge "${deadline}" ]; then
+                  echo "OpenLake did not become healthy within ${STARTUP_TIMEOUT_SECONDS}s" >&2
+                  exit 1
+                fi
+                sleep 5
+              done
+
+              vllm serve "${MODEL_ID}" \
+                --host 127.0.0.1 \
+                --port "${VLLM_PORT}" \
+                --dtype bfloat16 \
+                --max-model-len "${MAX_MODEL_LEN}" \
+                --max-num-seqs 1 \
+                --kv-transfer-config "$(cat /etc/openlake/vllm-kv-transfer-config.json)" &
+              server_pid=$!
+              trap cleanup EXIT HUP INT TERM
+
+              until healthcheck "http://127.0.0.1:${VLLM_PORT}/health"; do
+                if ! kill -0 "${server_pid}" 2>/dev/null; then
+                  echo "vLLM exited before becoming healthy" >&2
+                  wait "${server_pid}"
+                fi
+                if [ "$(date +%s)" -ge "${deadline}" ]; then
+                  echo "vLLM did not become healthy within ${STARTUP_TIMEOUT_SECONDS}s" >&2
+                  exit 1
+                fi
+                sleep 5
+              done
+
+              echo "vLLM accepted the generated OpenLake connector configuration and became healthy"
+          env:
+            - name: MODEL_ID
+              value: {{ .Values.vllmSmokeTest.model | quote }}
+            - name: VLLM_PORT
+              value: {{ .Values.vllmSmokeTest.port | quote }}
+            - name: MAX_MODEL_LEN
+              value: {{ .Values.vllmSmokeTest.maxModelLen | quote }}
+            - name: STARTUP_TIMEOUT_SECONDS
+              value: {{ .Values.vllmSmokeTest.startupTimeoutSeconds | quote }}
+            - name: OPENLAKE_HEALTH_URL
+              value: {{ printf "http://%s:%v/v1/telemetry/openlake" $target.ip .Values.kv.ports.telemetry | quote }}
+            - name: PYTHONHASHSEED
+              value: "0"
+            - name: VLLM_CPU_KVCACHE_SPACE
+              value: "1"
+            - name: VLLM_CPU_OMP_THREADS_BIND
+              value: nobind
+            {{- if .Values.vllmSmokeTest.hfTokenSecretName }}
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.vllmSmokeTest.hfTokenSecretName | quote }}
+                  key: token
+            {{- end }}
+            {{- range $name, $value := .Values.vllmSmokeTest.env }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+          volumeMounts:
+            - name: connector-config
+              mountPath: /etc/openlake
+              readOnly: true
+            - name: host-shm
+              mountPath: /dev/shm
+          resources:
+            {{- toYaml .Values.vllmSmokeTest.resources | nindent 12 }}
+      volumes:
+        - name: connector-config
+          configMap:
+            name: {{ include "openlake.fullname" . }}-kv-config
+            items:
+              - key: vllm-kv-transfer-config.json
+                path: vllm-kv-transfer-config.json
+        - name: host-shm
+          hostPath:
+            path: {{ .Values.kv.sharedMemory.hostPath | quote }}
+            type: Directory
+{{- end }}

--- a/charts/openlake/tests/render.sh
+++ b/charts/openlake/tests/render.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+set -eu
+
+helm_bin=${HELM_BIN:-helm}
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+chart_dir=$(CDPATH= cd -- "${script_dir}/.." && pwd)
+test_tmp=$(mktemp -d /tmp/openlake-helm-tests.XXXXXX)
+trap 'rm -rf -- "${test_tmp}"' EXIT HUP INT TERM
+
+fail() {
+  echo "helm render test failed: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  file=$1
+  expected=$2
+  grep -Fq -- "${expected}" "${file}" ||
+    fail "${file} does not contain: ${expected}"
+}
+
+assert_not_contains() {
+  file=$1
+  unexpected=$2
+  if grep -Fq -- "${unexpected}" "${file}"; then
+    fail "${file} unexpectedly contains: ${unexpected}"
+  fi
+}
+
+expect_render_failure() {
+  expected=$1
+  shift
+  error_file="${test_tmp}/expected-error.txt"
+  if "${helm_bin}" template invalid "${chart_dir}" "$@" >"${error_file}" 2>&1; then
+    fail "invalid values rendered successfully: $*"
+  fi
+  assert_contains "${error_file}" "${expected}"
+}
+
+command -v "${helm_bin}" >/dev/null 2>&1 || fail "Helm is not installed"
+
+storage_render="${test_tmp}/storage.yaml"
+"${helm_bin}" lint "${chart_dir}"
+"${helm_bin}" template storage "${chart_dir}" >"${storage_render}"
+assert_contains "${storage_render}" "kind: Secret"
+assert_contains "${storage_render}" "volumeClaimTemplates:"
+assert_contains "${storage_render}" "openlake.dev/workload: storage"
+assert_not_contains "${storage_render}" "-kv-config"
+
+h2_values="${chart_dir}/examples/kv-h2-values.yaml"
+h2_render="${test_tmp}/kv-h2.yaml"
+"${helm_bin}" lint "${chart_dir}" --values "${h2_values}"
+"${helm_bin}" template openlake "${chart_dir}" --values "${h2_values}" >"${h2_render}"
+assert_contains "${h2_render}" "name: openlake-openlake-kv-config"
+assert_contains "${h2_render}" "0|gpu-worker-0|10.0.0.11"
+assert_contains "${h2_render}" '"10.0.0.11:9400",'
+assert_contains "${h2_render}" '"10.0.0.12:9400",'
+assert_contains "${h2_render}" "replicas: 2"
+assert_contains "${h2_render}" "matchFields:"
+assert_contains "${h2_render}" 'key: metadata.name'
+assert_contains "${h2_render}" "requiredDuringSchedulingIgnoredDuringExecution:"
+assert_contains "${h2_render}" "hostNetwork: true"
+assert_contains "${h2_render}" 'sizeLimit: "8Gi"'
+assert_not_contains "${h2_render}" "vllm-kv-transfer-config.json"
+assert_not_contains "${h2_render}" "/dev/infiniband"
+assert_not_contains "${h2_render}" "volumeClaimTemplates:"
+assert_not_contains "${h2_render}" "kind: Secret"
+
+ucx_values="${chart_dir}/examples/kv-ucx-values.yaml"
+ucx_render="${test_tmp}/kv-ucx.yaml"
+"${helm_bin}" lint "${chart_dir}" --values "${ucx_values}"
+"${helm_bin}" template openlake "${chart_dir}" --values "${ucx_values}" >"${ucx_render}"
+assert_contains "${ucx_render}" 'transport            = "rdma"'
+assert_contains "${ucx_render}" 'backend = "ucx"'
+assert_contains "${ucx_render}" '"openlake_device": "ucx"'
+assert_contains "${ucx_render}" "vllm-kv-transfer-config.json"
+assert_contains "${ucx_render}" "mountPath: /dev/infiniband"
+assert_contains "${ucx_render}" 'add: ["IPC_LOCK", "NET_RAW"]'
+assert_not_contains "${ucx_render}" "self_node_id = __SELF_ID__"
+
+dct_values="${chart_dir}/examples/kv-dct-values.yaml"
+dct_render="${test_tmp}/kv-dct.yaml"
+"${helm_bin}" lint "${chart_dir}" --values "${dct_values}"
+"${helm_bin}" template openlake "${chart_dir}" --values "${dct_values}" >"${dct_render}"
+assert_contains "${dct_render}" 'backend = "dct"'
+assert_contains "${dct_render}" "self_node_id = __SELF_ID__"
+assert_contains "${dct_render}" 'dev_name     = "mlx5_0"'
+assert_contains "${dct_render}" '"openlake_device": "mlx5_0"'
+
+expect_render_failure \
+  "minItems: got 0, want 1" \
+  --set kv.enabled=true
+
+expect_render_failure \
+  'kv.targets contains duplicate ip "10.0.0.11"' \
+  --set kv.enabled=true \
+  --set kv.transport=rdma \
+  --set 'kv.targets[0].nodeName=gpu-worker-0' \
+  --set 'kv.targets[0].ip=10.0.0.11' \
+  --set 'kv.targets[1].nodeName=gpu-worker-1' \
+  --set 'kv.targets[1].ip=10.0.0.11'
+
+expect_render_failure \
+  "the H2/local connector supports one same-host KV target only" \
+  --set kv.enabled=true \
+  --set 'kv.targets[0].nodeName=gpu-worker-0' \
+  --set 'kv.targets[0].ip=10.0.0.11' \
+  --set 'kv.targets[1].nodeName=gpu-worker-1' \
+  --set 'kv.targets[1].ip=10.0.0.12'
+
+expect_render_failure \
+  "kv.rdma.devName is required for the dct backend" \
+  --set kv.enabled=true \
+  --set kv.transport=rdma \
+  --set kv.rdma.backend=dct \
+  --set 'kv.targets[0].nodeName=gpu-worker-0' \
+  --set 'kv.targets[0].ip=10.0.0.11'
+
+echo "Helm render tests passed"

--- a/charts/openlake/tests/render.sh
+++ b/charts/openlake/tests/render.sh
@@ -183,6 +183,9 @@ smoke_render="${test_tmp}/kv-vllm-smoke.yaml"
 "${helm_bin}" template openlake "${chart_dir}" --values "${smoke_values}" >"${smoke_render}"
 assert_contains "${smoke_render}" "kind: Job"
 assert_contains "${smoke_render}" '"helm.sh/hook": test'
+assert_contains "${smoke_render}" '"helm.sh/hook-delete-policy": before-hook-creation'
+assert_contains "${smoke_render}" "ttlSecondsAfterFinished: 600"
+assert_not_contains "${smoke_render}" "hook-succeeded"
 assert_contains "${smoke_render}" 'image: "registry.example.com/openlake/vllm-openlake-cpu:0.26.0-openlake-0.8.0"'
 assert_contains "${smoke_render}" 'vllm serve "${MODEL_ID}"'
 assert_contains "${smoke_render}" 'value: "facebook/opt-125m"'

--- a/charts/openlake/tests/render.sh
+++ b/charts/openlake/tests/render.sh
@@ -121,6 +121,7 @@ h2_render="${test_tmp}/kv-h2.yaml"
 "${helm_bin}" lint "${chart_dir}" --values "${h2_values}"
 "${helm_bin}" template openlake "${chart_dir}" --values "${h2_values}" >"${h2_render}"
 assert_contains "${h2_render}" "name: openlake-openlake-kv-config"
+assert_contains "${h2_render}" "target-ips: |"
 assert_contains "${h2_render}" "0|gpu-worker-0|10.0.0.11"
 assert_contains "${h2_render}" '"10.0.0.11:9400",'
 assert_contains "${h2_render}" '"10.0.0.12:9400",'

--- a/charts/openlake/tests/render.sh
+++ b/charts/openlake/tests/render.sh
@@ -37,7 +37,76 @@ expect_render_failure() {
   assert_contains "${error_file}" "${expected}"
 }
 
+validate_toml() {
+  render_file=$1
+  expected_transport=$2
+  expected_backend=${3:-}
+  config_file="${test_tmp}/openlake-${expected_transport}-${expected_backend:-none}.toml"
+
+  sed -n '
+    /^  openlake.toml.tpl: |$/,/^  entrypoint.sh: |$/ {
+      /^  openlake.toml.tpl: |$/d
+      /^  entrypoint.sh: |$/d
+      s/^    //
+      s/__SELF_ID__/0/g
+      p
+    }
+  ' "${render_file}" >"${config_file}"
+
+  python3 -c '
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as stream:
+    config = tomllib.load(stream)
+
+expected_transport = sys.argv[2]
+expected_backend = sys.argv[3] or None
+assert config["self_id"] == 0
+assert config["mode"] == "kv"
+assert config["transport"] == expected_transport
+assert config["kv_agents"] == ["10.0.0.11:9400", "10.0.0.12:9400"]
+assert config["nodes"] == [{"id": 0, "rpc_addr": "0.0.0.0:9400", "disk_count": 0}]
+assert config["kv_slab"]["capacity_gb"] > 0
+if expected_backend:
+    assert config["rdma"]["backend"] == expected_backend
+    if expected_backend == "dct":
+        assert config["rdma"]["self_node_id"] == 0
+else:
+    assert "rdma" not in config
+' "${config_file}" "${expected_transport}" "${expected_backend}"
+}
+
+validate_connector() {
+  render_file=$1
+  expected_device=$2
+  connector_file="${test_tmp}/connector-${expected_device}.json"
+
+  sed -n '
+    /^  vllm-kv-transfer-config.json: |$/,/^---$/ {
+      /^  vllm-kv-transfer-config.json: |$/d
+      /^---$/d
+      s/^    //
+      p
+    }
+  ' "${render_file}" >"${connector_file}"
+
+  python3 -c '
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as stream:
+    connector = json.load(stream)
+
+assert connector["kv_connector"] == "OpenLakeConnector"
+extra = connector["kv_connector_extra_config"]
+assert extra["openlake_nodes"] == ["10.0.0.11:9400", "10.0.0.12:9400"]
+assert extra["openlake_device"] == sys.argv[2]
+' "${connector_file}" "${expected_device}"
+}
+
 command -v "${helm_bin}" >/dev/null 2>&1 || fail "Helm is not installed"
+command -v python3 >/dev/null 2>&1 || fail "Python 3 is not installed"
 
 storage_render="${test_tmp}/storage.yaml"
 "${helm_bin}" lint "${chart_dir}"
@@ -65,6 +134,7 @@ assert_not_contains "${h2_render}" "vllm-kv-transfer-config.json"
 assert_not_contains "${h2_render}" "/dev/infiniband"
 assert_not_contains "${h2_render}" "volumeClaimTemplates:"
 assert_not_contains "${h2_render}" "kind: Secret"
+validate_toml "${h2_render}" h2
 
 ucx_values="${chart_dir}/examples/kv-ucx-values.yaml"
 ucx_render="${test_tmp}/kv-ucx.yaml"
@@ -77,6 +147,8 @@ assert_contains "${ucx_render}" "vllm-kv-transfer-config.json"
 assert_contains "${ucx_render}" "mountPath: /dev/infiniband"
 assert_contains "${ucx_render}" 'add: ["IPC_LOCK", "NET_RAW"]'
 assert_not_contains "${ucx_render}" "self_node_id = __SELF_ID__"
+validate_toml "${ucx_render}" rdma ucx
+validate_connector "${ucx_render}" ucx
 
 dct_values="${chart_dir}/examples/kv-dct-values.yaml"
 dct_render="${test_tmp}/kv-dct.yaml"
@@ -86,6 +158,8 @@ assert_contains "${dct_render}" 'backend = "dct"'
 assert_contains "${dct_render}" "self_node_id = __SELF_ID__"
 assert_contains "${dct_render}" 'dev_name     = "mlx5_0"'
 assert_contains "${dct_render}" '"openlake_device": "mlx5_0"'
+validate_toml "${dct_render}" rdma dct
+validate_connector "${dct_render}" mlx5_0
 
 expect_render_failure \
   "minItems: got 0, want 1" \

--- a/charts/openlake/tests/render.sh
+++ b/charts/openlake/tests/render.sh
@@ -80,6 +80,7 @@ else:
 validate_connector() {
   render_file=$1
   expected_device=$2
+  expected_nodes=${3:-"10.0.0.11:9400,10.0.0.12:9400"}
   connector_file="${test_tmp}/connector-${expected_device}.json"
 
   sed -n '
@@ -100,9 +101,23 @@ with open(sys.argv[1], encoding="utf-8") as stream:
 
 assert connector["kv_connector"] == "OpenLakeConnector"
 extra = connector["kv_connector_extra_config"]
-assert extra["openlake_nodes"] == ["10.0.0.11:9400", "10.0.0.12:9400"]
+assert extra["openlake_nodes"] == sys.argv[3].split(",")
 assert extra["openlake_device"] == sys.argv[2]
-' "${connector_file}" "${expected_device}"
+' "${connector_file}" "${expected_device}" "${expected_nodes}"
+}
+
+validate_smoke_script() {
+  render_file=$1
+  smoke_script="${test_tmp}/vllm-smoke.sh"
+  sed -n '
+    /^            - |$/,/^          env:$/ {
+      /^            - |$/d
+      /^          env:$/d
+      s/^              //
+      p
+    }
+  ' "${render_file}" >"${smoke_script}"
+  sh -n "${smoke_script}"
 }
 
 command -v "${helm_bin}" >/dev/null 2>&1 || fail "Helm is not installed"
@@ -162,6 +177,23 @@ assert_contains "${dct_render}" '"openlake_device": "mlx5_0"'
 validate_toml "${dct_render}" rdma dct
 validate_connector "${dct_render}" mlx5_0
 
+smoke_values="${chart_dir}/examples/kv-vllm-smoke-values.yaml"
+smoke_render="${test_tmp}/kv-vllm-smoke.yaml"
+"${helm_bin}" lint "${chart_dir}" --values "${smoke_values}"
+"${helm_bin}" template openlake "${chart_dir}" --values "${smoke_values}" >"${smoke_render}"
+assert_contains "${smoke_render}" "kind: Job"
+assert_contains "${smoke_render}" '"helm.sh/hook": test'
+assert_contains "${smoke_render}" 'image: "registry.example.com/openlake/vllm-openlake-cpu:0.26.0-openlake-0.8.0"'
+assert_contains "${smoke_render}" 'vllm serve "${MODEL_ID}"'
+assert_contains "${smoke_render}" 'value: "facebook/opt-125m"'
+assert_contains "${smoke_render}" 'value: "http://10.0.0.11:9401/v1/telemetry/openlake"'
+assert_contains "${smoke_render}" "key: vllm-kv-transfer-config.json"
+assert_contains "${smoke_render}" 'path: "/dev/shm"'
+assert_contains "${smoke_render}" '"openlake_device": "local"'
+assert_contains "${smoke_render}" 'value: nobind'
+validate_connector "${smoke_render}" local "10.0.0.11:9400"
+validate_smoke_script "${smoke_render}"
+
 expect_render_failure \
   "minItems: got 0, want 1" \
   --set kv.enabled=true
@@ -190,5 +222,14 @@ expect_render_failure \
   --set kv.rdma.backend=dct \
   --set 'kv.targets[0].nodeName=gpu-worker-0' \
   --set 'kv.targets[0].ip=10.0.0.11'
+
+expect_render_failure \
+  "vllmSmokeTest.enabled=true requires kv.enabled=true" \
+  --set vllmSmokeTest.enabled=true
+
+expect_render_failure \
+  "the H2/local vLLM smoke test requires kv.sharedMemory.type=hostPath" \
+  --values "${smoke_values}" \
+  --set kv.sharedMemory.type=emptyDir
 
 echo "Helm render tests passed"

--- a/charts/openlake/values.schema.json
+++ b/charts/openlake/values.schema.json
@@ -53,13 +53,16 @@
         },
         "targets": {
           "type": "array",
+          "maxItems": 65536,
           "items": {
             "type": "object",
             "required": ["nodeName", "ip"],
             "properties": {
               "nodeName": {
                 "type": "string",
-                "minLength": 1
+                "minLength": 1,
+                "maxLength": 253,
+                "pattern": "^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$"
               },
               "ip": {
                 "type": "string",
@@ -127,6 +130,9 @@
             },
             "env": {
               "type": "object",
+              "propertyNames": {
+                "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+              },
               "additionalProperties": {
                 "type": ["string", "number", "boolean"]
               }

--- a/charts/openlake/values.schema.json
+++ b/charts/openlake/values.schema.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "kv": {
+      "type": "object",
+      "required": [
+        "enabled",
+        "transport",
+        "ports",
+        "slab",
+        "targets",
+        "rdma",
+        "connector"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "transport": {
+          "type": "string",
+          "enum": ["h2", "rdma"]
+        },
+        "ports": {
+          "type": "object",
+          "required": ["rpc", "telemetry"],
+          "properties": {
+            "rpc": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            "telemetry": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            }
+          }
+        },
+        "slab": {
+          "type": "object",
+          "required": ["capacityGB", "reserveTtlSeconds"],
+          "properties": {
+            "capacityGB": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "reserveTtlSeconds": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        },
+        "targets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["nodeName", "ip"],
+            "properties": {
+              "nodeName": {
+                "type": "string",
+                "minLength": 1
+              },
+              "ip": {
+                "type": "string",
+                "format": "ipv4"
+              }
+            }
+          }
+        },
+        "rdma": {
+          "type": "object",
+          "required": [
+            "backend",
+            "devName",
+            "dcKey",
+            "srqDepth",
+            "maxSendWr",
+            "peerCredit",
+            "maxClients",
+            "qos",
+            "env"
+          ],
+          "properties": {
+            "backend": {
+              "type": "string",
+              "enum": ["dct", "ucx"]
+            },
+            "devName": {
+              "type": "string"
+            },
+            "dcKey": {
+              "type": "string",
+              "pattern": "^(0[xX][0-9a-fA-F]+|[0-9]+)$"
+            },
+            "srqDepth": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "maxSendWr": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "peerCredit": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "maxClients": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "qos": {
+              "type": "object",
+              "required": ["trafficClass", "serviceLevel"],
+              "properties": {
+                "trafficClass": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 255
+                },
+                "serviceLevel": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 255
+                }
+              }
+            },
+            "env": {
+              "type": "object",
+              "additionalProperties": {
+                "type": ["string", "number", "boolean"]
+              }
+            }
+          }
+        },
+        "connector": {
+          "type": "object",
+          "required": ["enabled", "device"],
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "device": {
+              "type": "string"
+            }
+          }
+        },
+        "resources": {
+          "type": "object"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "kv": {
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "kv": {
+            "properties": {
+              "targets": {
+                "minItems": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/charts/openlake/values.schema.json
+++ b/charts/openlake/values.schema.json
@@ -2,6 +2,19 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
     "kv": {
       "type": "object",
       "required": [
@@ -9,6 +22,7 @@
         "transport",
         "ports",
         "slab",
+        "sharedMemory",
         "targets",
         "rdma",
         "connector"
@@ -48,6 +62,20 @@
             "reserveTtlSeconds": {
               "type": "integer",
               "minimum": 1
+            }
+          }
+        },
+        "sharedMemory": {
+          "type": "object",
+          "required": ["type", "hostPath"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["emptyDir", "hostPath"]
+            },
+            "hostPath": {
+              "type": "string",
+              "pattern": "^/"
             }
           }
         },
@@ -149,6 +177,81 @@
             "device": {
               "type": "string"
             }
+          }
+        },
+        "resources": {
+          "type": "object"
+        },
+        "tolerations": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "vllmSmokeTest": {
+      "type": "object",
+      "required": [
+        "enabled",
+        "image",
+        "model",
+        "port",
+        "maxModelLen",
+        "startupTimeoutSeconds",
+        "hfTokenSecretName",
+        "env",
+        "resources"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "image": {
+          "type": "object",
+          "required": ["repository", "tag", "pullPolicy"],
+          "properties": {
+            "repository": {
+              "type": "string",
+              "minLength": 1
+            },
+            "tag": {
+              "type": "string",
+              "minLength": 1
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            }
+          }
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "maxModelLen": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "startupTimeoutSeconds": {
+          "type": "integer",
+          "minimum": 60
+        },
+        "hfTokenSecretName": {
+          "type": "string"
+        },
+        "env": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+          },
+          "additionalProperties": {
+            "type": ["string", "number", "boolean"]
           }
         },
         "resources": {

--- a/charts/openlake/values.yaml
+++ b/charts/openlake/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: openlake/openlaked
-  tag: "0.1.0"
+  tag: "0.8.0"
   pullPolicy: IfNotPresent
 
 mode: tls
@@ -42,3 +42,49 @@ resources: {}
 
 s3Service:
   type: ClusterIP
+
+# External KV-cache deployment. This is deliberately separate from the object
+# storage settings above: KV nodes are standalone slabs and use kv_agents for
+# their ordered peer reference list.
+kv:
+  enabled: false
+  transport: h2
+
+  ports:
+    rpc: 9400
+    telemetry: 9401
+
+  slab:
+    capacityGB: 1
+    reserveTtlSeconds: 60
+
+  # List order is the stable OpenLake node ID. nodeName controls Kubernetes
+  # placement; ip is the address advertised to OpenLake and vLLM peers.
+  targets: []
+  # - nodeName: gpu-worker-0
+  #   ip: 10.0.0.11
+  # - nodeName: gpu-worker-1
+  #   ip: 10.0.0.12
+
+  rdma:
+    backend: ucx
+    devName: ""
+    dcKey: "4919"
+    srqDepth: 4096
+    maxSendWr: 256
+    peerCredit: 4
+    maxClients: 512
+    qos:
+      trafficClass: 0
+      serviceLevel: 0
+    # Environment-specific UCX settings can be supplied without teaching the
+    # chart how the cluster's IB/RoCE fabric is provisioned.
+    env: {}
+
+  connector:
+    enabled: true
+    # Empty selects local for h2, ucx for the UCX backend, or rdma.devName for
+    # DCT. Set this explicitly when the connector uses another observed device.
+    device: ""
+
+  resources: {}

--- a/charts/openlake/values.yaml
+++ b/charts/openlake/values.yaml
@@ -3,6 +3,8 @@ image:
   tag: "0.8.0"
   pullPolicy: IfNotPresent
 
+imagePullSecrets: []
+
 mode: tls
 
 replicaCount: 2
@@ -58,6 +60,12 @@ kv:
     capacityGB: 1
     reserveTtlSeconds: 60
 
+  sharedMemory:
+    # emptyDir isolates the slab inside the OpenLake pod. hostPath is intended
+    # only for the one-node H2/vLLM smoke test, where both pods must see it.
+    type: emptyDir
+    hostPath: /dev/shm
+
   # List order is the stable OpenLake node ID. nodeName controls Kubernetes
   # placement; ip is the address advertised to OpenLake and vLLM peers.
   targets: []
@@ -87,4 +95,21 @@ kv:
     # DCT. Set this explicitly when the connector uses another observed device.
     device: ""
 
+  tolerations: []
+  resources: {}
+
+# Optional `helm test` Job. It proves that a CPU vLLM process can consume the
+# generated connector JSON and initialize against one same-host H2 KV server.
+vllmSmokeTest:
+  enabled: false
+  image:
+    repository: registry.example.com/openlake/vllm-openlake-cpu
+    tag: "0.26.0-openlake-0.8.0"
+    pullPolicy: IfNotPresent
+  model: facebook/opt-125m
+  port: 8000
+  maxModelLen: 512
+  startupTimeoutSeconds: 900
+  hfTokenSecretName: ""
+  env: {}
   resources: {}

--- a/docker/vllm-openlake-cpu.Dockerfile
+++ b/docker/vllm-openlake-cpu.Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.7
+
+ARG RUST_VERSION=1.91.1
+ARG DEBIAN_RELEASE=bookworm
+ARG VLLM_CPU_IMAGE=vllm/vllm-openai-cpu:v0.26.0-x86_64
+
+FROM rust:${RUST_VERSION}-${DEBIAN_RELEASE} AS openlake-wheel
+WORKDIR /build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        clang \
+        cmake \
+        libudev-dev \
+        pkg-config \
+        python3 \
+        python3-venv \
+    && rm -rf /var/lib/apt/lists/* \
+    && python3 -m venv /opt/maturin \
+    && /opt/maturin/bin/pip install --no-cache-dir 'maturin>=1.7,<2.0'
+
+COPY rust-toolchain.toml Cargo.toml Cargo.lock ./
+COPY crates ./crates
+COPY cli ./cli
+COPY vendor ./vendor
+COPY external ./external
+
+RUN --mount=type=cache,target=/build/target,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    PATH="/opt/maturin/bin:${PATH}" crates/openlake_kv_client/build.sh cpu
+
+FROM ${VLLM_CPU_IMAGE}
+USER root
+
+COPY --from=openlake-wheel /build/crates/openlake_kv_client/dist/*.whl /tmp/openlake-wheels/
+RUN uv pip install --system /tmp/openlake-wheels/*.whl \
+    && rm -rf /tmp/openlake-wheels
+
+ENTRYPOINT ["vllm", "serve"]

--- a/docker/vllm-openlake-cpu.Dockerfile
+++ b/docker/vllm-openlake-cpu.Dockerfile
@@ -33,7 +33,7 @@ FROM ${VLLM_CPU_IMAGE}
 USER root
 
 COPY --from=openlake-wheel /build/crates/openlake_kv_client/dist/*.whl /tmp/openlake-wheels/
-RUN uv pip install --system /tmp/openlake-wheels/*.whl \
+RUN uv pip install --python /opt/venv/bin/python /tmp/openlake-wheels/*.whl \
     && rm -rf /tmp/openlake-wheels
 
 ENTRYPOINT ["vllm", "serve"]


### PR DESCRIPTION
## Summary

Adds Helm-based Kubernetes orchestration for deploying OpenLake KV instances as an ordered peer set.

The chart now accepts a list of Kubernetes node names and target IPs, deploys one host-networked OpenLake instance on each selected node, assigns each instance a stable `self_id`, and propagates the same ordered KV-node list to OpenLake and vLLM connector configurations.

## What changed

- Added a KV-specific, host-networked StatefulSet with one OpenLake instance per selected Kubernetes node.
- Added exact node placement and pod anti-affinity for the configured node set.
- Added a ConfigMap containing:
  - the ordered target IP list;
  - node-to-`self_id` mappings;
  - generated OpenLake KV server configuration;
  - ordered `kv_agents` values;
  - optional vLLM `openlake_nodes` connector configuration.
- Added startup, readiness, and liveness probes.
- Added values and examples for H2, UCX, and DCT configurations.
- Added an optional CPU-only Helm test that starts vLLM with the generated OpenLake connector configuration.
- Added a Dockerfile for building the connector into the CPU vLLM image.
- Added Helm schema validation, render tests, configuration parsing tests, examples, and deployment documentation.

## Design decisions

- The node/IP list is consumed during `helm install` or `helm upgrade`; this PR does not add a continuously running ConfigMap controller.
- A StatefulSet is used to provide stable pod identities, while `self_id` is derived from the configured node ordering.
- Every OpenLake and vLLM instance receives the same ordered KV peer list.
- IB/UCX provisioning remains external to this chart.
- H2 with the local connector is limited to a same-node validation setup. Production multi-node deployments use UCX or DCT after the required networking is available.

## Validation

- Helm lint and render tests pass for the supported KV deployment variants.
- Generated JSON and TOML configurations are parsed during tests.
- Invalid combinations, including multi-node H2/local deployments, are rejected.
- All 15 OpenLake connector regression tests pass.
- Both Dockerfiles pass Docker build checks.
- Verified on a local kind cluster that:
  - the OpenLake StatefulSet becomes ready;
  - node placement and `self_id` generation are correct;
  - the generated vLLM configuration contains the expected ordered KV endpoint list;
  - vLLM accepts the generated connector configuration and becomes healthy;
  - the OpenLake client attaches successfully to the H2 KV instance.