### PR TITLE
(#223) [v0.9] vLLM: Wire up exans nvidia nvcomp variant with fixed block

### DIFF
--- a/crates/openlake_kv_client/build.sh
+++ b/crates/openlake_kv_client/build.sh
@@ -40,6 +40,17 @@ else
   cp ../openlake_server/configs/kv_local.toml "$PKG/configs/default.toml"
 fi
 
+if command -v nvcc >/dev/null 2>&1 && \
+   [ -n "${NVCOMP_ROOT:-}" ] && \
+   [ -f "$NVCOMP_ROOT/include/nvcomp/ans.h" ]; then
+  cmake -S cuda -B cuda/build \
+    -DOPENLAKE_CUDA_CODEC_BUILD_TESTS=OFF \
+    -DOPENLAKE_EXPANS_BUILD=ON \
+    -DNVCOMP_ROOT="$NVCOMP_ROOT"
+  cmake --build cuda/build --config Release --target openlake_expans
+  cp cuda/build/libopenlake_expans.so "$PKG/"
+fi
+
 # 4. maturin compiles the client .so and packs the wheel
 rm -rf ../../target/maturin
 maturin build --release $FEAT $AUDIT -o dist

--- a/crates/openlake_kv_client/cuda/CMakeLists.txt
+++ b/crates/openlake_kv_client/cuda/CMakeLists.txt
@@ -37,9 +37,54 @@ set_target_properties(openlake_kv_cuda_codec PROPERTIES
 )
 
 option(OPENLAKE_CUDA_CODEC_BUILD_TESTS "Build the CUDA codec GPU smoke test" ON)
+option(OPENLAKE_EXPANS_BUILD "Build the optional lossless ExpANS codec" OFF)
 
 if(OPENLAKE_CUDA_CODEC_BUILD_TESTS)
   include(CTest)
+endif()
+
+if(OPENLAKE_EXPANS_BUILD)
+  set(NVCOMP_ROOT "" CACHE PATH "Path to nvCOMP")
+  find_package(nvcomp REQUIRED CONFIG PATHS
+    "${NVCOMP_ROOT}/lib/cmake/nvcomp"
+    "${NVCOMP_ROOT}/lib64/cmake/nvcomp"
+  )
+
+  add_library(openlake_expans SHARED
+    src/expans_codec.cu
+  )
+  target_include_directories(openlake_expans
+    PUBLIC
+      ${CMAKE_CURRENT_SOURCE_DIR}/include
+    PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/src
+  )
+  target_link_libraries(openlake_expans
+    PRIVATE
+      CUDA::cudart
+      nvcomp::nvcomp
+  )
+  target_compile_features(openlake_expans PUBLIC cxx_std_17)
+  target_compile_options(openlake_expans PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>
+  )
+  set_target_properties(openlake_expans PROPERTIES
+    CUDA_STANDARD 17
+    CUDA_STANDARD_REQUIRED ON
+  )
+
+  if(OPENLAKE_CUDA_CODEC_BUILD_TESTS)
+    add_executable(openlake_expans_test tests/expans_codec_test.cu)
+    target_link_libraries(openlake_expans_test PRIVATE openlake_expans CUDA::cudart)
+    set_target_properties(openlake_expans_test PROPERTIES
+      CUDA_STANDARD 17
+      CUDA_STANDARD_REQUIRED ON
+    )
+    add_test(NAME openlake_expans_test COMMAND openlake_expans_test)
+  endif()
+endif()
+
+if(OPENLAKE_CUDA_CODEC_BUILD_TESTS)
   add_executable(openlake_kv_cuda_codec_smoke
     tests/kv_compression_smoke.cu
   )

--- a/crates/openlake_kv_client/cuda/include/openlake/expans_codec.h
+++ b/crates/openlake_kv_client/cuda/include/openlake/expans_codec.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct openlake_expans_codec openlake_expans_codec;
+
+int openlake_expans_create(
+    uint64_t raw_block_bytes,
+    uint64_t record_bytes,
+    const uint32_t* segment_bytes,
+    uint32_t segment_count,
+    uint32_t max_batch_blocks,
+    openlake_expans_codec** output);
+
+void openlake_expans_destroy(openlake_expans_codec* codec);
+
+const char* openlake_expans_last_error(openlake_expans_codec* codec);
+
+int openlake_expans_encode(
+    openlake_expans_codec* codec,
+    const uint64_t* input_addresses,
+    const uint32_t* input_sizes,
+    const uint32_t* block_segment_offsets,
+    uint32_t block_count,
+    uint64_t output_records,
+    uint8_t* host_fits,
+    uint64_t cuda_stream);
+
+int openlake_expans_decode(
+    openlake_expans_codec* codec,
+    uint64_t input_records,
+    const uint32_t* record_indexes,
+    uint32_t record_count,
+    const uint64_t* output_addresses,
+    const uint32_t* output_sizes,
+    const uint32_t* block_segment_offsets,
+    uint64_t cuda_stream);
+
+#ifdef __cplusplus
+}
+#endif

