### PR TITLE
(#258) [v0.9] KVE: reject duplicate node IDs at startup

### DIFF
--- a/crates/openlake_server/src/config.rs
+++ b/crates/openlake_server/src/config.rs
@@ -357,6 +357,17 @@ impl Config {
         if !cfg.nodes.iter().any(|n| n.id == cfg.self_id) {
             anyhow::bail!("self_id {} not present in nodes table", cfg.self_id);
         }
+        {
+            let mut seen_ids: std::collections::HashSet<u16> = std::collections::HashSet::new();
+            for n in &cfg.nodes {
+                if !seen_ids.insert(n.id) {
+                    anyhow::bail!(
+                        "duplicate node id {} in nodes table; each node must have a unique id",
+                        n.id,
+                    );
+                }
+            }
+        }
 
         if cfg.mode == Mode::Kv {
             if cfg.kv_slab.is_none() {


### PR DESCRIPTION
Fixes #258

## Problem

`Config::from_toml` validated that `self_id` exists in the nodes
table, but never checked whether all node IDs in the `[[nodes]]`
list are unique. A misconfigured cluster with duplicate node IDs
could silently start in an invalid state.

## Fix

Added a check that iterates over all nodes and rejects the config
with a clear error if any node ID is duplicated — following the
same `HashSet`-based pattern already used for detecting duplicate
`data_dirs` in this file.

## Testing

- Built and verified compilation succeeds (`cargo build -p openlake_server`)