### PR TITLE
  vLLM: wire optional on-GPU KV compression codec into the connector (#223)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ Cargo.lock.bak
 /data
 __pycache__/
 *.pyc
+
+# Local agent tooling state, not project source.
+/.claude
+/.serena

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2231,6 +2231,7 @@ dependencies = [
 name = "openlake_kv_client"
 version = "0.8.0"
 dependencies = [
+ "cc",
  "compio",
  "futures",
  "libc",

--- a/crates/openlake_kv_client/Cargo.toml
+++ b/crates/openlake_kv_client/Cargo.toml
@@ -14,6 +14,10 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 rdma = ["openlake_io/rdma"]
+# On-GPU int8 group-quantization codec for the vLLM connector's optional
+# low-bandwidth KV transfer path (see cuda/src/kv_compression.cu). Off by
+# default: it requires nvcc and a CUDA 12+ toolkit at build time.
+cuda = ["dep:cc"]
 
 [dependencies]
 openlake_io = { path = "../openlake_io" }
@@ -24,3 +28,6 @@ futures = { workspace = true }
 pyo3    = { version = "0.29", features = ["abi3-py310", "extension-module"] }
 tracing = { workspace = true }
 xxhash-rust = { version = "0.8", features = ["xxh64"] }
+
+[build-dependencies]
+cc = { version = "1", optional = true }

--- a/crates/openlake_kv_client/build.rs
+++ b/crates/openlake_kv_client/build.rs
@@ -1,0 +1,70 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    #[cfg(feature = "cuda")]
+    cuda::build_codec();
+}
+
+// Compiles cuda/src/kv_compression.cu (the GPU codec used by the connector's
+// optional low-bandwidth KV transfer path) into a static lib and links it
+// plus the CUDA runtime into the `openlake_client` extension. Mirrors
+// openlake_io/build.rs's `cc::Build` pattern for ucx_shim.c.
+#[cfg(feature = "cuda")]
+mod cuda {
+    use std::env;
+    use std::path::PathBuf;
+
+    pub fn build_codec() {
+        println!("cargo:rerun-if-changed=cuda/src/kv_compression.cu");
+        println!("cargo:rerun-if-changed=cuda/include/openlake/kv_compression.h");
+
+        let mut build = cc::Build::new();
+        build
+            .cuda(true)
+            .flag("-std=c++17")
+            .flag("--expt-relaxed-constexpr")
+            .include("cuda/include")
+            .file("cuda/src/kv_compression.cu");
+
+        let archs = env::var("OPENLAKE_CUDA_ARCHS").unwrap_or_else(|_| "80,89,90".to_string());
+        for arch in archs.split(',').map(str::trim).filter(|a| !a.is_empty()) {
+            build.flag(format!("-gencode=arch=compute_{arch},code=sm_{arch}"));
+        }
+
+        build.compile("openlake_kv_cuda_codec");
+
+        if let Some(lib_dir) = cuda_runtime_lib_dir() {
+            println!("cargo:rustc-link-search=native={}", lib_dir.display());
+        }
+        println!("cargo:rustc-link-lib=dylib=cudart");
+    }
+
+    /// Best-effort discovery of the CUDA runtime's lib dir, so `cudart` links
+    /// even when it is not already on the default linker search path.
+    fn cuda_runtime_lib_dir() -> Option<PathBuf> {
+        let home = env::var_os("CUDA_HOME")
+            .or_else(|| env::var_os("CUDA_PATH"))
+            .map(PathBuf::from)
+            .or_else(|| {
+                which_nvcc().and_then(|nvcc| {
+                    // .../<cuda-home>/bin/nvcc -> <cuda-home>
+                    nvcc.parent()
+                        .and_then(|bin| bin.parent())
+                        .map(PathBuf::from)
+                })
+            })?;
+        for candidate in ["lib64", "lib/x64", "lib"] {
+            let path = home.join(candidate);
+            if path.is_dir() {
+                return Some(path);
+            }
+        }
+        None
+    }
+
+    fn which_nvcc() -> Option<PathBuf> {
+        let path = env::var_os("PATH")?;
+        env::split_paths(&path)
+            .map(|dir| dir.join("nvcc"))
+            .find(|candidate| candidate.is_file())
+    }
+}

--- a/crates/openlake_kv_client/python/openlake_client/__init__.py
+++ b/crates/openlake_kv_client/python/openlake_client/__init__.py
@@ -1,3 +1,12 @@
-from openlake_client._native import Client, __version__
+from openlake_client._native import Client, __version__, cuda_compression_available
 
-__all__ = ["Client", "__version__"]
+__all__ = ["Client", "__version__", "cuda_compression_available"]
+
+if cuda_compression_available():
+    from openlake_client._native import (
+        cuda_compress,
+        cuda_compressed_size,
+        cuda_decompress,
+    )
+
+    __all__ += ["cuda_compress", "cuda_compressed_size", "cuda_decompress"]

--- a/crates/openlake_kv_client/src/cuda_codec.rs
+++ b/crates/openlake_kv_client/src/cuda_codec.rs
@@ -1,0 +1,212 @@
+//! FFI bindings to the on-GPU int8 group-quantization codec in
+//! `cuda/src/kv_compression.cu`, used by the vLLM connector's *optional*
+//! GPU-side KV compression path for low-bandwidth (RDMA/UCX/H2) transfers.
+//!
+//! This codec is **not** bit-exact: each `group_size`-element chunk is
+//! rescaled to a shared absmax and quantized to int8 (see the CUDA smoke
+//! test's tolerated `0.05` max error), trading KV-cache precision for a
+//! smaller wire payload. Callers that need bit-exact round trips must not
+//! enable it.
+//!
+//! Only compiled with `--features cuda`; requires a CUDA 12+ toolkit and
+//! `nvcc` at build time (see build.rs).
+#![cfg(feature = "cuda")]
+
+use std::ffi::{c_void, CStr};
+use std::os::raw::{c_char, c_int};
+
+pub const MIN_GROUP_SIZE: u32 = 16;
+pub const MAX_GROUP_SIZE: u32 = 4096;
+pub const GROUP_SIZE_ALIGNMENT: u32 = 16;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Dtype {
+    Fp16,
+    Bf16,
+}
+
+impl Dtype {
+    pub fn parse(name: &str) -> Result<Self, String> {
+        match name {
+            "fp16" | "float16" | "half" => Ok(Dtype::Fp16),
+            "bf16" | "bfloat16" => Ok(Dtype::Bf16),
+            other => Err(format!(
+                "unsupported GPU-compression dtype {other:?} (want fp16 or bf16)"
+            )),
+        }
+    }
+}
+
+type CudaStream = *mut c_void;
+
+unsafe extern "C" {
+    fn openlake_kv_compressed_size(element_count: usize, group_size: u32) -> usize;
+
+    fn openlake_kv_compress_fp16_async(
+        input: *const c_void,
+        element_count: usize,
+        group_size: u32,
+        output: *mut c_void,
+        output_bytes: usize,
+        stream: CudaStream,
+    ) -> c_int;
+    fn openlake_kv_compress_bf16_async(
+        input: *const c_void,
+        element_count: usize,
+        group_size: u32,
+        output: *mut c_void,
+        output_bytes: usize,
+        stream: CudaStream,
+    ) -> c_int;
+
+    fn openlake_kv_decompress_fp16_async(
+        input: *const c_void,
+        input_bytes: usize,
+        element_count: usize,
+        group_size: u32,
+        output: *mut c_void,
+        stream: CudaStream,
+    ) -> c_int;
+    fn openlake_kv_decompress_bf16_async(
+        input: *const c_void,
+        input_bytes: usize,
+        element_count: usize,
+        group_size: u32,
+        output: *mut c_void,
+        stream: CudaStream,
+    ) -> c_int;
+
+    fn cudaGetErrorString(error: c_int) -> *const c_char;
+}
+
+fn cuda_result(status: c_int, op: &str) -> Result<(), String> {
+    if status == 0 {
+        return Ok(());
+    }
+    let message = unsafe {
+        let ptr = cudaGetErrorString(status);
+        if ptr.is_null() {
+            "unknown CUDA error".to_string()
+        } else {
+            CStr::from_ptr(ptr).to_string_lossy().into_owned()
+        }
+    };
+    Err(format!("{op} failed: {message} (cudaError_t={status})"))
+}
+
+fn validate_group_size(group_size: u32) -> Result<(), String> {
+    if group_size < MIN_GROUP_SIZE
+        || group_size > MAX_GROUP_SIZE
+        || group_size % GROUP_SIZE_ALIGNMENT != 0
+    {
+        return Err(format!(
+            "group_size {group_size} must be in [{MIN_GROUP_SIZE}, {MAX_GROUP_SIZE}] and a \
+             multiple of {GROUP_SIZE_ALIGNMENT}"
+        ));
+    }
+    Ok(())
+}
+
+/// Worst-case (and, since this is fixed-ratio quantization, *exact*) byte
+/// size of the compressed buffer for `element_count` elements of the given
+/// `group_size`. Returns 0 for invalid inputs, matching the C ABI.
+pub fn compressed_size(element_count: usize, group_size: u32) -> Result<usize, String> {
+    validate_group_size(group_size)?;
+    if element_count == 0 {
+        return Err("element_count must be > 0".to_string());
+    }
+    let size = unsafe { openlake_kv_compressed_size(element_count, group_size) };
+    if size == 0 {
+        return Err(format!(
+            "no valid compressed layout for element_count={element_count} group_size={group_size}"
+        ));
+    }
+    Ok(size)
+}
+
+/// Launches the compression kernel on `stream` (a raw `cudaStream_t` value,
+/// e.g. from `torch.cuda.Stream().cuda_stream`; 0 is CUDA's default stream).
+///
+/// # Safety
+/// `input` must point to at least `element_count * sizeof(dtype)` readable
+/// device bytes and `output` to at least `output_bytes` writable device
+/// bytes, both valid for the lifetime of the (asynchronous) kernel launch.
+/// `stream` must be a valid `cudaStream_t` (or 0).
+pub unsafe fn compress_async(
+    dtype: Dtype,
+    input: u64,
+    element_count: usize,
+    group_size: u32,
+    output: u64,
+    output_bytes: usize,
+    stream: u64,
+) -> Result<(), String> {
+    validate_group_size(group_size)?;
+    let input = input as usize as *const c_void;
+    let output = output as usize as *mut c_void;
+    let stream = stream as usize as CudaStream;
+    let status = unsafe {
+        match dtype {
+            Dtype::Fp16 => openlake_kv_compress_fp16_async(
+                input,
+                element_count,
+                group_size,
+                output,
+                output_bytes,
+                stream,
+            ),
+            Dtype::Bf16 => openlake_kv_compress_bf16_async(
+                input,
+                element_count,
+                group_size,
+                output,
+                output_bytes,
+                stream,
+            ),
+        }
+    };
+    cuda_result(status, "openlake_kv_compress_async")
+}
+
+/// Launches the decompression kernel on `stream`. See [`compress_async`] for
+/// the pointer-validity and stream requirements.
+///
+/// # Safety
+/// `input` must point to at least `input_bytes` readable device bytes
+/// (the buffer produced by [`compress_async`]) and `output` to at least
+/// `element_count * sizeof(dtype)` writable device bytes.
+pub unsafe fn decompress_async(
+    dtype: Dtype,
+    input: u64,
+    input_bytes: usize,
+    element_count: usize,
+    group_size: u32,
+    output: u64,
+    stream: u64,
+) -> Result<(), String> {
+    validate_group_size(group_size)?;
+    let input = input as usize as *const c_void;
+    let output = output as usize as *mut c_void;
+    let stream = stream as usize as CudaStream;
+    let status = unsafe {
+        match dtype {
+            Dtype::Fp16 => openlake_kv_decompress_fp16_async(
+                input,
+                input_bytes,
+                element_count,
+                group_size,
+                output,
+                stream,
+            ),
+            Dtype::Bf16 => openlake_kv_decompress_bf16_async(
+                input,
+                input_bytes,
+                element_count,
+                group_size,
+                output,
+                stream,
+            ),
+        }
+    };
+    cuda_result(status, "openlake_kv_decompress_async")
+}

--- a/crates/openlake_kv_client/src/lib.rs
+++ b/crates/openlake_kv_client/src/lib.rs
@@ -1,4 +1,6 @@
 mod client;
+#[cfg(feature = "cuda")]
+mod cuda_codec;
 #[cfg(all(feature = "rdma", target_os = "linux"))]
 mod protocol;
 mod shm_local;
@@ -8,6 +10,7 @@ mod ucx_protocol;
 
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
+use pyo3::wrap_pyfunction;
 
 use crate::client::{KvClient, StoreClient};
 #[cfg(all(feature = "rdma", target_os = "linux"))]
@@ -123,9 +126,104 @@ impl PyClient {
     }
 }
 
+/// True when this extension was built with `--features cuda`, i.e. the
+/// `cuda_compressed_size`/`cuda_compress`/`cuda_decompress` functions below
+/// are available. Always defined so callers don't need to `hasattr`-probe.
+#[pyfunction]
+fn cuda_compression_available() -> bool {
+    cfg!(feature = "cuda")
+}
+
+/// Exact compressed byte size for `element_count` fp16/bf16 elements at
+/// `group_size`. This codec is fixed-ratio (int8 group quantization), so the
+/// size does not depend on the actual data.
+#[cfg(feature = "cuda")]
+#[pyfunction]
+fn cuda_compressed_size(element_count: u64, group_size: u32) -> PyResult<u64> {
+    cuda_codec::compressed_size(element_count as usize, group_size)
+        .map(|size| size as u64)
+        .map_err(PyValueError::new_err)
+}
+
+/// Launches the GPU compression kernel on the given CUDA stream. `input_ptr`
+/// and `output_ptr` are raw device addresses (e.g. `tensor.data_ptr()`);
+/// `stream_ptr` is a raw `cudaStream_t` (e.g.
+/// `torch.cuda.Stream().cuda_stream`, or 0 for the default stream). The
+/// launch is asynchronous: the caller must synchronize `stream_ptr` before
+/// reading `output_ptr`.
+///
+/// This is lossy int8 group quantization, not a bit-exact codec: see
+/// `cuda/src/kv_compression.cu`.
+#[cfg(feature = "cuda")]
+#[pyfunction]
+#[pyo3(signature = (dtype, input_ptr, element_count, group_size, output_ptr, output_bytes, stream_ptr = 0))]
+#[allow(clippy::too_many_arguments)]
+fn cuda_compress(
+    py: Python<'_>,
+    dtype: &str,
+    input_ptr: u64,
+    element_count: u64,
+    group_size: u32,
+    output_ptr: u64,
+    output_bytes: u64,
+    stream_ptr: u64,
+) -> PyResult<()> {
+    let dtype = cuda_codec::Dtype::parse(dtype).map_err(PyValueError::new_err)?;
+    py.detach(|| unsafe {
+        cuda_codec::compress_async(
+            dtype,
+            input_ptr,
+            element_count as usize,
+            group_size,
+            output_ptr,
+            output_bytes as usize,
+            stream_ptr,
+        )
+    })
+    .map_err(PyRuntimeError::new_err)
+}
+
+/// Launches the GPU decompression kernel on the given CUDA stream. See
+/// [`cuda_compress`] for pointer/stream conventions.
+#[cfg(feature = "cuda")]
+#[pyfunction]
+#[pyo3(signature = (dtype, input_ptr, input_bytes, element_count, group_size, output_ptr, stream_ptr = 0))]
+#[allow(clippy::too_many_arguments)]
+fn cuda_decompress(
+    py: Python<'_>,
+    dtype: &str,
+    input_ptr: u64,
+    input_bytes: u64,
+    element_count: u64,
+    group_size: u32,
+    output_ptr: u64,
+    stream_ptr: u64,
+) -> PyResult<()> {
+    let dtype = cuda_codec::Dtype::parse(dtype).map_err(PyValueError::new_err)?;
+    py.detach(|| unsafe {
+        cuda_codec::decompress_async(
+            dtype,
+            input_ptr,
+            input_bytes as usize,
+            element_count as usize,
+            group_size,
+            output_ptr,
+            stream_ptr,
+        )
+    })
+    .map_err(PyRuntimeError::new_err)
+}
+
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyClient>()?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    m.add_function(wrap_pyfunction!(cuda_compression_available, m)?)?;
+    #[cfg(feature = "cuda")]
+    {
+        m.add_function(wrap_pyfunction!(cuda_compressed_size, m)?)?;
+        m.add_function(wrap_pyfunction!(cuda_compress, m)?)?;
+        m.add_function(wrap_pyfunction!(cuda_decompress, m)?)?;
+    }
     Ok(())
 }