--- a/crates/openlake_kv_client/cuda/src/expans_codec.cu
+++ b/crates/openlake_kv_client/cuda/src/expans_codec.cu
@@ -1,0 +1,651 @@
+#include "openlake/expans_codec.h"
+
+#include <cuda_runtime.h>
+#include <nvcomp/ans.h>
+
+#include <cstdint>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "expans_kernels.cuh"
+
+namespace {
+
+constexpr uint32_t kRecordMagic = 0x31505845U;
+constexpr uint16_t kRecordVersion = 2;
+constexpr uint32_t kRecordHeaderBytes = 64;
+constexpr uint32_t kRecordAlignment = 16;
+constexpr uint32_t kSignFractionOffset = kRecordHeaderBytes;
+constexpr uint32_t kPhaseOffset = kSignFractionOffset + kSymbolsPerBlock;
+constexpr uint32_t kFrameOffset =
+    ((kPhaseOffset + kPhaseBytesPerBlock + kRecordAlignment - 1) /
+     kRecordAlignment) * kRecordAlignment;
+
+struct __align__(16) ExpansRecordHeader {
+  uint32_t magic;
+  uint16_t version;
+  uint16_t header_bytes;
+  uint64_t layout_id;
+  uint32_t raw_bytes;
+  uint32_t actual_bytes;
+  uint32_t sign_fraction_offset;
+  uint32_t sign_fraction_bytes;
+  uint32_t phase_offset;
+  uint32_t phase_bytes;
+  uint32_t frame_offset;
+  uint32_t frame_bytes;
+  uint32_t flags;
+  uint32_t reserved[3];
+};
+
+static_assert(sizeof(ExpansRecordHeader) == kRecordHeaderBytes);
+
+uint64_t layout_id(const uint32_t* segment_bytes, uint32_t segment_count) {
+  uint64_t hash = 1469598103934665603ULL;
+  auto add = [&](uint32_t value) {
+    for (uint32_t byte = 0; byte < sizeof(value); ++byte) {
+      hash ^= static_cast<uint8_t>(value >> (byte * 8));
+      hash *= 1099511628211ULL;
+    }
+  };
+  add(kRawBytesPerBlock);
+  add(segment_count);
+  for (uint32_t i = 0; i < segment_count; ++i) add(segment_bytes[i]);
+  return hash;
+}
+
+__global__ void gather_segments(
+    const uint64_t* addresses,
+    const uint32_t* segment_offsets,
+    uint32_t segment_count,
+    uint8_t* output,
+    uint32_t blocks) {
+  const uint32_t index = blockIdx.x;
+  if (index >= blocks * segment_count) return;
+  const uint32_t block = index / segment_count;
+  const uint32_t segment = index % segment_count;
+  const auto* source = reinterpret_cast<const uint8_t*>(addresses[index]);
+  uint8_t* destination = output +
+      static_cast<size_t>(block) * kRawBytesPerBlock +
+      segment_offsets[segment];
+  const uint32_t bytes = segment_offsets[segment + 1] - segment_offsets[segment];
+  for (uint32_t i = threadIdx.x; i < bytes; i += blockDim.x) {
+    destination[i] = source[i];
+  }
+}
+
+__global__ void residual_histogram(
+    const uint16_t* input,
+    const uint8_t* centers,
+    uint32_t* histogram,
+    size_t words) {
+  const size_t index = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= words) return;
+  const uint32_t position = index % kSymbolsPerBlock;
+  const uint8_t exponent = static_cast<uint8_t>((input[index] >> 7) & 0xffU);
+  const uint8_t residual = static_cast<uint8_t>(
+      static_cast<uint32_t>(exponent) + 127U - centers[position]);
+  atomicAdd(histogram + residual, 1U);
+}
+
+__global__ void histogram_costs(
+    const uint32_t* histogram,
+    float* costs,
+    uint32_t total) {
+  const uint32_t symbol = threadIdx.x;
+  if (symbol >= 256) return;
+  costs[symbol] = -log2f(
+      (static_cast<float>(histogram[symbol]) + 0.5f) /
+      (static_cast<float>(total) + 128.0f));
+}
+
+__global__ void scatter_segments(
+    const uint8_t* input,
+    const uint64_t* addresses,
+    const uint32_t* segment_offsets,
+    uint32_t segment_count,
+    uint32_t blocks) {
+  const uint32_t index = blockIdx.x;
+  if (index >= blocks * segment_count) return;
+  const uint32_t block = index / segment_count;
+  const uint32_t segment = index % segment_count;
+  const uint8_t* source = input +
+      static_cast<size_t>(block) * kRawBytesPerBlock +
+      segment_offsets[segment];
+  auto* destination = reinterpret_cast<uint8_t*>(addresses[index]);
+  const uint32_t bytes = segment_offsets[segment + 1] - segment_offsets[segment];
+  for (uint32_t i = threadIdx.x; i < bytes; i += blockDim.x) {
+    destination[i] = source[i];
+  }
+}
+
+__global__ void pack_records(
+    uint8_t* records,
+    uint32_t record_bytes,
+    const uint8_t* sign_fraction,
+    const uint8_t* phase_bitmaps,
+    const uint8_t* frames,
+    size_t frame_stride,
+    const size_t* frame_sizes,
+    uint8_t* fits,
+    uint64_t expected_layout_id,
+    uint32_t batches) {
+  const uint32_t batch = blockIdx.x;
+  if (batch >= batches) return;
+  uint8_t* record = records + static_cast<size_t>(batch) * record_bytes;
+  const size_t frame_bytes = frame_sizes[batch];
+  const size_t actual_bytes = kFrameOffset + frame_bytes;
+  const bool fit = frame_bytes != 0 && actual_bytes <= record_bytes;
+  if (threadIdx.x == 0) fits[batch] = fit;
+  if (!fit) return;
+
+  const uint8_t* block_sign = sign_fraction +
+      static_cast<size_t>(batch) * kSymbolsPerBlock;
+  const uint8_t* block_phase = phase_bitmaps +
+      static_cast<size_t>(batch) * kPhaseBytesPerBlock;
+  const uint8_t* block_frame = frames +
+      static_cast<size_t>(batch) * frame_stride;
+  for (uint32_t i = threadIdx.x; i < kSymbolsPerBlock; i += blockDim.x) {
+    record[kSignFractionOffset + i] = block_sign[i];
+  }
+  for (uint32_t i = threadIdx.x; i < kPhaseBytesPerBlock; i += blockDim.x) {
+    record[kPhaseOffset + i] = block_phase[i];
+  }
+  for (size_t i = threadIdx.x; i < frame_bytes; i += blockDim.x) {
+    record[kFrameOffset + i] = block_frame[i];
+  }
+  if (threadIdx.x == 0) {
+    auto* header = reinterpret_cast<ExpansRecordHeader*>(record);
+    *header = ExpansRecordHeader{
+        kRecordMagic,
+        kRecordVersion,
+        kRecordHeaderBytes,
+        expected_layout_id,
+        kRawBytesPerBlock,
+        static_cast<uint32_t>(actual_bytes),
+        kSignFractionOffset,
+        kSymbolsPerBlock,
+        kPhaseOffset,
+        kPhaseBytesPerBlock,
+        kFrameOffset,
+        static_cast<uint32_t>(frame_bytes),
+        0,
+        {0, 0, 0}};
+  }
+}
+
+__global__ void unpack_records(
+    const uint8_t* records,
+    uint32_t record_bytes,
+    const uint32_t* record_indexes,
+    uint8_t* sign_fraction,
+    uint8_t* phase_bitmaps,
+    uint8_t* frames,
+    size_t frame_stride,
+    uint32_t batches) {
+  const uint32_t batch = blockIdx.x;
+  if (batch >= batches) return;
+  const uint8_t* record = records +
+      static_cast<size_t>(record_indexes[batch]) * record_bytes;
+  const auto* header = reinterpret_cast<const ExpansRecordHeader*>(record);
+  uint8_t* block_sign = sign_fraction +
+      static_cast<size_t>(batch) * kSymbolsPerBlock;
+  uint8_t* block_phase = phase_bitmaps +
+      static_cast<size_t>(batch) * kPhaseBytesPerBlock;
+  uint8_t* block_frame = frames +
+      static_cast<size_t>(batch) * frame_stride;
+  for (uint32_t i = threadIdx.x; i < kSymbolsPerBlock; i += blockDim.x) {
+    block_sign[i] = record[header->sign_fraction_offset + i];
+  }
+  for (uint32_t i = threadIdx.x; i < kPhaseBytesPerBlock; i += blockDim.x) {
+    block_phase[i] = record[header->phase_offset + i];
+  }
+  for (uint32_t i = threadIdx.x; i < header->frame_bytes; i += blockDim.x) {
+    block_frame[i] = record[header->frame_offset + i];
+  }
+}
+
+bool valid_layout(
+    const uint32_t* sizes,
+    const uint32_t* offsets,
+    uint32_t blocks,
+    const std::vector<uint32_t>& expected) {
+  if (!sizes || !offsets || offsets[0] != 0) return false;
+  for (uint32_t block = 0; block < blocks; ++block) {
+    if (offsets[block + 1] - offsets[block] != expected.size()) return false;
+    for (uint32_t segment = 0; segment < expected.size(); ++segment) {
+      if (sizes[offsets[block] + segment] != expected[segment]) return false;
+    }
+  }
+  return true;
+}
+
+}
+
+struct openlake_expans_codec {
+  uint32_t record_bytes = 0;
+  uint32_t max_batch_blocks = 0;
+  uint32_t segment_count = 0;
+  size_t frame_stride = 0;
+  size_t compress_temp_bytes = 0;
+  size_t decompress_temp_bytes = 0;
+  int device = 0;
+  uint64_t layout = 0;
+  nvcompBatchedANSCompressOpts_t compress_opts =
+      nvcompBatchedANSCompressDefaultOpts;
+  nvcompBatchedANSDecompressOpts_t decompress_opts =
+      nvcompBatchedANSDecompressDefaultOpts;
+  std::vector<uint32_t> segment_bytes;
+  std::string error;
+  uint8_t* input = nullptr;
+  uint8_t* output = nullptr;
+  uint8_t* centers = nullptr;
+  uint8_t* phase_bitmaps = nullptr;
+  uint8_t* sign_fraction = nullptr;
+  uint8_t* residual = nullptr;
+  uint8_t* frames = nullptr;
+  void** residual_ptrs = nullptr;
+  void** frame_ptrs = nullptr;
+  size_t* raw_sizes = nullptr;
+  size_t* frame_sizes = nullptr;
+  size_t* decoded_sizes = nullptr;
+  nvcompStatus_t* statuses = nullptr;
+  void* compress_temp = nullptr;
+  void* decompress_temp = nullptr;
+  uint64_t* addresses = nullptr;
+  uint32_t* segment_offsets = nullptr;
+  uint32_t* record_indexes = nullptr;
+  uint32_t* histogram = nullptr;
+  float* phase_costs = nullptr;
+  uint8_t* fits = nullptr;
+
+  ~openlake_expans_codec() {
+    cudaSetDevice(device);
+    cudaFree(input);
+    cudaFree(output);
+    cudaFree(centers);
+    cudaFree(phase_bitmaps);
+    cudaFree(sign_fraction);
+    cudaFree(residual);
+    cudaFree(frames);
+    cudaFree(residual_ptrs);
+    cudaFree(frame_ptrs);
+    cudaFree(raw_sizes);
+    cudaFree(frame_sizes);
+    cudaFree(decoded_sizes);
+    cudaFree(statuses);
+    cudaFree(compress_temp);
+    cudaFree(decompress_temp);
+    cudaFree(addresses);
+    cudaFree(segment_offsets);
+    cudaFree(record_indexes);
+    cudaFree(histogram);
+    cudaFree(phase_costs);
+    cudaFree(fits);
+  }
+};
+
+namespace {
+
+int fail(openlake_expans_codec* codec, const std::string& message) {
+  if (codec) codec->error = message;
+  return 1;
+}
+
+int fail_cuda(openlake_expans_codec* codec, cudaError_t status, const char* op) {
+  std::ostringstream message;
+  message << op << ": " << cudaGetErrorString(status);
+  return fail(codec, message.str());
+}
+
+int fail_nvcomp(
+    openlake_expans_codec* codec, nvcompStatus_t status, const char* op) {
+  std::ostringstream message;
+  message << op << ": nvCOMP status " << static_cast<int>(status);
+  return fail(codec, message.str());
+}
+
+#define EXPANS_ALLOC(member, count)                                            \
+  do {                                                                         \
+    const size_t bytes__ = static_cast<size_t>(count);                         \
+    if (bytes__ != 0) {                                                        \
+      cudaError_t status__ = cudaMalloc(&codec->member, bytes__);              \
+      if (status__ != cudaSuccess) return fail_cuda(codec, status__, #member); \
+    }                                                                          \
+  } while (0)
+
+bool valid_header(
+    const ExpansRecordHeader& header,
+    const openlake_expans_codec& codec) {
+  return header.magic == kRecordMagic &&
+      header.version == kRecordVersion &&
+      header.header_bytes == kRecordHeaderBytes &&
+      header.raw_bytes == kRawBytesPerBlock &&
+      header.actual_bytes <= codec.record_bytes &&
+      header.sign_fraction_offset == kSignFractionOffset &&
+      header.sign_fraction_bytes == kSymbolsPerBlock &&
+      header.phase_offset == kPhaseOffset &&
+      header.phase_bytes == kPhaseBytesPerBlock &&
+      header.frame_offset == kFrameOffset &&
+      header.frame_bytes != 0 &&
+      header.frame_bytes <= codec.frame_stride &&
+      header.frame_offset + header.frame_bytes == header.actual_bytes &&
+      header.layout_id == codec.layout;
+}
+
+}
+
+extern "C" int openlake_expans_create(
+    uint64_t raw_block_bytes,
+    uint64_t record_bytes,
+    const uint32_t* segment_bytes,
+    uint32_t segment_count,
+    uint32_t max_batch_blocks,
+    openlake_expans_codec** output) {
+  if (!output) return 1;
+  *output = nullptr;
+  auto codec = std::make_unique<openlake_expans_codec>();
+  if (!segment_bytes || segment_count == 0 || max_batch_blocks == 0) {
+    return fail(codec.get(), "invalid ExpANS creation arguments");
+  }
+  if (raw_block_bytes != kRawBytesPerBlock ||
+      record_bytes <= kFrameOffset || record_bytes >= raw_block_bytes ||
+      record_bytes > UINT32_MAX) {
+    return fail(codec.get(), "unsupported ExpANS block or record size");
+  }
+  codec->record_bytes = static_cast<uint32_t>(record_bytes);
+  codec->segment_count = segment_count;
+  codec->max_batch_blocks = max_batch_blocks;
+  codec->segment_bytes.assign(segment_bytes, segment_bytes + segment_count);
+  uint64_t sum = 0;
+  for (uint32_t bytes : codec->segment_bytes) sum += bytes;
+  if (sum != raw_block_bytes) {
+    return fail(codec.get(), "segment bytes do not form one ExpANS block");
+  }
+  codec->layout = layout_id(segment_bytes, segment_count);
+  cudaError_t status = cudaGetDevice(&codec->device);
+  if (status != cudaSuccess) return fail_cuda(codec.get(), status, "cudaGetDevice");
+  codec->compress_opts.data_type = NVCOMP_TYPE_UCHAR;
+  nvcompStatus_t nvcomp_status = nvcompBatchedANSCompressGetMaxOutputChunkSize(
+      kSymbolsPerBlock, codec->compress_opts, &codec->frame_stride);
+  if (nvcomp_status != nvcompSuccess) {
+    return fail_nvcomp(
+        codec.get(), nvcomp_status,
+        "nvcompBatchedANSCompressGetMaxOutputChunkSize");
+  }
+  codec->frame_stride =
+      (codec->frame_stride + kRecordAlignment - 1) & ~(kRecordAlignment - 1);
+  const size_t blocks = max_batch_blocks;
+  const size_t symbols = blocks * kSymbolsPerBlock;
+  nvcomp_status = nvcompBatchedANSCompressGetTempSizeAsync(
+      blocks, kSymbolsPerBlock, codec->compress_opts,
+      &codec->compress_temp_bytes, symbols);
+  if (nvcomp_status != nvcompSuccess) {
+    return fail_nvcomp(
+        codec.get(), nvcomp_status,
+        "nvcompBatchedANSCompressGetTempSizeAsync");
+  }
+  nvcomp_status = nvcompBatchedANSDecompressGetTempSizeAsync(
+      blocks, kSymbolsPerBlock, codec->decompress_opts,
+      &codec->decompress_temp_bytes, symbols);
+  if (nvcomp_status != nvcompSuccess) {
+    return fail_nvcomp(
+        codec.get(), nvcomp_status,
+        "nvcompBatchedANSDecompressGetTempSizeAsync");
+  }
+  const size_t address_count = blocks * segment_count;
+  EXPANS_ALLOC(input, blocks * kRawBytesPerBlock);
+  EXPANS_ALLOC(output, blocks * kRawBytesPerBlock);
+  EXPANS_ALLOC(centers, kSymbolsPerBlock);
+  EXPANS_ALLOC(phase_bitmaps, blocks * kPhaseBytesPerBlock);
+  EXPANS_ALLOC(sign_fraction, symbols);
+  EXPANS_ALLOC(residual, symbols);
+  EXPANS_ALLOC(frames, blocks * codec->frame_stride);
+  EXPANS_ALLOC(residual_ptrs, blocks * sizeof(void*));
+  EXPANS_ALLOC(frame_ptrs, blocks * sizeof(void*));
+  EXPANS_ALLOC(raw_sizes, blocks * sizeof(size_t));
+  EXPANS_ALLOC(frame_sizes, blocks * sizeof(size_t));
+  EXPANS_ALLOC(decoded_sizes, blocks * sizeof(size_t));
+  EXPANS_ALLOC(statuses, blocks * sizeof(nvcompStatus_t));
+  EXPANS_ALLOC(compress_temp, codec->compress_temp_bytes);
+  EXPANS_ALLOC(decompress_temp, codec->decompress_temp_bytes);
+  EXPANS_ALLOC(addresses, address_count * sizeof(uint64_t));
+  EXPANS_ALLOC(segment_offsets, (segment_count + 1) * sizeof(uint32_t));
+  EXPANS_ALLOC(record_indexes, blocks * sizeof(uint32_t));
+  EXPANS_ALLOC(histogram, 256 * sizeof(uint32_t));
+  EXPANS_ALLOC(phase_costs, 256 * sizeof(float));
+  EXPANS_ALLOC(fits, blocks);
+
+  status = cudaMemset(codec->centers, 127, kSymbolsPerBlock);
+  if (status != cudaSuccess) {
+    return fail_cuda(codec.get(), status, "initialize centers");
+  }
+  std::vector<uint32_t> offsets(segment_count + 1, 0);
+  for (uint32_t i = 0; i < segment_count; ++i) {
+    offsets[i + 1] = offsets[i] + segment_bytes[i];
+  }
+  status = cudaMemcpy(
+      codec->segment_offsets, offsets.data(), offsets.size() * sizeof(uint32_t),
+      cudaMemcpyHostToDevice);
+  if (status != cudaSuccess) {
+    return fail_cuda(codec.get(), status, "copy segment layout");
+  }
+  std::vector<void*> residual_ptrs(blocks);
+  std::vector<void*> frame_ptrs(blocks);
+  std::vector<size_t> raw_sizes(blocks, kSymbolsPerBlock);
+  for (size_t block = 0; block < blocks; ++block) {
+    residual_ptrs[block] = codec->residual + block * kSymbolsPerBlock;
+    frame_ptrs[block] = codec->frames + block * codec->frame_stride;
+  }
+  status = cudaMemcpy(
+      codec->residual_ptrs, residual_ptrs.data(), blocks * sizeof(void*),
+      cudaMemcpyHostToDevice);
+  if (status != cudaSuccess) {
+    return fail_cuda(codec.get(), status, "copy residual pointers");
+  }
+  status = cudaMemcpy(
+      codec->frame_ptrs, frame_ptrs.data(), blocks * sizeof(void*),
+      cudaMemcpyHostToDevice);
+  if (status != cudaSuccess) {
+    return fail_cuda(codec.get(), status, "copy frame pointers");
+  }
+  status = cudaMemcpy(
+      codec->raw_sizes, raw_sizes.data(), blocks * sizeof(size_t),
+      cudaMemcpyHostToDevice);
+  if (status != cudaSuccess) {
+    return fail_cuda(codec.get(), status, "copy raw sizes");
+  }
+  *output = codec.release();
+  return 0;
+}
+
+extern "C" void openlake_expans_destroy(openlake_expans_codec* codec) {
+  delete codec;
+}
+
+extern "C" const char* openlake_expans_last_error(openlake_expans_codec* codec) {
+  return codec ? codec->error.c_str() : "invalid ExpANS codec";
+}
+
+extern "C" int openlake_expans_encode(
+    openlake_expans_codec* codec,
+    const uint64_t* input_addresses,
+    const uint32_t* input_sizes,
+    const uint32_t* block_segment_offsets,
+    uint32_t block_count,
+    uint64_t output_records,
+    uint8_t* host_fits,
+    uint64_t cuda_stream) {
+  if (!codec || !input_addresses || !host_fits || output_records == 0 ||
+      block_count == 0 || block_count > codec->max_batch_blocks ||
+      !valid_layout(input_sizes, block_segment_offsets, block_count,
+                    codec->segment_bytes)) {
+    return fail(codec, "invalid ExpANS encode arguments or scatter layout");
+  }
+  cudaError_t status = cudaSetDevice(codec->device);
+  if (status != cudaSuccess) return fail_cuda(codec, status, "cudaSetDevice");
+  auto stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  const size_t address_count =
+      static_cast<size_t>(block_count) * codec->segment_count;
+  status = cudaMemcpyAsync(
+      codec->addresses, input_addresses, address_count * sizeof(uint64_t),
+      cudaMemcpyHostToDevice, stream);
+  if (status != cudaSuccess) return fail_cuda(codec, status, "copy input addresses");
+  gather_segments<<<address_count, 256, 0, stream>>>(
+      codec->addresses, codec->segment_offsets, codec->segment_count,
+      codec->input, block_count);
+  status = cudaMemsetAsync(
+      codec->phase_bitmaps, 0,
+      static_cast<size_t>(block_count) * kPhaseBytesPerBlock, stream);
+  if (status != cudaSuccess) return fail_cuda(codec, status, "clear phase bitmap");
+  const size_t words = static_cast<size_t>(block_count) * kSymbolsPerBlock;
+  const int vectors = static_cast<int>(((words / 8) + 255) / 256);
+  status = cudaMemsetAsync(codec->histogram, 0, 256 * sizeof(uint32_t), stream);
+  if (status != cudaSuccess) return fail_cuda(codec, status, "clear histogram");
+  status = cudaMemsetAsync(
+      codec->frame_sizes, 0, block_count * sizeof(size_t), stream);
+  if (status != cudaSuccess) return fail_cuda(codec, status, "clear frame sizes");
+  const int histogram_blocks = static_cast<int>((words + 255) / 256);
+  residual_histogram<<<histogram_blocks, 256, 0, stream>>>(
+      reinterpret_cast<const uint16_t*>(codec->input), codec->centers,
+      codec->histogram, words);
+  histogram_costs<<<1, 256, 0, stream>>>(
+      codec->histogram, codec->phase_costs, static_cast<uint32_t>(words));
+  fit_group_direction_phases<<<block_count * kGroups, 1024, 0, stream>>>(
+      reinterpret_cast<const uint16_t*>(codec->input), codec->centers,
+      codec->phase_costs, codec->phase_bitmaps, block_count);
+  split_bf16_position_phase<<<vectors, 256, 0, stream>>>(
+      reinterpret_cast<const uint16_t*>(codec->input), codec->centers,
+      codec->phase_bitmaps, codec->sign_fraction, codec->residual, words);
+  nvcompStatus_t nvcomp_status = nvcompBatchedANSCompressAsync(
+      const_cast<const void* const*>(codec->residual_ptrs), codec->raw_sizes,
+      kSymbolsPerBlock, block_count, codec->compress_temp,
+      codec->compress_temp_bytes, codec->frame_ptrs, codec->frame_sizes,
+      codec->compress_opts, codec->statuses, stream);
+  if (nvcomp_status != nvcompSuccess) {
+    return fail_nvcomp(codec, nvcomp_status, "nvcompBatchedANSCompressAsync");
+  }
+  status = cudaMemsetAsync(
+      reinterpret_cast<void*>(output_records), 0,
+      static_cast<size_t>(block_count) * codec->record_bytes, stream);
+  if (status != cudaSuccess) return fail_cuda(codec, status, "clear output records");
+  pack_records<<<block_count, 256, 0, stream>>>(
+      reinterpret_cast<uint8_t*>(output_records), codec->record_bytes,
+      codec->sign_fraction, codec->phase_bitmaps, codec->frames,
+      codec->frame_stride, codec->frame_sizes, codec->fits, codec->layout,
+      block_count);
+  std::vector<nvcompStatus_t> statuses(block_count);
+  status = cudaMemcpyAsync(
+      host_fits, codec->fits, block_count, cudaMemcpyDeviceToHost, stream);
+  if (status != cudaSuccess) return fail_cuda(codec, status, "copy fit results");
+  status = cudaMemcpyAsync(
+      statuses.data(), codec->statuses,
+      block_count * sizeof(nvcompStatus_t), cudaMemcpyDeviceToHost, stream);
+  if (status != cudaSuccess) return fail_cuda(codec, status, "copy nvCOMP statuses");
+  status = cudaStreamSynchronize(stream);
+  if (status != cudaSuccess) return fail_cuda(codec, status, "encode synchronize");
+  for (nvcompStatus_t value : statuses) {
+    if (value != nvcompSuccess) {
+      return fail_nvcomp(codec, value, "nvCOMP encode operation");
+    }
+  }
+  return 0;
+}
+
+extern "C" int openlake_expans_decode(
+    openlake_expans_codec* codec,
+    uint64_t input_records,
+    const uint32_t* record_indexes,
+    uint32_t record_count,
+    const uint64_t* output_addresses,
+    const uint32_t* output_sizes,
+    const uint32_t* block_segment_offsets,
+    uint64_t cuda_stream) {
+  if (!codec || input_records == 0 || !record_indexes || !output_addresses ||
+      record_count == 0 || record_count > codec->max_batch_blocks ||
+      !valid_layout(output_sizes, block_segment_offsets, record_count,
+                    codec->segment_bytes)) {
+    return fail(codec, "invalid ExpANS decode arguments or scatter layout");
+  }
+  cudaError_t status = cudaSetDevice(codec->device);
+  if (status != cudaSuccess) return fail_cuda(codec, status, "cudaSetDevice");
+  auto stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  std::vector<ExpansRecordHeader> headers(record_count);
+  for (uint32_t i = 0; i < record_count; ++i) {
+    if (record_indexes[i] >= codec->max_batch_blocks) {
+      return fail(codec, "ExpANS record index exceeds lane capacity");
+    }
+    status = cudaMemcpyAsync(
+        &headers[i],
+        reinterpret_cast<const uint8_t*>(input_records) +
+            static_cast<size_t>(record_indexes[i]) * codec->record_bytes,
+        sizeof(ExpansRecordHeader), cudaMemcpyDeviceToHost, stream);
+    if (status != cudaSuccess) return fail_cuda(codec, status, "copy record header");
+  }
+  status = cudaStreamSynchronize(stream);
+  if (status != cudaSuccess) return fail_cuda(codec, status, "header synchronize");
+  std::vector<size_t> frame_sizes(record_count);
+  for (uint32_t i = 0; i < record_count; ++i) {
+    if (!valid_header(headers[i], *codec)) {
+      return fail(codec, "invalid or incompatible ExpANS record header");
+    }
+    frame_sizes[i] = headers[i].frame_bytes;
+  }
+  const size_t address_count =
+      static_cast<size_t>(record_count) * codec->segment_count;
+  status = cudaMemcpyAsync(
+      codec->record_indexes, record_indexes, record_count * sizeof(uint32_t),
+      cudaMemcpyHostToDevice, stream);
+  if (status != cudaSuccess) return fail_cuda(codec, status, "copy record indexes");
+  status = cudaMemcpyAsync(
+      codec->addresses, output_addresses, address_count * sizeof(uint64_t),
+      cudaMemcpyHostToDevice, stream);
+  if (status != cudaSuccess) return fail_cuda(codec, status, "copy output addresses");
+  status = cudaMemcpyAsync(
+      codec->frame_sizes, frame_sizes.data(), record_count * sizeof(size_t),
+      cudaMemcpyHostToDevice, stream);
+  if (status != cudaSuccess) return fail_cuda(codec, status, "copy frame sizes");
+  unpack_records<<<record_count, 256, 0, stream>>>(
+      reinterpret_cast<const uint8_t*>(input_records), codec->record_bytes,
+      codec->record_indexes, codec->sign_fraction, codec->phase_bitmaps,
+      codec->frames, codec->frame_stride, record_count);
+  nvcompStatus_t nvcomp_status = nvcompBatchedANSDecompressAsync(
+      const_cast<const void* const*>(codec->frame_ptrs), codec->frame_sizes,
+      codec->raw_sizes, codec->decoded_sizes, record_count,
+      codec->decompress_temp, codec->decompress_temp_bytes,
+      codec->residual_ptrs, codec->decompress_opts, codec->statuses, stream);
+  if (nvcomp_status != nvcompSuccess) {
+    return fail_nvcomp(codec, nvcomp_status, "nvcompBatchedANSDecompressAsync");
+  }
+  const size_t words = static_cast<size_t>(record_count) * kSymbolsPerBlock;
+  const int vectors = static_cast<int>(((words / 8) + 255) / 256);
+  merge_bf16_position_phase<<<vectors, 256, 0, stream>>>(
+      codec->residual, codec->sign_fraction, codec->centers,
+      codec->phase_bitmaps, reinterpret_cast<uint16_t*>(codec->output), words);
+  scatter_segments<<<address_count, 256, 0, stream>>>(
+      codec->output, codec->addresses, codec->segment_offsets,
+      codec->segment_count, record_count);
+  std::vector<nvcompStatus_t> statuses(record_count);
+  std::vector<size_t> decoded_sizes(record_count);
+  status = cudaMemcpyAsync(
+      statuses.data(), codec->statuses,
+      record_count * sizeof(nvcompStatus_t), cudaMemcpyDeviceToHost, stream);
+  if (status != cudaSuccess) return fail_cuda(codec, status, "copy nvCOMP statuses");
+  status = cudaMemcpyAsync(
+      decoded_sizes.data(), codec->decoded_sizes,
+      record_count * sizeof(size_t), cudaMemcpyDeviceToHost, stream);
+  if (status != cudaSuccess) return fail_cuda(codec, status, "copy decoded sizes");
+  status = cudaStreamSynchronize(stream);
+  if (status != cudaSuccess) return fail_cuda(codec, status, "decode synchronize");
+  for (uint32_t i = 0; i < record_count; ++i) {
+    if (statuses[i] != nvcompSuccess) {
+      return fail_nvcomp(codec, statuses[i], "nvCOMP decode operation");
+    }
+    if (decoded_sizes[i] != kSymbolsPerBlock) {
+      return fail(codec, "nvCOMP decoded an incompatible ExpANS frame");
+    }
+  }
+  return 0;
+}

--- a/crates/openlake_kv_client/cuda/src/expans_kernels.cuh
+++ b/crates/openlake_kv_client/cuda/src/expans_kernels.cuh
@@ -1,0 +1,208 @@
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace {
+
+constexpr uint32_t kGroups = 122;
+constexpr uint32_t kSymbolsPerGroup = 4096;
+constexpr uint32_t kSymbolsPerBlock = kGroups * kSymbolsPerGroup;
+constexpr uint32_t kRawBytesPerBlock = kSymbolsPerBlock * sizeof(uint16_t);
+constexpr uint32_t kPhaseUnitValues = 128;
+constexpr uint32_t kPhaseUnitsPerBlock =
+    kSymbolsPerBlock / kPhaseUnitValues;
+constexpr uint32_t kPhasePresenceBytes = kPhaseUnitsPerBlock / 8;
+constexpr uint32_t kPhaseDirectionBytes =
+    ((kGroups * 2 + 31) / 32) * sizeof(uint32_t);
+constexpr uint32_t kPhaseBytesPerBlock =
+    kPhasePresenceBytes + kPhaseDirectionBytes;
+
+static_assert(kSymbolsPerBlock % kPhaseUnitValues == 0);
+
+__device__ __forceinline__ int32_t phase_for_position(
+    const uint8_t* bitmap, uint32_t position) {
+  const uint32_t unit = position / kPhaseUnitValues;
+  const uint32_t present = (bitmap[unit >> 3] >> (unit & 7U)) & 1U;
+  if (!present) return 0;
+  const uint32_t direction_bit = (position / kSymbolsPerGroup) * 2;
+  const uint32_t code =
+      (bitmap[kPhasePresenceBytes + (direction_bit >> 3)] >>
+       (direction_bit & 7U)) & 3U;
+  return code == 0 ? -2 : (code == 1 ? -1 : 1);
+}
+
+__device__ __forceinline__ float phase_warp_sum(float value) {
+#pragma unroll
+  for (int delta = 16; delta > 0; delta >>= 1) {
+    value += __shfl_down_sync(0xffffffffU, value, delta);
+  }
+  return value;
+}
+
+__global__ __launch_bounds__(1024) void fit_group_direction_phases(
+    const uint16_t* __restrict__ input,
+    const uint8_t* __restrict__ centers,
+    const float* __restrict__ costs,
+    uint8_t* __restrict__ bitmaps,
+    uint32_t batches) {
+  const uint32_t block_group = blockIdx.x;
+  if (block_group >= batches * kGroups) return;
+  constexpr uint32_t units_per_group =
+      kSymbolsPerGroup / kPhaseUnitValues;
+  const uint32_t batch = block_group / kGroups;
+  const uint32_t group = block_group % kGroups;
+  const uint32_t warp = threadIdx.x >> 5;
+  const uint32_t lane = threadIdx.x & 31;
+  const uint32_t unit = group * units_per_group + warp;
+  const uint32_t first = unit * kPhaseUnitValues;
+  const size_t block_base = static_cast<size_t>(batch) * kSymbolsPerBlock;
+
+  float local[4] = {0, 0, 0, 0};
+  for (uint32_t i = lane; i < kPhaseUnitValues; i += 32) {
+    const uint32_t position = first + i;
+    const uint8_t exponent = static_cast<uint8_t>(
+        (input[block_base + position] >> 7) & 0xffU);
+    const uint8_t residual = static_cast<uint8_t>(
+        static_cast<uint32_t>(exponent) + 127U - centers[position]);
+    local[0] += costs[residual];
+    local[1] += costs[static_cast<uint8_t>(residual + 2U)];
+    local[2] += costs[static_cast<uint8_t>(residual + 1U)];
+    local[3] += costs[static_cast<uint8_t>(residual - 1U)];
+  }
+
+  __shared__ float unit_costs[units_per_group][4];
+#pragma unroll
+  for (int candidate = 0; candidate < 4; ++candidate) {
+    const float total = phase_warp_sum(local[candidate]);
+    if (lane == 0) unit_costs[warp][candidate] = total;
+  }
+  __syncthreads();
+
+  __shared__ uint32_t selected_candidate;
+  if (warp == 0) {
+    float group_cost[3];
+#pragma unroll
+    for (int candidate = 1; candidate < 4; ++candidate) {
+      const float contribution =
+          fminf(unit_costs[lane][0], unit_costs[lane][candidate]);
+      group_cost[candidate - 1] = phase_warp_sum(contribution);
+    }
+    if (lane == 0) {
+      uint32_t best = 1;
+      if (group_cost[1] < group_cost[0]) best = 2;
+      if (group_cost[2] < group_cost[best - 1]) best = 3;
+      selected_candidate = best;
+      uint8_t* bitmap = bitmaps +
+          static_cast<size_t>(batch) * kPhaseBytesPerBlock;
+      auto* directions = reinterpret_cast<uint32_t*>(
+          bitmap + kPhasePresenceBytes);
+      atomicOr(
+          directions + ((group * 2) >> 5),
+          (best - 1) << ((group * 2) & 31));
+    }
+  }
+  __syncthreads();
+  if (lane == 0 &&
+      unit_costs[warp][selected_candidate] < unit_costs[warp][0]) {
+    uint8_t* bitmap = bitmaps +
+        static_cast<size_t>(batch) * kPhaseBytesPerBlock;
+    auto* presence = reinterpret_cast<uint32_t*>(bitmap);
+    atomicOr(presence + (unit >> 5), 1U << (unit & 31));
+  }
+}
+
+__global__ void split_bf16_position_phase(
+    const uint16_t* __restrict__ input,
+    const uint8_t* __restrict__ centers,
+    const uint8_t* __restrict__ phase_bitmaps,
+    uint8_t* __restrict__ sign_fraction,
+    uint8_t* __restrict__ residual,
+    size_t words) {
+  const size_t vector =
+      static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const size_t first = vector * 8;
+  if (first >= words) return;
+  const uint4 packed = *reinterpret_cast<const uint4*>(input + first);
+  const uint32_t lanes[4] = {packed.x, packed.y, packed.z, packed.w};
+  uint64_t packed_sm = 0;
+  uint64_t packed_residual = 0;
+#pragma unroll
+  for (int lane = 0; lane < 4; ++lane) {
+    const uint16_t values[2] = {
+        static_cast<uint16_t>(lanes[lane]),
+        static_cast<uint16_t>(lanes[lane] >> 16)};
+#pragma unroll
+    for (int half = 0; half < 2; ++half) {
+      const size_t global = first + lane * 2 + half;
+      const uint32_t batch = static_cast<uint32_t>(
+          global / kSymbolsPerBlock);
+      const uint32_t position = static_cast<uint32_t>(
+          global % kSymbolsPerBlock);
+      const uint8_t* bitmap = phase_bitmaps +
+          static_cast<size_t>(batch) * kPhaseBytesPerBlock;
+      const uint16_t value = values[half];
+      const uint8_t exponent = static_cast<uint8_t>((value >> 7) & 0xffU);
+      const uint8_t sm = static_cast<uint8_t>(
+          ((value >> 8) & 0x80U) | (value & 0x7fU));
+      const uint8_t centered = static_cast<uint8_t>(
+          static_cast<uint32_t>(exponent) + 127U - centers[position]);
+      const uint8_t transformed = static_cast<uint8_t>(
+          centered - phase_for_position(bitmap, position));
+      const int shift = lane * 16 + half * 8;
+      packed_sm |= static_cast<uint64_t>(sm) << shift;
+      packed_residual |= static_cast<uint64_t>(transformed) << shift;
+    }
+  }
+  *reinterpret_cast<uint64_t*>(sign_fraction + first) = packed_sm;
+  *reinterpret_cast<uint64_t*>(residual + first) = packed_residual;
+}
+
+__global__ void merge_bf16_position_phase(
+    const uint8_t* __restrict__ residual,
+    const uint8_t* __restrict__ sign_fraction,
+    const uint8_t* __restrict__ centers,
+    const uint8_t* __restrict__ phase_bitmaps,
+    uint16_t* __restrict__ output,
+    size_t words) {
+  const size_t vector =
+      static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const size_t first = vector * 8;
+  if (first >= words) return;
+  const uint32_t batch = static_cast<uint32_t>(first / kSymbolsPerBlock);
+  const uint32_t first_position = static_cast<uint32_t>(
+      first % kSymbolsPerBlock);
+  const uint8_t* bitmap = phase_bitmaps +
+      static_cast<size_t>(batch) * kPhaseBytesPerBlock;
+  const uint64_t packed_sm =
+      *reinterpret_cast<const uint64_t*>(sign_fraction + first);
+  const uint64_t packed_residual =
+      *reinterpret_cast<const uint64_t*>(residual + first);
+  uint32_t lanes[4];
+#pragma unroll
+  for (int lane = 0; lane < 4; ++lane) {
+    uint32_t pair = 0;
+#pragma unroll
+    for (int half = 0; half < 2; ++half) {
+      const int shift = lane * 16 + half * 8;
+      const uint32_t position = first_position + lane * 2 + half;
+      const uint8_t sm = static_cast<uint8_t>(packed_sm >> shift);
+      const uint8_t transformed = static_cast<uint8_t>(
+          packed_residual >> shift);
+      const uint8_t exponent = static_cast<uint8_t>(
+          static_cast<int32_t>(transformed) + centers[position] - 127 +
+          phase_for_position(bitmap, position));
+      const uint16_t value = static_cast<uint16_t>(
+          ((sm & 0x80U) << 8) | (static_cast<uint16_t>(exponent) << 7) |
+          (sm & 0x7fU));
+      pair |= static_cast<uint32_t>(value) << (half * 16);
+    }
+    lanes[lane] = pair;
+  }
+  *reinterpret_cast<uint4*>(output + first) =
+      make_uint4(lanes[0], lanes[1], lanes[2], lanes[3]);
+}
+
+}

--- a/crates/openlake_kv_client/cuda/tests/expans_codec_test.cu
+++ b/crates/openlake_kv_client/cuda/tests/expans_codec_test.cu
@@ -1,0 +1,130 @@
+#include "openlake/expans_codec.h"
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+constexpr uint32_t kRawBytes = 999424;
+constexpr uint32_t kRecordBytes = 770048;
+
+bool cuda_ok(cudaError_t status, const char* operation) {
+  if (status == cudaSuccess) return true;
+  std::cerr << operation << ": " << cudaGetErrorString(status) << '\n';
+  return false;
+}
+
+bool codec_ok(int status, openlake_expans_codec* codec, const char* operation) {
+  if (status == 0) return true;
+  std::cerr << operation << ": " << openlake_expans_last_error(codec) << '\n';
+  return false;
+}
+
+}
+
+int main() {
+  std::vector<uint16_t> input(kRawBytes / sizeof(uint16_t));
+  for (size_t i = 0; i < input.size(); ++i) {
+    const uint16_t sign = static_cast<uint16_t>((i & 1U) << 15);
+    const uint16_t exponent = static_cast<uint16_t>((125U + i % 4U) << 7);
+    const uint16_t fraction = static_cast<uint16_t>((i * 29U) & 0x7fU);
+    input[i] = sign | exponent | fraction;
+  }
+  std::vector<uint16_t> output(input.size());
+
+  uint8_t* device_input = nullptr;
+  uint8_t* device_output = nullptr;
+  uint8_t* device_record = nullptr;
+  cudaStream_t stream = nullptr;
+  openlake_expans_codec* codec = nullptr;
+  bool success =
+      cuda_ok(cudaMalloc(&device_input, kRawBytes), "allocate input") &&
+      cuda_ok(cudaMalloc(&device_output, kRawBytes), "allocate output") &&
+      cuda_ok(cudaMalloc(&device_record, kRecordBytes), "allocate record") &&
+      cuda_ok(cudaStreamCreate(&stream), "create stream");
+  if (!success) return 1;
+
+  const uint32_t segment_bytes[] = {kRawBytes};
+  success = codec_ok(
+      openlake_expans_create(
+          kRawBytes, kRecordBytes, segment_bytes, 1, 1, &codec),
+      codec, "create codec");
+  const uint64_t input_addresses[] = {
+      reinterpret_cast<uint64_t>(device_input)};
+  const uint32_t input_sizes[] = {kRawBytes};
+  const uint32_t offsets[] = {0, 1};
+  uint8_t fits = 0;
+  if (success) {
+    success = cuda_ok(
+        cudaMemcpy(
+            device_input, input.data(), kRawBytes, cudaMemcpyHostToDevice),
+        "copy input");
+  }
+  if (success) {
+    success = codec_ok(
+        openlake_expans_encode(
+            codec, input_addresses, input_sizes, offsets, 1,
+            reinterpret_cast<uint64_t>(device_record), &fits,
+            reinterpret_cast<uint64_t>(stream)),
+        codec, "encode compressible block");
+  }
+  if (success && !fits) {
+    std::cerr << "compressible block did not fit the 1.3x record\n";
+    success = false;
+  }
+
+  const uint32_t record_indexes[] = {0};
+  const uint64_t output_addresses[] = {
+      reinterpret_cast<uint64_t>(device_output)};
+  if (success) {
+    success = codec_ok(
+        openlake_expans_decode(
+            codec, reinterpret_cast<uint64_t>(device_record), record_indexes,
+            1, output_addresses, input_sizes, offsets,
+            reinterpret_cast<uint64_t>(stream)),
+        codec, "decode block");
+  }
+  if (success) {
+    success = cuda_ok(
+        cudaMemcpy(
+            output.data(), device_output, kRawBytes, cudaMemcpyDeviceToHost),
+        "copy output");
+  }
+  if (success && output != input) {
+    std::cerr << "ExpANS round trip was not bit-exact\n";
+    success = false;
+  }
+
+  for (size_t i = 0; i < input.size(); ++i) {
+    input[i] = static_cast<uint16_t>(((i % 256U) << 7) | (i & 0x7fU));
+  }
+  if (success) {
+    success = cuda_ok(
+        cudaMemcpy(
+            device_input, input.data(), kRawBytes, cudaMemcpyHostToDevice),
+        "copy overflow input");
+  }
+  fits = 1;
+  if (success) {
+    success = codec_ok(
+        openlake_expans_encode(
+            codec, input_addresses, input_sizes, offsets, 1,
+            reinterpret_cast<uint64_t>(device_record), &fits,
+            reinterpret_cast<uint64_t>(stream)),
+        codec, "encode overflow block");
+  }
+  if (success && fits) {
+    std::cerr << "incompressible block unexpectedly fit the fixed record\n";
+    success = false;
+  }
+
+  openlake_expans_destroy(codec);
+  cudaStreamDestroy(stream);
+  cudaFree(device_record);
+  cudaFree(device_output);
+  cudaFree(device_input);
+  return success ? 0 : 1;
+}

