### PR TITLE
(#253) [v0.9] fix(helm): require shared hostpath for h2 connector

### DIFF
--- a/charts/openlake/templates/_helpers.tpl
+++ b/charts/openlake/templates/_helpers.tpl
@@ -61,9 +61,6 @@ ucx
   {{- if not .Values.kv.connector.enabled -}}
     {{- fail "the vLLM smoke test requires kv.connector.enabled=true" -}}
   {{- end -}}
-  {{- if ne .Values.kv.sharedMemory.type "hostPath" -}}
-    {{- fail "the H2/local vLLM smoke test requires kv.sharedMemory.type=hostPath" -}}
-  {{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -80,6 +77,9 @@ ucx
   {{- end -}}
   {{- if and .Values.kv.connector.enabled (eq .Values.kv.transport "h2") (gt (len .Values.kv.targets) 1) -}}
     {{- fail "the H2/local connector supports one same-host KV target only; disable kv.connector.enabled for a multi-node H2 orchestration smoke test or use the rdma transport" -}}
+  {{- end -}}
+  {{- if and .Values.kv.connector.enabled (eq .Values.kv.transport "h2") (ne .Values.kv.sharedMemory.type "hostPath") -}}
+    {{- fail "the H2/local connector requires kv.sharedMemory.type=hostPath so vLLM and OpenLake can share the POSIX slab" -}}
   {{- end -}}
   {{- if eq (int .Values.kv.ports.rpc) (int .Values.kv.ports.telemetry) -}}
     {{- fail "kv.ports.rpc and kv.ports.telemetry must be different" -}}

--- a/charts/openlake/tests/render.sh
+++ b/charts/openlake/tests/render.sh
@@ -219,6 +219,12 @@ expect_render_failure \
   --set 'kv.targets[1].ip=10.0.0.12'
 
 expect_render_failure \
+  "the H2/local connector requires kv.sharedMemory.type=hostPath" \
+  --set kv.enabled=true \
+  --set 'kv.targets[0].nodeName=gpu-worker-0' \
+  --set 'kv.targets[0].ip=10.0.0.11'
+
+expect_render_failure \
   "kv.rdma.devName is required for the dct backend" \
   --set kv.enabled=true \
   --set kv.transport=rdma \
@@ -231,7 +237,7 @@ expect_render_failure \
   --set vllmSmokeTest.enabled=true
 
 expect_render_failure \
-  "the H2/local vLLM smoke test requires kv.sharedMemory.type=hostPath" \
+  "the H2/local connector requires kv.sharedMemory.type=hostPath" \
   --values "${smoke_values}" \
   --set kv.sharedMemory.type=emptyDir
 


### PR DESCRIPTION
 - Requires kv.sharedMemory.type=hostPath when the H2 connector is enabled.
 - Moves the validation from the optional vLLM smoke test into general KV validation.
 - Adds a regression test for invalid H2 connector configurations.