--- a/external/connectors/vllm/openlake_adapter.py
+++ b/external/connectors/vllm/openlake_adapter.py
@@ -502,6 +502,141 @@ def _group_tp_replication_factors(
     return tuple(factor_for(group.kv_cache_spec) for group in kv_cache_groups)
 
 
+class GpuBlockCompressor:
+    """Optional on-GPU int8 group-quantization codec for the KV transfer
+    path (see crates/openlake_kv_client/cuda/src/kv_compression.cu).
+
+    The codec is fixed-ratio: a block's compressed byte size depends only
+    on its element count and ``group_size``, never on its contents, so the
+    staging layout below can be sized once, at registration time, and every
+    (addr, size) pair handed to put_batch/get_batch stays constant for the
+    lifetime of the worker.
+
+    This is **not** a bit-exact codec -- each ``group_size``-element chunk
+    is rescaled to a shared int8 range, which loses precision. Only enable
+    it (``openlake_gpu_compression``) when that KV-cache precision loss is
+    an acceptable trade for a smaller wire payload on a bandwidth-limited
+    link (e.g. cross-node RDMA/UCX).
+    """
+
+    _TORCH_DTYPE_NAMES = {
+        "torch.float16": "fp16",
+        "torch.bfloat16": "bf16",
+    }
+
+    def __init__(self, group_size: int):
+        import openlake_client
+
+        if not openlake_client.cuda_compression_available():
+            raise RuntimeError(
+                "openlake_gpu_compression requires the CUDA-enabled "
+                "openlake_client build (built with `--features cuda`)"
+            )
+        self._native = openlake_client
+        self.group_size = group_size
+        # Parallel per-segment metadata: (dtype_name, element_count,
+        # compressed_block_bytes, raw_block_bytes, raw_base_addr,
+        # staging_base_addr).
+        self._segments: list[tuple[str, int, int, int, int, int]] = []
+        # Keeps the staging tensors alive for the compressor's lifetime.
+        self._staging_tensors: list[torch.Tensor] = []
+        self._stream = torch.cuda.Stream()
+
+    def add_segment(self, cache, base_addr: int, block_bytes: int, num_blocks: int,
+                    register_memory) -> int:
+        """Registers one raw KV-cache segment (as produced by
+        OpenLakeWorker.register_kv_caches) and allocates its compressed
+        staging buffer. Returns the fixed per-block compressed byte size.
+        """
+        dtype_name = self._TORCH_DTYPE_NAMES.get(str(cache.dtype))
+        if dtype_name is None:
+            raise ValueError(
+                f"openlake_gpu_compression only supports fp16/bf16 KV "
+                f"caches, got {cache.dtype}"
+            )
+        itemsize = cache.element_size()
+        if block_bytes % itemsize != 0:
+            raise ValueError(
+                f"segment block size {block_bytes} is not a whole number "
+                f"of {cache.dtype} elements"
+            )
+        element_count = block_bytes // itemsize
+        compressed_bytes = self._native.cuda_compressed_size(
+            element_count, self.group_size
+        )
+        staging = torch.empty(
+            num_blocks * compressed_bytes, dtype=torch.uint8, device=cache.device
+        )
+        register_memory(staging.data_ptr(), staging.numel())
+        self._staging_tensors.append(staging)
+        self._segments.append((
+            dtype_name, element_count, compressed_bytes, block_bytes,
+            base_addr, staging.data_ptr(),
+        ))
+        return compressed_bytes
+
+    def wait_for(self, event) -> None:
+        """Makes this compressor's stream wait (GPU-side, non-blocking on
+        the host) for `event`, e.g. the event recorded after the model's
+        compute stream finished writing the KV cache blocks about to be
+        compressed."""
+        if event is not None:
+            self._stream.wait_event(event)
+
+    def compress_block(self, block_id: int) -> list[tuple[int, int]]:
+        """Launches (asynchronously, on this compressor's stream) the
+        compression kernel for every segment of `block_id` and returns the
+        resulting (staging_addr, compressed_bytes) scatter list. Call
+        `synchronize()` before the staging buffers are read (e.g. by
+        put_batch)."""
+        stream_ptr = self._stream.cuda_stream
+        scatter = []
+        with torch.cuda.stream(self._stream):
+            for dtype_name, element_count, compressed_bytes, block_bytes, \
+                    raw_addr, staging_addr in self._segments:
+                self._native.cuda_compress(
+                    dtype_name,
+                    raw_addr + block_id * block_bytes,
+                    element_count,
+                    self.group_size,
+                    staging_addr + block_id * compressed_bytes,
+                    compressed_bytes,
+                    stream_ptr,
+                )
+                scatter.append(
+                    (staging_addr + block_id * compressed_bytes, compressed_bytes)
+                )
+        return scatter
+
+    def decompress_block(self, block_id: int) -> list[tuple[int, int]]:
+        """Returns the (staging_addr, compressed_bytes) scatter list to
+        pass to get_batch for `block_id`. Call `finish_decompress(block_id)`
+        once the get completes to launch the decode kernels, then
+        `synchronize()` before the raw KV cache is read."""
+        return [
+            (staging_addr + block_id * compressed_bytes, compressed_bytes)
+            for _, _, compressed_bytes, _, _, staging_addr in self._segments
+        ]
+
+    def finish_decompress(self, block_id: int) -> None:
+        stream_ptr = self._stream.cuda_stream
+        with torch.cuda.stream(self._stream):
+            for dtype_name, element_count, compressed_bytes, block_bytes, \
+                    raw_addr, staging_addr in self._segments:
+                self._native.cuda_decompress(
+                    dtype_name,
+                    staging_addr + block_id * compressed_bytes,
+                    compressed_bytes,
+                    element_count,
+                    self.group_size,
+                    raw_addr + block_id * block_bytes,
+                    stream_ptr,
+                )
+
+    def synchronize(self) -> None:
+        self._stream.synchronize()
+
+
 class KVTransferThread(threading.Thread):
 
     def __init__(self, client, group_keys, block_size, tp_rank, namespaces, layout,
@@ -579,11 +714,13 @@ class KVCacheSendingThread(KVTransferThread):
 
     def __init__(self, client, group_keys, block_size, tp_rank, namespaces, layout,
                  coord, ready_event, replication_factors,
-                 enable_kv_event: bool = False, record_operation=None):
+                 enable_kv_event: bool = False, record_operation=None,
+                 gpu_compressor: "GpuBlockCompressor | None" = None):
         super().__init__(client, group_keys, block_size, tp_rank, namespaces, layout,
                          coord, ready_event, name="KVCacheSendingThread",
                          record_operation=record_operation)
         self.replication_factors = replication_factors
+        self.gpu_compressor = gpu_compressor
         self.stored_requests: dict[str, int] = {}
         self.enable_kv_event = enable_kv_event
         self._store_pressure_active = False
@@ -689,9 +826,19 @@ class KVCacheSendingThread(KVTransferThread):
             sizes: list[list[int]] = []
             stored_events: list[BlockStored] = []
             prev_hash_per_group: dict[int, object] = {}
+            compressing = self.gpu_compressor is not None
+            if compressing:
+                # GPU-side wait (non-blocking on the host): the compress
+                # kernels below must not read the KV cache blocks until the
+                # compute stream has finished writing them.
+                self.gpu_compressor.wait_for(req_meta.current_event)
             for group, chunk_idx, block_hash in entries:
                 block_id = req_meta.block_ids[group.g_idx][chunk_idx]
-                scatter = self.layout.addrs_for(block_id)
+                scatter = (
+                    self.gpu_compressor.compress_block(block_id)
+                    if compressing
+                    else self.layout.addrs_for(block_id)
+                )
                 addrs.append([addr for addr, _ in scatter])
                 sizes.append([size for _, size in scatter])
                 if self.enable_kv_event:
@@ -710,7 +857,11 @@ class KVCacheSendingThread(KVTransferThread):
                     ))
                     prev_hash_per_group[group.g_idx] = event_hash
 