--- a/crates/openlake_kv_client/pyproject.toml
+++ b/crates/openlake_kv_client/pyproject.toml
@@ -18,5 +18,6 @@ python-source = "python"
 include = [
   "python/openlake_client/openlaked",
   "python/openlake_client/openlake_*.py",
+  "python/openlake_client/libopenlake_expans.so",
   "python/openlake_client/configs/*.toml",
 ]

--- a/external/connectors/vllm/openlake_adapter.py
+++ b/external/connectors/vllm/openlake_adapter.py
@@ -49,6 +49,9 @@ MAX_SLOT_BYTES = (1 << 32) - 1
 CLIENT_NODE_ID_BASE = 2_048
 CLIENT_NODE_ID_MAX = 0xFFF
 
+EXPANS_RECORD_ALIGNMENT = 4096
+EXPANS_MAX_BATCH_BLOCKS = 64
+
 _HASH_SEED_HELP = (
     "OpenLake external KV offloading requires PYTHONHASHSEED to be set for "
     "block-hash consistency. Please set it, e.g. "
@@ -65,6 +68,30 @@ def _unwrap(spec):
     if isinstance(spec, UniformTypeKVCacheSpecs):
         return next(iter(spec.kv_cache_specs.values()))
     return spec
+
+
+def _expans_enabled(extra) -> bool:
+    value = extra.get("openlake_compression")
+    if value is None:
+        return False
+    if not isinstance(value, dict):
+        raise ValueError("openlake_compression must be an object")
+    if not bool(value.get("enabled", False)):
+        return False
+    if value.get("codec") != "expans":
+        raise ValueError("openlake_compression.codec must be expans")
+    if value.get("mode") != "lossless":
+        raise ValueError("openlake_compression.mode must be lossless")
+    return True
+
+
+def _expans_record_bytes(raw_block_bytes: int) -> int:
+    unaligned = (int(raw_block_bytes) * 10 + 12) // 13
+    return (
+        (unaligned + EXPANS_RECORD_ALIGNMENT - 1)
+        // EXPANS_RECORD_ALIGNMENT
+        * EXPANS_RECORD_ALIGNMENT
+    )
 
 
 class ChunkHashes(BlockHashListWithBlockSize):
@@ -460,9 +487,13 @@ def _group_key_spaces(vllm_config, kv_cache_config):
         vllm_config.kv_transfer_config.kv_connector_extra_config
         if vllm_config.kv_transfer_config is not None else {}
     )
