### PR TITLE
(#257) [v0.9] Core: validate x-amz-checksum-sha256 header in DeleteObjects

### DIFF
--- a/crates/openlake_server/src/s3/handlers/objects.rs
+++ b/crates/openlake_server/src/s3/handlers/objects.rs
@@ -229,7 +229,6 @@ pub async fn delete_objects(
             ));
         }
     }
-    
 
     let request: DeleteRequest = quick_xml::de::from_reader(bytes.as_ref())
         .map_err(|_| AppError::Malformed("invalid <Delete> XML"))?;

--- a/crates/openlake_server/src/s3/handlers/objects.rs
+++ b/crates/openlake_server/src/s3/handlers/objects.rs
@@ -218,6 +218,18 @@ pub async fn delete_objects(
             ));
         }
     }
+    if let Some(expected_sha256) = supplied_sha256.as_deref() {
+        use base64::Engine as _;
+        use sha2::Digest as _;
+        let digest = sha2::Sha256::digest(bytes.as_ref());
+        let actual_sha256 = base64::engine::general_purpose::STANDARD.encode(digest);
+        if actual_sha256 != expected_sha256 {
+            return Err(AppError::Malformed(
+                "x-amz-checksum-sha256 does not match request body",
+            ));
+        }
+    }
+    
 
     let request: DeleteRequest = quick_xml::de::from_reader(bytes.as_ref())
         .map_err(|_| AppError::Malformed("invalid <Delete> XML"))?;


### PR DESCRIPTION
Fixes #257

## Problem

The `DeleteObjects` handler checked whether the `x-amz-checksum-sha256`
header was present, but only validated `Content-MD5` against the
request body. Any SHA256 value — including an incorrect or garbage
one — allowed the delete operation to proceed unchecked.

## Fix

Added a SHA256 validation block that mirrors the existing MD5 check:
it computes the actual SHA256 digest of the request body and rejects
the request with a `Malformed` error if it doesn't match the supplied
`x-amz-checksum-sha256` header value.

## Testing

- Built and verified compilation succeeds (`cargo build -p openlake_server`)