-            if req_meta.current_event is not None:
+            if compressing:
+                # Blocks until the compress kernels finish, so put_batch
+                # below reads finished data out of the staging buffers.
+                self.gpu_compressor.synchronize()
+            elif req_meta.current_event is not None:
                 req_meta.current_event.synchronize()
 
             batch_bytes = sum(sum(seg) for seg in sizes)
@@ -752,11 +903,13 @@ class KVCacheSendingThread(KVTransferThread):
 class KVCacheRecvingThread(KVTransferThread):
 
     def __init__(self, client, group_keys, block_size, tp_rank, namespaces, layout,
-                 coord, ready_event, request_queue=None, record_operation=None):
+                 coord, ready_event, request_queue=None, record_operation=None,
+                 gpu_compressor: "GpuBlockCompressor | None" = None):
         super().__init__(client, group_keys, block_size, tp_rank, namespaces, layout,
                          coord, ready_event, name="KVCacheRecvingThread",
                          request_queue=request_queue,
                          record_operation=record_operation)
+        self.gpu_compressor = gpu_compressor
         self._invalid_block_ids_lock = threading.Lock()
         self._invalid_block_ids: set[int] = set()
 
@@ -799,10 +952,15 @@ class KVCacheRecvingThread(KVTransferThread):
         entries = entries[rotation:] + entries[:rotation]
         key_list = [key for _, key in entries]
         block_id_list = [block_id for block_id, _ in entries]