+    compression = _expans_enabled(extra)
     cache_prefix = str(extra.get("cache_prefix", ""))
-    if model_name or cache_prefix:
+    compression_tag = "expans:lossless:nvcomp:fixed-13-to-10:v1" if compression else ""
+    if model_name or cache_prefix or compression_tag:
         tag_source = model_name if not cache_prefix else f"{cache_prefix}\0{model_name}"
+        if compression_tag:
+            tag_source = f"{tag_source}\0{compression_tag}"
         model_tag = hashlib.blake2b(tag_source.encode(), digest_size=12).digest()
     else:
         model_tag = bytes(12)
@@ -506,7 +537,7 @@ class KVTransferThread(threading.Thread):
 
     def __init__(self, client, group_keys, block_size, tp_rank, namespaces, layout,
                  coord, ready_event, name, request_queue=None,
-                 record_operation=None):
+                 record_operation=None, compression=None):
         super().__init__(daemon=True, name=name)
         self.client = client
         self.coord = coord
@@ -516,6 +547,7 @@ class KVTransferThread(threading.Thread):
         self.tp_rank = tp_rank
         self.namespaces = namespaces
         self.layout = layout
+        self.compression = compression
         self.ready_event = ready_event
         self.done_task_lock = threading.Lock()
         self.request_queue: queue.Queue = (
@@ -579,16 +611,19 @@ class KVCacheSendingThread(KVTransferThread):
 
     def __init__(self, client, group_keys, block_size, tp_rank, namespaces, layout,
                  coord, ready_event, replication_factors,
-                 enable_kv_event: bool = False, record_operation=None):
+                 enable_kv_event: bool = False, record_operation=None,
+                 compression=None):
         super().__init__(client, group_keys, block_size, tp_rank, namespaces, layout,
                          coord, ready_event, name="KVCacheSendingThread",
-                         record_operation=record_operation)
+                         record_operation=record_operation,
+                         compression=compression)
         self.replication_factors = replication_factors
         self.stored_requests: dict[str, int] = {}
         self.enable_kv_event = enable_kv_event
         self._store_pressure_active = False
         self._skip_store_requests: set[str] = set()
         self._saved_offset: dict[str, int] = {}
