### PR TITLE
fix(s3): reject bucket names with surrounding whitespace

### DIFF
--- a/crates/openlake_storage/src/engine.rs
+++ b/crates/openlake_storage/src/engine.rs
@@ -2254,32 +2254,33 @@ fn validate_bucket_name(name: &str) -> StorageResult<()> {
         std::sync::LazyLock::new(|| regex::Regex::new(r"^(\d+\.){3}\d+$").unwrap());
 
     let bad = || StorageError::InvalidBucketName(name.to_owned());
-    let trimmed = name.trim();
 
-    if trimmed.is_empty() {
+    // Validate the raw name — do not trim before checking. Leading or
+    // trailing whitespace (including tabs) must be rejected, not
+    // silently normalized away.
+    if name.is_empty() {
         return Err(bad());
     }
-    if trimmed.len() < 3 {
+    if name.len() < 3 {
         return Err(bad());
     }
-    if trimmed.len() > 63 {
+    if name.len() > 63 {
         return Err(bad());
     }
-    if trimmed == "openlake" {
+    if name == "openlake" {
         return Err(bad());
     }
-    if IP_ADDRESS.is_match(trimmed) {
+    if IP_ADDRESS.is_match(name) {
         return Err(bad());
     }
-    if trimmed.contains("..") || trimmed.contains(".-") || trimmed.contains("-.") {
+    if name.contains("..") || name.contains(".-") || name.contains("-.") {
         return Err(bad());
     }
-    if !VALID_BUCKET_NAME_STRICT.is_match(trimmed) {
+    if !VALID_BUCKET_NAME_STRICT.is_match(name) {
         return Err(bad());
     }
     Ok(())
 }
-
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
@@ -3551,6 +3552,45 @@ mod tests {
         ] {
             validate_bucket_name(ok).unwrap();
         }
+    }
+
+    #[test]
+    fn rejects_bucket_names_with_surrounding_whitespace() {
+        let cases: &[(&str, &str)] = &[
+            (" demo", "leading space"),
+            ("demo ", "trailing space"),
+            (" demo ", "leading and trailing space"),
+            ("\tdemo", "leading tab"),
+            ("demo\t", "trailing tab"),
+            ("\tdemo\t", "leading and trailing tab"),
+        ];
+        for (name, desc) in cases {
+            assert!(
+                validate_bucket_name(name).is_err(),
+                "should reject {desc}: {name:?}"
+            );
+        }
+        for ok in ["demo", "a-b-c", "abc123"] {
+            validate_bucket_name(ok).unwrap();
+        }
+    }
+
+    #[compio::test]
+    async fn bucket_ops_reject_whitespace_padded_names_consistently() {
+        let (_dirs, e) = eng(3, 3).await;
+        let bad = " demo ";
+
+        let err = e
+            .create_bucket(bad, BucketMeta::new(0, false))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, StorageError::InvalidBucketName(_)));
+
+        let err = e.stat_bucket(bad).await.unwrap_err();
+        assert!(matches!(err, StorageError::InvalidBucketName(_)));
+
+        let err = e.delete_bucket(bad, false).await.unwrap_err();
+        assert!(matches!(err, StorageError::InvalidBucketName(_)));
     }
 
     #[compio::test]


### PR DESCRIPTION
Closes #264.

What was wrong

validate_bucket_name trimmed the bucket name before running any checks against it. That meant a name like " demo " would pass validation, since the trimmed value "demo" is perfectly valid, even though the original name had spaces that should have been rejected outright.

Design decision

The fix is to validate the raw name directly instead of a trimmed copy. I considered adding a dedicated whitespace check up front, but that turned out to be unnecessary: the existing strict-name regex already excludes any character outside [a-z0-9.-], so once the trim is removed, whitespace fails validation naturally through the existing rules. This keeps the fix minimal and avoids duplicating logic that's already there.

Since create_bucket, stat_bucket, and delete_bucket all call this one validator, fixing it here applies consistently across all three operations without needing changes at each call site.

Testing

Added a table driven test covering leading space, trailing space, both together, and tabs, along with a handful of valid names to confirm nothing gets over rejected.
Added an engine level test that calls create_bucket, stat_bucket, and delete_bucket with a whitespace padded name and confirms all three return InvalidBucketName consistently.
Ran the full suite for both affected crates: cargo test -p openlake_storage (65 passed) and cargo test -p openlake_server (51 passed).

Limitations

I didn't find an HTTP level test harness in this codebase, nothing currently spins up the router and sends a real request, so the regression test here operates at the Engine level rather than a true wire level S3 test. Happy to add a router level test as well if that's expected here, let me know.