+        compressing = self.gpu_compressor is not None
         addr_list: list[list[int]] = []
         size_list: list[list[int]] = []
         for block_id, _ in entries:
-            scatter = self.layout.addrs_for(block_id)
+            scatter = (
+                self.gpu_compressor.decompress_block(block_id)
+                if compressing
+                else self.layout.addrs_for(block_id)
+            )
             addr_list.append([addr for addr, _ in scatter])
             size_list.append([size for _, size in scatter])
 
@@ -825,6 +983,11 @@ class KVCacheRecvingThread(KVTransferThread):
                     "load_get", get_start, len(batch_keys), num_bytes=batch_bytes,
                     status="partial_failure" if failed else "ok",
                     num_failed_keys=len(failed))
+                if compressing:
+                    failed_ids = {block_id for _, _, block_id in failed}
+                    for block_id in batch_block_ids:
+                        if block_id not in failed_ids:
+                            self.gpu_compressor.finish_decompress(block_id)
                 if failed:
                     self._add_load_error_block_ids(
                         [block_id for _, _, block_id in failed]
@@ -841,6 +1004,10 @@ class KVCacheRecvingThread(KVTransferThread):
                                    status="error",
                                    num_failed_keys=len(current_batch_block_ids))
             logger.error("get_batch failed (req=%s): %s", req_id, err)