+        self._compression_stopped_requests: set[str] = set()
 
     def add_stored_request(self, req_id: str) -> None:
         with self.done_task_lock:
@@ -603,6 +638,7 @@ class KVCacheSendingThread(KVTransferThread):
         with self.done_task_lock:
             self.stored_requests.pop(req_id, None)
             self._skip_store_requests.discard(req_id)
+            self._compression_stopped_requests.discard(req_id)
             self._saved_offset.pop(req_id, None)
 
     def _should_skip_request(self, req_id: str) -> bool:
@@ -629,6 +665,101 @@ class KVCacheSendingThread(KVTransferThread):
             if req_id in self.stored_requests:
                 self._saved_offset[req_id] = token_len
 
+    def _stored_event(self, entry, req_meta, prev_hash_per_group):
+        group, chunk_idx, block_hash = entry
+        start = chunk_idx * group.block_size
+        event_hash = maybe_convert_block_hash(block_hash)
+        event = BlockStored(
+            block_hashes=[event_hash],
+            parent_block_hash=prev_hash_per_group.get(group.g_idx),
+            token_ids=req_meta.token_ids[start : start + group.block_size]
+            if req_meta.token_ids is not None else None,
+            block_size=group.block_size,
+            lora_id=None,
+            medium="external",
+            lora_name=None,
+            group_idx=group.g_idx,
+        )
+        prev_hash_per_group[group.g_idx] = event_hash
+        return event
+
+    def _put_compressed(self, entries, keys, req_meta, token_len, req_id):
+        stored_events: list[BlockStored] = []
+        prev_hash_per_group: dict[int, object] = {}
+        completed = 0
+
+        while completed < len(entries):
+            end = min(
+                completed + self.compression.max_batch_blocks,
+                len(entries),
+            )
+            batch_entries = entries[completed:end]
+            batch_keys = keys[completed:end]
+            raw_scatters = []
+            for group, chunk_idx, _ in batch_entries:
+                block_id = req_meta.block_ids[group.g_idx][chunk_idx]
+                raw_scatters.append(self.layout.addrs_for(block_id))
+
+            encoded_addresses, fits = self.compression.encode(raw_scatters)
+            fit_count = next(
+                (i for i, fit in enumerate(fits) if not fit),
+                len(batch_entries),
+            )
+            overflowed = fit_count != len(batch_entries)
+            batch_entries = batch_entries[:fit_count]
+            batch_keys = batch_keys[:fit_count]
+
+            if batch_keys:
+                batch_addrs = [[addr] for addr in encoded_addresses[:fit_count]]
+                batch_sizes = [
+                    [self.compression.record_bytes]
+                    for _ in range(fit_count)
+                ]
+                put_start = time.perf_counter()
+                try:
+                    result = self.client.put_batch(
+                        batch_keys, batch_addrs, batch_sizes
+                    )
+                except Exception as err:
+                    self._record_operation(
+                        "save_put", put_start, len(batch_keys),
+                        num_bytes=len(batch_keys) * self.compression.record_bytes,
+                        status="error", num_failed_keys=len(batch_keys))
+                    logger.error("put_batch failed (req=%s): %s", req_id, err)
+                    return
+                failed = [i for i, value in enumerate(result) if value < 0]
+                self._record_operation(
+                    "save_put", put_start, len(batch_keys),
+                    num_bytes=len(batch_keys) * self.compression.record_bytes,
+                    status="partial_failure" if failed else "ok",
+                    num_failed_keys=len(failed))
+                if failed:
+                    logger.warning(
+                        "put_batch: %d/%d compressed keys failed for request %s",
+                        len(failed), len(batch_keys), req_id,
+                    )
+                    self._mark_request_skipped_for_pressure(req_id)
+                    return
+                if self.enable_kv_event:
+                    stored_events.extend(
+                        self._stored_event(entry, req_meta, prev_hash_per_group)
+                        for entry in batch_entries
+                    )
+
+            if overflowed:
+                with self.done_task_lock:
+                    self._compression_stopped_requests.add(req_id)
+                if stored_events:
+                    self.update_kv_event(stored_events)
+                return
+            completed = end
+
+        self._record_saved(req_id, token_len)
+        if self._clear_store_pressure():
+            logger.info("store pressure cleared after a full batch")
+        if stored_events:
+            self.update_kv_event(stored_events)
+
     def _handle_request(self, req_meta: "ReqMeta"):
         lcm = self.coord.lcm_block_size
         token_len = req_meta.token_len_chunk // lcm * lcm