+        if compressing:
+            # Blocks until the decompress kernels finish, so the raw KV
+            # cache is fully populated before this request is reported done.
+            self.gpu_compressor.synchronize()
         self.set_finished_request(req_id)
         self.request_queue.task_done()
 
@@ -938,6 +1105,11 @@ class OpenLakeWorker:
             )
         self.num_recv_threads = max(1, int(extra.get("openlake_recv_threads", 1)))
         self.enable_kv_events = bool(extra.get("openlake_kv_events", False))
+        self.gpu_compression_enabled = bool(extra.get("openlake_gpu_compression", False))
+        self.gpu_compression_group_size = int(
+            extra.get("openlake_gpu_compression_group_size", 128)
+        )
+        self._gpu_compressor: "GpuBlockCompressor | None" = None
         self.layout = GroupLayout()
         self.kv_send_thread: "KVCacheSendingThread | None" = None
         self.kv_recv_threads: list[KVCacheRecvingThread] = []
@@ -992,6 +1164,7 @@ class OpenLakeWorker:
         seen_ptrs: set[int] = set()
         addrs: list[int] = []
         block_lens: list[int] = []
+        segment_caches: list = []
         for value in kv_caches.values():
             cache = value[0] if isinstance(value, list) else value
             storage = cache.untyped_storage()
@@ -1010,13 +1183,43 @@ class OpenLakeWorker:
             if not outer:
                 addrs.append(base_addr)
                 block_lens.append(page_bytes)
+                segment_caches.append(cache)
             else:
                 seg_stride = cache.stride(outer[0]) * element
                 for idx in range(cache.shape[outer[0]]):
                     addrs.append(base_addr + idx * seg_stride)
                     block_lens.append(seg_stride // self._num_blocks)
+                    segment_caches.append(cache)
         self.layout.set(addrs, block_lens)
-        local_slot_bytes = SLOT_HEADER_BYTES + sum(block_lens) if addrs else 0
+
+        compressed_block_lens: list[int] | None = None
+        if self.gpu_compression_enabled and addrs:
+            try:
+                compressor = GpuBlockCompressor(self.gpu_compression_group_size)
+                compressed_block_lens = [
+                    compressor.add_segment(
+                        segment_caches[i], addrs[i], block_lens[i],
+                        self._num_blocks, self._client.register_memory,
+                    )
+                    for i in range(len(addrs))
+                ]
+                self._gpu_compressor = compressor
+                logger.info(
+                    "openlake: GPU compression enabled (group_size=%d): "
+                    "%d B/block -> %d B/block payload",
+                    self.gpu_compression_group_size,
+                    sum(block_lens), sum(compressed_block_lens),
+                )
+            except Exception as err:
+                logger.warning(
+                    "openlake: GPU compression unavailable, falling back to "
+                    "uncompressed KV transfer: %s", err,
+                )
+                self._gpu_compressor = None
+                compressed_block_lens = None
+
+        payload_lens = compressed_block_lens or block_lens
+        local_slot_bytes = SLOT_HEADER_BYTES + sum(payload_lens) if addrs else 0
         slot_bytes = self._sync_max_slot_bytes(local_slot_bytes)
         if not addrs:
             logger.warning(
@@ -1047,6 +1250,7 @@ class OpenLakeWorker:
                 self._group_tp_replication_factors,
                 self.enable_kv_events,
                 record_operation=self._record_kv_connector_operation,
+                gpu_compressor=self._gpu_compressor,
             )
             self.kv_send_thread.start()
 
@@ -1065,6 +1269,7 @@ class OpenLakeWorker:
                 ready_event_recving,
                 request_queue=self.recv_request_queue,
                 record_operation=self._record_kv_connector_operation,
+                gpu_compressor=self._gpu_compressor,
             )
             recv_thread.name = f"KVCacheRecvingThread-{i}"
             recv_thread.start()

--- a/external/connectors/vllm/tests/test_openlake_adapter.py
+++ b/external/connectors/vllm/tests/test_openlake_adapter.py
@@ -33,6 +33,19 @@ def _module(name: str) -> types.ModuleType:
     return module
 
 
+class _StreamContext:
+    """Fakes the object returned by ``torch.cuda.stream(...)``."""
+
+    def __init__(self, stream):
+        self._stream = stream
+
+    def __enter__(self):
+        return self._stream
+
+    def __exit__(self, *_exc):
+        return False
+
+
 def _install_import_stubs() -> None:
     torch = _module("torch")
     torch.cuda = SimpleNamespace(Event=object)