@@ -636,12 +767,15 @@ class KVCacheSendingThread(KVTransferThread):
 
         with self.done_task_lock:
             live = req_id in self.stored_requests
+            compression_stopped = req_id in self._compression_stopped_requests
         if not live:
             self.request_queue.task_done()
             return
 
         try:
             if token_len == 0:
+                return
+            if compression_stopped:
                 return
             if self._should_skip_request(req_id):
                 logger.debug(
@@ -685,6 +819,12 @@ class KVCacheSendingThread(KVTransferThread):
             entries = [entries[i] for i in missing]
             keys = [keys[i] for i in missing]
 
+            if self.compression is not None:
+                if req_meta.current_event is not None:
+                    req_meta.current_event.synchronize()
+                self._put_compressed(entries, keys, req_meta, token_len, req_id)
+                return
+
             addrs: list[list[int]] = []
             sizes: list[list[int]] = []
             stored_events: list[BlockStored] = []
@@ -695,20 +835,11 @@ class KVCacheSendingThread(KVTransferThread):
                 addrs.append([addr for addr, _ in scatter])
                 sizes.append([size for _, size in scatter])
                 if self.enable_kv_event:
-                    start = chunk_idx * group.block_size
-                    event_hash = maybe_convert_block_hash(block_hash)
-                    stored_events.append(BlockStored(
-                        block_hashes=[event_hash],
-                        parent_block_hash=prev_hash_per_group.get(group.g_idx),
-                        token_ids=req_meta.token_ids[start : start + group.block_size]
-                        if req_meta.token_ids is not None else None,
-                        block_size=group.block_size,
-                        lora_id=None,
-                        medium="external",
-                        lora_name=None,
-                        group_idx=group.g_idx,
+                    stored_events.append(self._stored_event(
+                        (group, chunk_idx, block_hash),
+                        req_meta,
+                        prev_hash_per_group,
                     ))
-                    prev_hash_per_group[group.g_idx] = event_hash
 
             if req_meta.current_event is not None:
                 req_meta.current_event.synchronize()
@@ -752,11 +883,13 @@ class KVCacheSendingThread(KVTransferThread):
 class KVCacheRecvingThread(KVTransferThread):
 
     def __init__(self, client, group_keys, block_size, tp_rank, namespaces, layout,
-                 coord, ready_event, request_queue=None, record_operation=None):
+                 coord, ready_event, request_queue=None, record_operation=None,
+                 compression=None):
         super().__init__(client, group_keys, block_size, tp_rank, namespaces, layout,
                          coord, ready_event, name="KVCacheRecvingThread",
                          request_queue=request_queue,
-                         record_operation=record_operation)
+                         record_operation=record_operation,
+                         compression=compression)
         self._invalid_block_ids_lock = threading.Lock()
         self._invalid_block_ids: set[int] = set()
 
@@ -769,6 +902,72 @@ class KVCacheRecvingThread(KVTransferThread):
             invalid = self._invalid_block_ids.copy()
             self._invalid_block_ids.clear()
         return invalid
+
+    def _get_compressed(self, entries, req_id):
+        completed = 0
+        while completed < len(entries):
+            end = min(
+                completed + self.compression.max_batch_blocks,
+                len(entries),
+            )
+            batch_entries = entries[completed:end]
+            batch_keys = [key for _, key in batch_entries]
+            batch_block_ids = [block_id for block_id, _ in batch_entries]
+            records = self.compression.reserve(len(batch_entries))
+            batch_addrs = [[address] for address in records]
+            batch_sizes = [
+                [self.compression.record_bytes]
+                for _ in batch_entries
+            ]
+            get_start = time.perf_counter()
+            try:
+                result = self.client.get_batch(
+                    batch_keys, batch_addrs, batch_sizes
+                )
+            except Exception as err:
+                self._add_load_error_block_ids(
+                    block_id for block_id, _ in entries[completed:]
+                )
+                self._record_operation(
+                    "load_get", get_start, len(batch_keys),
+                    num_bytes=len(batch_keys) * self.compression.record_bytes,
+                    status="error", num_failed_keys=len(batch_keys))
+                logger.error("get_batch failed (req=%s): %s", req_id, err)
+                return
+
+            failed_indexes = {
+                i for i, value in enumerate(result) if value < 0
+            }
+            self._record_operation(
+                "load_get", get_start, len(batch_keys),
+                num_bytes=len(batch_keys) * self.compression.record_bytes,
+                status="partial_failure" if failed_indexes else "ok",
+                num_failed_keys=len(failed_indexes))
+            if failed_indexes:
+                self._add_load_error_block_ids(
+                    batch_block_ids[i] for i in failed_indexes
+                )
+
+            record_indexes = [
+                i for i in range(len(batch_entries))
+                if i not in failed_indexes
+            ]
+            destinations = [
+                self.layout.addrs_for(batch_block_ids[i])
+                for i in record_indexes
+            ]
+            if record_indexes:
+                try:
+                    self.compression.decode(record_indexes, destinations)
+                except Exception as err:
+                    self._add_load_error_block_ids(
+                        block_id for block_id, _ in entries[completed:]
+                    )
+                    logger.error(
+                        "ExpANS decode failed (req=%s): %s", req_id, err
+                    )
+                    return
+            completed = end
 
     def _handle_request(self, req_meta: "ReqMeta"):
         load = req_meta.load
@@ -797,6 +996,13 @@ class KVCacheRecvingThread(KVTransferThread):
             return
         rotation = self.tp_rank % len(entries)
         entries = entries[rotation:] + entries[:rotation]
+
+        if self.compression is not None:
+            self._get_compressed(entries, req_id)
+            self.set_finished_request(req_id)
+            self.request_queue.task_done()
+            return
+
         key_list = [key for _, key in entries]
         block_id_list = [block_id for block_id, _ in entries]
         addr_list: list[list[int]] = []
@@ -897,6 +1103,7 @@ class OpenLakeWorker:
 
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         extra = vllm_config.kv_transfer_config.kv_connector_extra_config
+        self.compression_enabled = _expans_enabled(extra)
         nodes = extra.get("openlake_nodes")
         if not nodes:
             raise ValueError("kv_connector_extra_config.openlake_nodes required")
@@ -939,6 +1146,7 @@ class OpenLakeWorker:
         self.num_recv_threads = max(1, int(extra.get("openlake_recv_threads", 1)))
         self.enable_kv_events = bool(extra.get("openlake_kv_events", False))
         self.layout = GroupLayout()
+        self.compression = None
         self.kv_send_thread: "KVCacheSendingThread | None" = None
         self.kv_recv_threads: list[KVCacheRecvingThread] = []
         self.recv_request_queue: queue.Queue = queue.Queue()
@@ -994,6 +1202,8 @@ class OpenLakeWorker:
         block_lens: list[int] = []
         for value in kv_caches.values():
             cache = value[0] if isinstance(value, list) else value
+            if self.compression_enabled and cache.dtype != torch.bfloat16:
+                raise ValueError("ExpANS requires a BF16 vLLM KV cache")
             storage = cache.untyped_storage()
             base_addr = storage.data_ptr()
             if base_addr in seen_ptrs:
@@ -1016,7 +1226,27 @@ class OpenLakeWorker:
                     addrs.append(base_addr + idx * seg_stride)
                     block_lens.append(seg_stride // self._num_blocks)
         self.layout.set(addrs, block_lens)
-        local_slot_bytes = SLOT_HEADER_BYTES + sum(block_lens) if addrs else 0
+        raw_block_bytes = sum(block_lens)
+        if addrs and self.compression_enabled:
+            if len(self.group_keys) != 1:
+                raise ValueError(
+                    "ExpANS currently supports one homogeneous KV cache group"
+                )
+            from openlake_client.openlake_expans import ExpansCodec
+
+            record_bytes = _expans_record_bytes(raw_block_bytes)
+            self.compression = ExpansCodec(
+                raw_block_bytes=raw_block_bytes,
+                record_bytes=record_bytes,
+                segment_bytes=tuple(block_lens),
+                max_batch_blocks=EXPANS_MAX_BATCH_BLOCKS,
+                client=self._client,
+            )
+            local_slot_bytes = SLOT_HEADER_BYTES + record_bytes
+        else:
+            local_slot_bytes = (
+                SLOT_HEADER_BYTES + raw_block_bytes if addrs else 0
+            )
         slot_bytes = self._sync_max_slot_bytes(local_slot_bytes)
         if not addrs:
             logger.warning(
@@ -1047,6 +1277,8 @@ class OpenLakeWorker:
                 self._group_tp_replication_factors,
                 self.enable_kv_events,
                 record_operation=self._record_kv_connector_operation,
+                compression=self.compression.new_lane()
+                if self.compression is not None else None,
             )
             self.kv_send_thread.start()
 
@@ -1065,6 +1297,8 @@ class OpenLakeWorker:
                 ready_event_recving,
                 request_queue=self.recv_request_queue,
                 record_operation=self._record_kv_connector_operation,
+                compression=self.compression.new_lane()
+                if self.compression is not None else None,
             )
             recv_thread.name = f"KVCacheRecvingThread-{i}"
             recv_thread.start()

--- a/external/connectors/vllm/openlake_expans.py
+++ b/external/connectors/vllm/openlake_expans.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import ctypes
+from pathlib import Path
+
+import torch
+
+
+def _array(kind, values):
+    values = tuple(values)
+    return (kind * len(values))(*values)
+
+
+def _configure_abi(library):
+    void_pointer = ctypes.c_void_p
+    library.openlake_expans_create.argtypes = [
+        ctypes.c_uint64,
+        ctypes.c_uint64,
+        ctypes.POINTER(ctypes.c_uint32),
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.POINTER(void_pointer),
+    ]
+    library.openlake_expans_create.restype = ctypes.c_int
+    library.openlake_expans_destroy.argtypes = [void_pointer]
+    library.openlake_expans_destroy.restype = None
+    library.openlake_expans_last_error.argtypes = [void_pointer]
+    library.openlake_expans_last_error.restype = ctypes.c_char_p
+    library.openlake_expans_encode.argtypes = [
+        void_pointer,
+        ctypes.POINTER(ctypes.c_uint64),
+        ctypes.POINTER(ctypes.c_uint32),
+        ctypes.POINTER(ctypes.c_uint32),
+        ctypes.c_uint32,
+        ctypes.c_uint64,
+        ctypes.POINTER(ctypes.c_uint8),
+        ctypes.c_uint64,
+    ]
+    library.openlake_expans_encode.restype = ctypes.c_int
+    library.openlake_expans_decode.argtypes = [
+        void_pointer,
+        ctypes.c_uint64,
+        ctypes.POINTER(ctypes.c_uint32),
+        ctypes.c_uint32,
+        ctypes.POINTER(ctypes.c_uint64),
+        ctypes.POINTER(ctypes.c_uint32),
+        ctypes.POINTER(ctypes.c_uint32),
+        ctypes.c_uint64,
+    ]
+    library.openlake_expans_decode.restype = ctypes.c_int
+
+
+class ExpansCodec:
+    def __init__(self, *, raw_block_bytes, record_bytes, segment_bytes,
+                 max_batch_blocks, client):
+        self.raw_block_bytes = int(raw_block_bytes)
+        self.record_bytes = int(record_bytes)
+        self.segment_bytes = tuple(int(value) for value in segment_bytes)
+        self.max_batch_blocks = int(max_batch_blocks)
+        self.client = client
+        self._library = ctypes.CDLL(
+            str(Path(__file__).with_name("libopenlake_expans.so"))
+        )
+        _configure_abi(self._library)
+
+    def new_lane(self):
+        return _ExpansLane(self)
+
+
+class _ExpansLane:
+    def __init__(self, codec):
+        self.record_bytes = codec.record_bytes
+        self.max_batch_blocks = codec.max_batch_blocks
+        self._library = codec._library
+        self._handle = ctypes.c_void_p()
+        segment_bytes = _array(ctypes.c_uint32, codec.segment_bytes)
+        status = self._library.openlake_expans_create(
+            codec.raw_block_bytes,
+            self.record_bytes,
+            segment_bytes,
+            len(codec.segment_bytes),
+            self.max_batch_blocks,
+            ctypes.byref(self._handle),
+        )
+        self._check(status)
+        self._records = torch.empty(
+            self.max_batch_blocks * self.record_bytes,
+            dtype=torch.uint8,
+            device="cuda",
+        )
+        codec.client.register_memory(
+            self._records.data_ptr(), self._records.numel()
+        )
+
+    def __del__(self):
+        handle = getattr(self, "_handle", None)
+        library = getattr(self, "_library", None)
+        if handle is not None and handle.value and library is not None:
+            library.openlake_expans_destroy(handle)
+            handle.value = None
+
+    def _check(self, status):
+        if status == 0:
+            return
+        message = self._library.openlake_expans_last_error(self._handle)
+        detail = message.decode() if message else f"status {status}"
+        raise RuntimeError(f"ExpANS CUDA codec failed: {detail}")
+
+    def _addresses(self, count):
+        if not 0 <= count <= self.max_batch_blocks:
+            raise ValueError(
+                f"ExpANS batch has {count} blocks; capacity is "
+                f"{self.max_batch_blocks}"
+            )
+        base = self._records.data_ptr()
+        return tuple(base + i * self.record_bytes for i in range(count))
+
+    @staticmethod
+    def _flatten(scatters):
+        addresses = []
+        sizes = []
+        offsets = [0]
+        for scatter in scatters:
+            addresses.extend(int(address) for address, _ in scatter)
+            sizes.extend(int(size) for _, size in scatter)
+            offsets.append(len(addresses))
+        return addresses, sizes, offsets
+
+    @staticmethod
+    def _stream():
+        return int(torch.cuda.current_stream().cuda_stream)
+
+    def encode(self, scatters):
+        count = len(scatters)
+        output_addresses = self._addresses(count)
+        addresses, sizes, offsets = self._flatten(scatters)
+        host_fits = (ctypes.c_uint8 * count)()
+        status = self._library.openlake_expans_encode(
+            self._handle,
+            _array(ctypes.c_uint64, addresses),
+            _array(ctypes.c_uint32, sizes),
+            _array(ctypes.c_uint32, offsets),
+            count,
+            self._records.data_ptr(),
+            host_fits,
+            self._stream(),
+        )
+        self._check(status)
+        return (
+            output_addresses,
+            tuple(bool(host_fits[i]) for i in range(count)),
+        )
+
+    def reserve(self, count):
+        return self._addresses(count)
+
+    def decode(self, record_indexes, destinations):
+        if len(record_indexes) != len(destinations):
+            raise ValueError("ExpANS record and destination counts differ")
+        addresses, sizes, offsets = self._flatten(destinations)
+        status = self._library.openlake_expans_decode(
+            self._handle,
+            self._records.data_ptr(),
+            _array(ctypes.c_uint32, record_indexes),
+            len(record_indexes),
+            _array(ctypes.c_uint64, addresses),
+            _array(ctypes.c_uint32, sizes),
+            _array(ctypes.c_uint32, offsets),
+            self._stream(),
+        )
+        self._check(status)

--- a/external/connectors/vllm/tests/test_openlake_adapter.py
+++ b/external/connectors/vllm/tests/test_openlake_adapter.py
@@ -36,6 +36,7 @@ def _module(name: str) -> types.ModuleType:
 def _install_import_stubs() -> None:
     torch = _module("torch")
     torch.cuda = SimpleNamespace(Event=object)
+    torch.bfloat16 = "bfloat16"
     torch.int64 = "int64"
 
     _module("vllm")
@@ -165,6 +166,148 @@ def _parallel(**overrides):
 
 
 class OpenLakeRankNamespaceTests(unittest.TestCase):
+    def test_compression_config_rejects_non_lossless_codecs(self):
+        for field, codec, mode in (
+            ("codec", "unknown", "lossless"),
+            ("mode", "expans", "lossy"),
+        ):
+            with self.subTest(field=field), self.assertRaisesRegex(
+                ValueError, field
+            ):
+                ADAPTER._expans_enabled({"openlake_compression": {
+                    "enabled": True, "codec": codec, "mode": mode,
+                }})
+
+    def test_expans_namespace_isolated_without_changing_default(self):
+        interface = sys.modules["vllm.v1.kv_cache_interface"]
+        spec = interface.FullAttentionSpec()
+        spec.block_size = 16
+        kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[SimpleNamespace(kv_cache_spec=spec)]
+        )
+
+        def tag(compression=None):
+            extra = {}
+            if compression is not None:
+                extra["openlake_compression"] = compression
+            config = SimpleNamespace(
+                model_config=SimpleNamespace(model="org/model"),
+                kv_transfer_config=SimpleNamespace(
+                    kv_connector_extra_config=extra
+                ),
+                speculative_config=None,
+            )
+            return ADAPTER._group_key_spaces(
+                config, kv_cache_config
+            )[1][0]._model_tag
+
+        default = tag()
+        disabled = tag({"enabled": False})
+        enabled = tag({
+            "enabled": True,
+            "codec": "expans",
+            "mode": "lossless",
+        })
+
+        self.assertEqual(default, disabled)
+        self.assertNotEqual(default, enabled)
+
+    def test_compressed_store_stops_at_first_overflow(self):
+        sender = ADAPTER.KVCacheSendingThread.__new__(
+            ADAPTER.KVCacheSendingThread
+        )
+        sender.done_task_lock = __import__("threading").Lock()
+        sender.stored_requests = {"request": 1}
+        sender._compression_stopped_requests = set()
+        sender._saved_offset = {}
+        sender._store_pressure_active = False
+        sender._skip_store_requests = set()
+        sender.enable_kv_event = False
+        sender._record_operation_cb = None
+        sender.layout = SimpleNamespace(
+            addrs_for=lambda block_id: [(block_id * 1000, 100)]
+        )
+
+        class FakeCompression:
+            max_batch_blocks = 8
+            record_bytes = 768
+
+            def encode(self, _scatters):
+                return (
+                    (10_000, 11_000, 12_000, 13_000),
+                    (True, True, False, True),
+                )
+
+        calls = []
+        sender.compression = FakeCompression()
+        sender.client = SimpleNamespace(
+            put_batch=lambda keys, addrs, sizes: (
+                calls.append((keys, addrs, sizes)) or [0] * len(keys)
+            )
+        )
+        group = SimpleNamespace(g_idx=0, block_size=16)
+        entries = [
+            (group, index, bytes([index])) for index in range(4)
+        ]
+        keys = [bytes([index]) * ADAPTER.SLOT_HEADER_BYTES for index in range(4)]
+        req_meta = SimpleNamespace(block_ids=([4, 5, 6, 7],))
+
+        sender._put_compressed(entries, keys, req_meta, 64, "request")
+
+        self.assertEqual(calls, [(
+            keys[:2], [[10_000], [11_000]], [[768], [768]],
+        )])
+        self.assertIn("request", sender._compression_stopped_requests)
+        self.assertNotIn("request", sender._saved_offset)
+
+    def test_compressed_load_uses_fixed_records_and_decodes_hits(self):
+        receiver = ADAPTER.KVCacheRecvingThread.__new__(
+            ADAPTER.KVCacheRecvingThread
+        )
+        receiver._invalid_block_ids_lock = __import__("threading").Lock()
+        receiver._invalid_block_ids = set()
+        receiver._record_operation_cb = None
+        receiver.layout = SimpleNamespace(
+            addrs_for=lambda block_id: [(block_id * 1000, 100)]
+        )
+
+        class FakeCompression:
+            max_batch_blocks = 8
+            record_bytes = 768
+
+            def __init__(self):
+                self.decode_calls = []
+
+            def reserve(self, count):
+                return tuple(10_000 + i * 768 for i in range(count))
+
+            def decode(self, indexes, destinations):
+                self.decode_calls.append((indexes, destinations))
+
+        get_calls = []
+        receiver.compression = FakeCompression()
+        receiver.client = SimpleNamespace(
+            get_batch=lambda keys, addrs, sizes: (
+                get_calls.append((keys, addrs, sizes)) or [0, -1, 0]
+            )
+        )
+        entries = [(4, b"a"), (5, b"b"), (6, b"c")]
+
+        receiver._get_compressed(entries, "request")
+
+        self.assertEqual(
+            get_calls,
+            [(
+                [b"a", b"b", b"c"],
+                [[10_000], [10_768], [11_536]],
+                [[768], [768], [768]],
+            )],
+        )
+        self.assertEqual(receiver._invalid_block_ids, {5})
+        self.assertEqual(receiver.compression.decode_calls, [(
+            [0, 2], [[(4000, 100)], [(6000, 100)]],
+        )])
+
     def test_cross_layer_cache_uses_the_standard_registration_path(self):
         worker = ADAPTER.OpenLakeWorker.__new__(ADAPTER.OpenLakeWorker)
         captured = []