@@ -487,6 +500,340 @@ class OpenLakeRankNamespaceTests(unittest.TestCase):
         self.assertEqual(
             scheduler._gather_exists([block_hash], 16),
             {(0, block_hash), (1, block_hash)},
+        )
+
+
+class GpuBlockCompressorTests(unittest.TestCase):
+    """Unit tests for the optional on-GPU KV compression codec wiring.
+
+    These mock out ``openlake_client``'s ``cuda_*`` functions (the pyo3
+    bindings over crates/openlake_kv_client/src/cuda_codec.rs) and
+    ``torch.cuda`` so the address/size arithmetic can be checked without a
+    CUDA build or GPU.
+    """
+
+    def setUp(self):
+        torch = sys.modules["torch"]
+        self._orig_cuda = torch.cuda
+        self._orig_empty = getattr(torch, "empty", None)
+        self._orig_uint8 = getattr(torch, "uint8", None)
+
+        class FakeStream:
+            def __init__(self):
+                self.cuda_stream = id(self)
+                self.waited = []
+                self.synced = 0
+
+            def wait_event(self, event):
+                self.waited.append(event)
+
+            def synchronize(self):
+                self.synced += 1
+
+        self.FakeStream = FakeStream
+        torch.cuda = SimpleNamespace(
+            Event=object,
+            Stream=FakeStream,
+            stream=lambda stream: _StreamContext(stream),
+        )
+
+        class FakeStagingTensor:
+            def __init__(self, nbytes, dtype, device):
+                self._nbytes = nbytes
+                self.dtype = dtype
+                self.device = device
+
+            def data_ptr(self):
+                return 0xB000
+
+            def numel(self):
+                return self._nbytes
+
+        self.FakeStagingTensor = FakeStagingTensor
+        torch.empty = lambda n, dtype=None, device=None: FakeStagingTensor(n, dtype, device)
+        torch.uint8 = "uint8"
+        self.addCleanup(self._restore_torch)
+
+    def _restore_torch(self):
+        torch = sys.modules["torch"]
+        torch.cuda = self._orig_cuda
+        if self._orig_empty is not None:
+            torch.empty = self._orig_empty
+        else:
+            del torch.empty
+        if self._orig_uint8 is not None:
+            torch.uint8 = self._orig_uint8
+        else:
+            del torch.uint8
+
+    def _fake_client(self, *, available=True):
+        client = _module("openlake_client")
+        client.cuda_compression_available = lambda: available
+        # One byte of compressed payload per element, so expected sizes stay
+        # easy to compute by hand in the assertions below.
+        client.cuda_compressed_size = lambda element_count, group_size: element_count
+        calls = SimpleNamespace(compress=[], decompress=[])
+        client.cuda_compress = lambda *args: calls.compress.append(args)
+        client.cuda_decompress = lambda *args: calls.decompress.append(args)
+        return client, calls
+
+    def test_requires_cuda_enabled_build(self):
+        self._fake_client(available=False)
+        with self.assertRaisesRegex(RuntimeError, "requires the CUDA-enabled"):
+            ADAPTER.GpuBlockCompressor(128)
+
+    def test_add_segment_rejects_unsupported_dtype(self):
+        self._fake_client()
+        compressor = ADAPTER.GpuBlockCompressor(128)
+        cache = SimpleNamespace(dtype="torch.float32", device="cuda:0", element_size=lambda: 4)
+
+        with self.assertRaisesRegex(ValueError, "fp16/bf16"):
+            compressor.add_segment(
+                cache, base_addr=0, block_bytes=64, num_blocks=2,
+                register_memory=lambda *_: None,
+            )
+
+    def test_add_segment_rejects_block_bytes_not_a_whole_number_of_elements(self):
+        self._fake_client()
+        compressor = ADAPTER.GpuBlockCompressor(128)
+        cache = SimpleNamespace(dtype="torch.bfloat16", device="cuda:0", element_size=lambda: 2)
+
+        with self.assertRaisesRegex(ValueError, "whole number"):
+            compressor.add_segment(
+                cache, base_addr=0, block_bytes=5, num_blocks=1,
+                register_memory=lambda *_: None,
+            )
+
+    def test_add_segment_sizes_and_registers_fixed_ratio_staging_buffer(self):
+        self._fake_client()
+        compressor = ADAPTER.GpuBlockCompressor(128)
+        cache = SimpleNamespace(dtype="torch.float16", device="cuda:3", element_size=lambda: 2)
+        registered = []
+
+        compressed_bytes = compressor.add_segment(
+            cache, base_addr=0x1000, block_bytes=256, num_blocks=4,
+            register_memory=lambda addr, length: registered.append((addr, length)),
+        )
+
+        # element_count = block_bytes // itemsize = 128; the fake
+        # cuda_compressed_size above returns element_count directly.
+        self.assertEqual(compressed_bytes, 128)
+        self.assertEqual(registered, [(0xB000, 4 * 128)])
+        self.assertEqual(len(compressor._staging_tensors), 1)
+        self.assertEqual(compressor._staging_tensors[0].device, "cuda:3")
+
+    def test_compress_block_launches_kernel_at_block_offset_and_returns_scatter(self):
+        _, calls = self._fake_client()
+        compressor = ADAPTER.GpuBlockCompressor(64)
+        cache = SimpleNamespace(dtype="torch.float16", device="cuda:0", element_size=lambda: 2)
+        compressed_bytes = compressor.add_segment(
+            cache, base_addr=0x1000, block_bytes=256, num_blocks=4,
+            register_memory=lambda *_: None,
+        )
+        staging_addr = compressor._segments[0][5]
+
+        scatter = compressor.compress_block(2)
+
+        self.assertEqual(scatter, [(staging_addr + 2 * compressed_bytes, compressed_bytes)])
+        self.assertEqual(len(calls.compress), 1)
+        dtype, input_ptr, element_count, group_size, output_ptr, output_bytes, _stream_ptr = calls.compress[0]
+        self.assertEqual(dtype, "fp16")
+        self.assertEqual(input_ptr, 0x1000 + 2 * 256)
+        self.assertEqual(element_count, 128)
+        self.assertEqual(group_size, 64)
+        self.assertEqual(output_ptr, staging_addr + 2 * compressed_bytes)
+        self.assertEqual(output_bytes, compressed_bytes)
+
+    def test_decompress_block_returns_scatter_without_launching_a_kernel(self):
+        _, calls = self._fake_client()
+        compressor = ADAPTER.GpuBlockCompressor(64)
+        cache = SimpleNamespace(dtype="torch.bfloat16", device="cuda:0", element_size=lambda: 2)
+        compressed_bytes = compressor.add_segment(
+            cache, base_addr=0x2000, block_bytes=128, num_blocks=3,
+            register_memory=lambda *_: None,
+        )
+        staging_addr = compressor._segments[0][5]
+
+        scatter = compressor.decompress_block(1)
+
+        self.assertEqual(scatter, [(staging_addr + compressed_bytes, compressed_bytes)])
+        self.assertEqual(calls.decompress, [])
+
+    def test_finish_decompress_launches_kernel_writing_into_the_raw_block(self):
+        _, calls = self._fake_client()
+        compressor = ADAPTER.GpuBlockCompressor(64)
+        cache = SimpleNamespace(dtype="torch.bfloat16", device="cuda:0", element_size=lambda: 2)
+        compressed_bytes = compressor.add_segment(
+            cache, base_addr=0x2000, block_bytes=128, num_blocks=3,
+            register_memory=lambda *_: None,
+        )
+        staging_addr = compressor._segments[0][5]
+
+        compressor.finish_decompress(1)
+
+        self.assertEqual(len(calls.decompress), 1)
+        dtype, input_ptr, input_bytes, element_count, group_size, output_ptr, _stream_ptr = calls.decompress[0]
+        self.assertEqual(dtype, "bf16")
+        self.assertEqual(input_ptr, staging_addr + compressed_bytes)
+        self.assertEqual(input_bytes, compressed_bytes)
+        self.assertEqual(element_count, 64)
+        self.assertEqual(group_size, 64)
+        self.assertEqual(output_ptr, 0x2000 + 1 * 128)
+
+    def test_wait_for_and_synchronize_delegate_to_the_compressor_stream(self):
+        self._fake_client()
+        compressor = ADAPTER.GpuBlockCompressor(64)
+        event = object()
+
+        compressor.wait_for(event)
+        compressor.wait_for(None)
+        compressor.synchronize()
+
+        self.assertEqual(compressor._stream.waited, [event])
+        self.assertEqual(compressor._stream.synced, 1)
+
+
+class RegisterKvCachesGpuCompressionTests(unittest.TestCase):
+    """Covers OpenLakeWorker.register_kv_caches's GPU-compression branch and
+    its fall back to uncompressed transfer when the CUDA build is
+    unavailable or the codec rejects the KV cache's dtype."""
+
+    def _worker(self, **overrides):
+        registered_memory = []
+        attached = []
+        layout_calls = []
+        worker = SimpleNamespace(
+            _num_blocks=4,
+            _client=SimpleNamespace(
+                register_memory=lambda addr, length: registered_memory.append((addr, length)),
+                attach=lambda addr, node_id, slot_bytes: attached.append((addr, node_id, slot_bytes)),
+            ),
+            layout=SimpleNamespace(set=lambda addrs, lens: layout_calls.append((addrs, lens))),
+            gpu_compression_enabled=True,
+            gpu_compression_group_size=128,
+            _gpu_compressor=None,
+            _nodes=["node-a"],
+            _sync_max_slot_bytes=lambda n: n,
+            # kv_role="kv_consumer" and num_recv_threads=0 keep this test
+            # from spinning up real KVCacheSendingThread/KVCacheRecvingThread
+            # background threads, which are exercised elsewhere.
+            kv_role="kv_consumer",
+            num_recv_threads=0,
+        )
+        for key, value in overrides.items():
+            setattr(worker, key, value)
+        worker.registered_memory = registered_memory
+        worker.attached = attached
+        worker.layout_calls = layout_calls
+        return worker
+
+    def _cache(self, *, dtype="torch.float16", itemsize=2, storage_bytes):
+        storage = SimpleNamespace(data_ptr=lambda: 0x9000, nbytes=lambda: storage_bytes)
+        return SimpleNamespace(
+            untyped_storage=lambda: storage,
+            element_size=lambda: itemsize,
+            ndim=1,
+            stride=lambda _d: 1,
+            shape=(1,),
+            dtype=dtype,
+            device="cuda:0",
+        )
+
+    def test_falls_back_to_uncompressed_when_cuda_build_is_unavailable(self):
+        _module("openlake_client").cuda_compression_available = lambda: False
+        worker = self._worker()
+        cache = self._cache(storage_bytes=1024)  # 4 blocks * 256 B/block
+
+        ADAPTER.OpenLakeWorker.register_kv_caches(worker, {"layer": cache})
+
+        self.assertIsNone(worker._gpu_compressor)
+        self.assertEqual(worker.layout_calls, [([0x9000], [256])])
+        self.assertEqual(
+            worker.attached, [("node-a", 0, ADAPTER.SLOT_HEADER_BYTES + 256)]
+        )
+
+    def test_falls_back_to_uncompressed_when_kv_cache_dtype_is_unsupported(self):
+        _module("openlake_client").cuda_compression_available = lambda: True
+
+        torch = sys.modules["torch"]
+        orig_cuda = torch.cuda
+
+        class FakeStream:
+            def wait_event(self, _event):
+                pass
+
+            def synchronize(self):
+                pass
+
+        torch.cuda = SimpleNamespace(Event=object, Stream=FakeStream)
+        try:
+            worker = self._worker()
+            cache = self._cache(dtype="torch.float32", itemsize=4, storage_bytes=1024)
+
+            ADAPTER.OpenLakeWorker.register_kv_caches(worker, {"layer": cache})
+        finally:
+            torch.cuda = orig_cuda
+
+        self.assertIsNone(worker._gpu_compressor)
+        self.assertEqual(
+            worker.attached, [("node-a", 0, ADAPTER.SLOT_HEADER_BYTES + 256)]
+        )
+
+    def test_enables_compression_and_shrinks_the_registered_slot(self):
+        client = _module("openlake_client")
+        client.cuda_compression_available = lambda: True
+        client.cuda_compressed_size = lambda element_count, _group_size: element_count // 4
+        client.cuda_compress = lambda *_args: None
+        client.cuda_decompress = lambda *_args: None
+
+        torch = sys.modules["torch"]
+        orig_cuda, orig_empty, orig_uint8 = (
+            torch.cuda, getattr(torch, "empty", None), getattr(torch, "uint8", None)
+        )
+
+        class FakeStream:
+            def wait_event(self, _event):
+                pass
+
+            def synchronize(self):
+                pass
+
+        class FakeStaging:
+            def __init__(self, n):
+                self._n = n
+
+            def data_ptr(self):
+                return 0xB000
+
+            def numel(self):
+                return self._n
+
+        torch.cuda = SimpleNamespace(
+            Event=object, Stream=FakeStream, stream=lambda s: _StreamContext(s)
+        )
+        torch.empty = lambda n, dtype=None, device=None: FakeStaging(n)
+        torch.uint8 = "uint8"
+        try:
+            worker = self._worker()
+            # 256 B/block, itemsize 2 -> 128 elements/block.
+            cache = self._cache(storage_bytes=1024)
+
+            ADAPTER.OpenLakeWorker.register_kv_caches(worker, {"layer": cache})
+        finally:
+            torch.cuda = orig_cuda
+            if orig_empty is not None:
+                torch.empty = orig_empty
+            else:
+                del torch.empty
+            if orig_uint8 is not None:
+                torch.uint8 = orig_uint8
+            else:
+                del torch.uint8
+
+        self.assertIsNotNone(worker._gpu_compressor)
+        # compressed_bytes = element_count // 4 = 32
+        self.assertEqual(
+            worker.attached, [("node-a", 0, ADAPTER.SLOT_HEADER_BYTES + 32)]
         )
 
 


### PR DESCRIPTION
 PR Description

  ## Summary
  - Add a `cuda` Cargo feature to `openlake_kv_client` (off by default) that
    builds the existing `cuda/src/kv_compression.cu` kernel via `nvcc`
    (`build.rs`) and exposes it to Python as `cuda_compression_available` /
    `cuda_compressed_size` / `cuda_compress` / `cuda_decompress`.
  - Wire an optional `GpuBlockCompressor` into the vLLM connector
    (`openlake_adapter.py`), enabled per-worker via
    `kv_connector_extra_config`'s `openlake_gpu_compression` /
    `openlake_gpu_compression_group_size`. Compression is fully opt-in and
    fails safe: any construction/dtype error falls back to uncompressed
    transfer with a warning log.
  - No wire-protocol or server-side changes: the codec is fixed-ratio
    (compressed size is a pure function of `element_count`/`group_size`), so
    existing slot sizing (`_sync_max_slot_bytes`) already handles it.

  ## Note on "lossless"
  The underlying kernel (merged earlier under #223) does per-group absmax
  int8 quantization — it is **lossy**, not bit-exact (the existing GPU smoke
  test tolerates up to 0.05 max abs error). This PR just wires it up as-is;
  it doesn't change that tradeoff. Worth confirming that's acceptable before
  enabling `openlake_gpu_compression` on precision-sensitive workloads.

  ## Test plan
  - [x] `cargo check -p openlake_kv_client` (default build, no `cuda`
        feature) — unaffected
  - [x] `cargo check -p openlake_kv_client --features cuda` against a real
        `nvcc`/CUDA 12.4 toolchain on a T4 GPU (Modal sandbox)
  - [x] GPU kernel smoke test (`cuda/tests/kv_compression_smoke.cu`) run on
        real T4 hardware — compress/decompress round trip within tolerance
  - [x] `python3 -m unittest discover -s external/connectors/vllm/tests` —
        26 tests passing, including new coverage for `GpuBlockCompressor`
        and the `register_kv_caches` fallback path
  - [x] End-to-end vLLM serving run with GPU compression enabled (not
        exercised in this PR)