@@ -174,6 +317,78 @@ class OpenLakeRankNamespaceTests(unittest.TestCase):
         worker.register_cross_layers_kv_caches(cache)
 
         self.assertEqual(captured, [{"__cross_layer__": cache}])
+
+    def test_worker_registration_honors_exact_compression_json(self):
+        raw_block_bytes = 999_424
+        parallel_state = sys.modules["vllm.distributed.parallel_state"]
+        parallel_state.get_world_group = lambda: SimpleNamespace(
+            world_size=1, cpu_group="cpu-world"
+        )
+
+        codec_calls = []
+
+        class FakeCodec:
+            def __init__(self, **kwargs):
+                codec_calls.append(kwargs)
+
+        expans_module = _module("openlake_client.openlake_expans")
+        expans_module.ExpansCodec = FakeCodec
+
+        storage = SimpleNamespace(
+            data_ptr=lambda: 1_000,
+            nbytes=lambda: 2 * raw_block_bytes,
+        )
+        cache = SimpleNamespace(
+            dtype=sys.modules["torch"].bfloat16,
+            ndim=1,
+            shape=(2,),
+            untyped_storage=lambda: storage,
+            element_size=lambda: 2,
+            stride=lambda _dimension: 1,
+        )
+
+        def register(compression):
+            attaches = []
+            worker = ADAPTER.OpenLakeWorker.__new__(ADAPTER.OpenLakeWorker)
+            worker.compression_enabled = ADAPTER._expans_enabled({
+                "openlake_compression": compression,
+            })
+            worker.compression = None
+            worker.group_keys = [object()]
+            worker.layout = ADAPTER.GroupLayout()
+            worker._num_blocks = 2
+            worker._nodes = ["node"]
+            worker.kv_role = "none"
+            worker.num_recv_threads = 0
+            worker._client = SimpleNamespace(
+                register_memory=lambda *_args: None,
+                attach=lambda *args: attaches.append(args),
+            )
+
+            worker.register_kv_caches({"layer": cache})
+            return worker, attaches
+
+        enabled_worker, enabled_attaches = register({
+            "enabled": True,
+            "codec": "expans",
+            "mode": "lossless",
+        })
+        self.assertEqual(codec_calls[0]["raw_block_bytes"], raw_block_bytes)
+        self.assertEqual(codec_calls[0]["record_bytes"], 770_048)
+        self.assertEqual(codec_calls[0]["segment_bytes"], (raw_block_bytes,))
+        self.assertIsInstance(enabled_worker.compression, FakeCodec)
+        self.assertEqual(
+            enabled_attaches,
+            [("node", 0, ADAPTER.SLOT_HEADER_BYTES + 770_048)],
+        )
+
+        disabled_worker, disabled_attaches = register({"enabled": False})
+        self.assertEqual(len(codec_calls), 1)
+        self.assertIsNone(disabled_worker.compression)
+        self.assertEqual(
+            disabled_attaches,
+            [("node", 0, ADAPTER.SLOT_HEADER_BYTES + raw_block_bytes)],
+        )
 
     def test_slot_size_uses_cpu_world_max_for_unequal_pp_stages(self):
         torch = sys.modules["torch"]


### PR DESCRIPTION
 - Store compressed blocks in fixed size OpenLake slots.
 - Preserve the existing uncompressed path when openlake_compression is absent or disabled.
 - Disable caching the remaining request suffix when a block exceeds the slot capacity.
 - Isolate compressed records from existing uncompressed cache entries.